### PR TITLE
docs: enhance job model and lifecycle documentation

### DIFF
--- a/docs/pages/reliability/retries.md
+++ b/docs/pages/reliability/retries.md
@@ -22,6 +22,7 @@ individual jobs.
 Operators need to distinguish:
 
 - normal retryable failures
+- failed attempts that transition into `retry-pending`
 - escalated failure states
 - conditions that should move work into dead-letter or governed recovery flows
 
@@ -34,7 +35,7 @@ Retry behavior should be understandable from an operator point of view:
 ```text
 job: billing-123
 attempt: 3
-status: retrying
+status: retry-pending
 next_retry_at: 2026-03-26T14:05:00Z
 reason: upstream timeout
 ```

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -15,7 +15,8 @@ CLI surfaces.
 - minimal runtime inspection APIs
 - queue and worker lifecycle control
 - bulk enqueue, retry, cancel, and pause/resume operations
-- operator-visible state used for safe intervention
+- operator-visible state used for safe intervention across `queued`,
+  `reserved`, `running`, `failed`, `retry-pending`, and `cancelled` job states
 
 ## Surface Model
 
@@ -28,6 +29,9 @@ CLI surfaces.
 Runtime controls define the safe entrypoints. Reliability, workflow, and
 governance features extend those same control boundaries rather than creating
 separate operational models.
+
+The control surface uses the same canonical lifecycle vocabulary defined in the
+job model rather than redefining job state per interface.
 
 ## Common Scenarios
 

--- a/docs/pages/runtime/index.md
+++ b/docs/pages/runtime/index.md
@@ -25,6 +25,7 @@ inspectable, and operationally predictable.
 The runtime section is the source of truth for:
 
 - canonical job and queue execution semantics
+- canonical job lifecycle states and transition boundaries
 - worker bootstrap and coordinated execution flow
 - graceful shutdown and drain behavior
 - lifecycle controls that later reliability and workflow features build on
@@ -33,4 +34,4 @@ The runtime section is the source of truth for:
 
 The examples in this section are intentionally simple. They show how the
 runtime is meant to feel without pretending every bootstrap or submission
-detail is already frozen.
+detail is already frozen beyond the canonical lifecycle and control vocabulary.

--- a/docs/pages/runtime/job-model.md
+++ b/docs/pages/runtime/job-model.md
@@ -11,6 +11,25 @@ Jobs are the canonical executable unit in Karya. The job model anchors queueing,
 worker execution, retry behavior, workflow composition, and operator
 inspection.
 
+## Canonical Job Shape
+
+The canonical model distinguishes between the application-defined job, the
+queued job instance, the reservation used to start work, and the terminal
+outcome recorded for operators and automation.
+
+A canonical job instance carries these behavior-level expectations:
+
+- stable job identity for the queued instance being tracked by the runtime
+- queue assignment that determines where the job becomes available
+- executable payload boundaries that identify the work to run without treating
+  queue metadata as application input
+- lifecycle metadata that callers, workers, and operator surfaces can inspect
+  consistently
+- one canonical current state for the job instance at any point in time
+
+Application code defines what the job does. Karya owns the queue placement,
+lifecycle, reservation, execution, and operator-visible state around that work.
+
 ## Core Expectations
 
 - a job has an explicit lifecycle rather than an implicit fire-and-forget state
@@ -18,14 +37,72 @@ inspection.
 - workers reserve jobs according to the runtime and reliability contracts
 - operators can inspect job state through UI, API, and CLI surfaces
 
+## Lifecycle States
+
+The base lifecycle vocabulary for queued job instances is:
+
+| State           | Meaning                                                                                       | Allowed next transitions                    |
+| --------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `submission`    | the runtime is accepting or validating enqueue intent                                         | `queued`                                    |
+| `queued`        | the job is durably available for reservation on its assigned queue                            | `reserved`, `cancelled`                     |
+| `reserved`      | one worker has an exclusive, temporary claim on the job                                       | `running`, `queued`, `cancelled`            |
+| `running`       | execution has started from a valid reservation                                                | `succeeded`, `failed`, `cancelled`          |
+| `succeeded`     | execution completed successfully                                                              | terminal state                              |
+| `failed`        | execution ended unsuccessfully for the current attempt                                        | `retry-pending`, terminal state             |
+| `retry-pending` | the job remains in the lifecycle and is waiting to re-enter queue execution under retry rules | `queued`, `cancelled`, dead-letter boundary |
+| `cancelled`     | execution will not continue because the runtime or operator stopped the job                   | terminal state                              |
+
+`dead-letter` is not defined here as a base lifecycle state. It is treated as a
+later extension boundary that may be reached from failure or retry exhaustion,
+but its detailed recovery semantics are defined elsewhere.
+
+## Lifecycle Invariants
+
+- one queued job instance has one canonical current state at a time
+- reservation is exclusive and temporary rather than a second execution state
+- execution starts only from a valid reservation
+- `succeeded` and `cancelled` are distinct terminal outcomes
+- `failed` records the result of an execution attempt, while `retry-pending`
+  keeps the same job instance in the lifecycle for later requeue
+- retries, uniqueness, and operator controls extend this lifecycle instead of
+  inventing parallel state models
+- terminal completion and failure outcomes remain operator-visible and
+  historically meaningful
+
 ## Lifecycle Boundaries
 
-The documented lifecycle includes:
+The documented lifecycle covers:
 
-- enqueue and reservation
+- submission and enqueue
+- queued availability and reservation
 - active execution
-- completion or failure
-- replay, retry, cancellation, or dead-letter transitions where applicable
+- success, failure, retry-pending, or cancellation
+- the boundary where later dead-letter behavior may take over
+
+## Non-Goals For This Contract
+
+This page does not define:
+
+- retry policy, backoff, jitter, or escalation rules
+- fairness, starvation prevention, or backpressure policy
+- dead-letter recovery behavior such as replay or discard rules
+- bulk-operation semantics beyond acknowledging that bulk actions operate on the
+  same lifecycle states
+
+## Dependency Boundaries
+
+This page is the source of truth for the job lifecycle model used by follow-on
+runtime work:
+
+- queueing and reservation behavior extend it
+- worker bootstrap and execution flow extend it
+- graceful shutdown and drain behavior extend it
+- runtime control and inspection APIs extend it
+- uniqueness, bulk operations, dead-letter handling, and
+  fairness/backpressure extend it
+
+Follow-on work may add detail, but it should not redefine the base lifecycle
+states or their core meanings.
 
 ## Why This Matters
 
@@ -47,7 +124,7 @@ end
 ```
 
 Application code defines executable work, and Karya owns the routing,
-lifecycle, and operator-visible state around it.
+lifecycle, reservation, and operator-visible state around it.
 
 ## Related Concepts
 

--- a/docs/pages/runtime/workers.md
+++ b/docs/pages/runtime/workers.md
@@ -14,6 +14,8 @@ coordinated runtime lifecycle behavior.
 
 - subscribe to the correct queues
 - reserve jobs without violating routing and fairness rules
+- move jobs from `queued` to `reserved` and then into `running` only through
+  valid lifecycle transitions
 - execute work while respecting timeouts, expirations, and cancellation
 - participate in graceful shutdown and drain behavior
 
@@ -25,6 +27,9 @@ Karya documents worker behavior around:
 - drain-safe shutdown
 - pause and resume interactions with queue state
 - runtime supervision hooks used by operators and automation
+
+Workers extend the canonical job lifecycle; they do not introduce a separate
+execution state model.
 
 ## Operator View
 


### PR DESCRIPTION
- Added detailed descriptions of job lifecycle states, including `retry-pending` and their transitions.
- Clarified the canonical job shape and expectations for job instances.
- Updated worker responsibilities to reflect valid lifecycle transitions.
- Improved overall clarity and consistency in the runtime documentation.

closes: #12 