### PR TITLE
feat: implement backpressure policies and job attributes

### DIFF
--- a/core/karya/lib/karya.rb
+++ b/core/karya/lib/karya.rb
@@ -10,6 +10,7 @@ require_relative 'karya/internal/null_logger'
 require_relative 'karya/version'
 
 require_relative 'karya/job_lifecycle'
+require_relative 'karya/backpressure'
 require_relative 'karya/job'
 require_relative 'karya/reservation'
 require_relative 'karya/queue_store'

--- a/core/karya/lib/karya/backpressure.rb
+++ b/core/karya/lib/karya/backpressure.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require 'bigdecimal'
+
+require_relative 'primitives/identifier'
+require_relative 'primitives/positive_finite_number'
+require_relative 'primitives/positive_integer'
+
+module Karya
+  module Backpressure
+    # Raised when backpressure policy input is invalid.
+    class InvalidPolicyError < Error; end
+
+    # Shared policy-input normalizers.
+    module Normalizers
+      module_function
+
+      def identifier(name, value)
+        Primitives::Identifier.new(name, value, error_class: InvalidPolicyError).normalize
+      end
+
+      def positive_integer(name, value)
+        Primitives::PositiveInteger.new(name, value, error_class: InvalidPolicyError).normalize
+      end
+
+      def positive_period(value)
+        Primitives::PositiveFiniteNumber.new(:period, value, error_class: InvalidPolicyError).normalize
+      end
+    end
+
+    # Builds policy instances from hash or instance input.
+    class PolicyNormalizer
+      def initialize(key, raw_policy, policy_class)
+        @key = key
+        @raw_policy = raw_policy
+        @policy_class = policy_class
+      end
+
+      def normalize
+        return raw_policy if matching_policy_instance?
+
+        policy_class.new(key:, **policy_attributes)
+      rescue ArgumentError
+        raise InvalidPolicyError, "#{policy_class.name.split('::').last} must be built from a Hash or policy instance"
+      end
+
+      private
+
+      attr_reader :key, :policy_class, :raw_policy
+
+      def matching_policy_instance?
+        raw_policy.is_a?(policy_class) && raw_policy.key == Normalizers.identifier(:key, key)
+      end
+
+      def policy_attributes
+        return raw_policy if raw_policy.is_a?(Hash)
+
+        {}
+      end
+    end
+
+    # Normalizes policy registries into immutable keyed hashes.
+    class PolicyHashNormalizer
+      def initialize(source, policy_class, invalid_type_message)
+        @source = source
+        @policy_class = policy_class
+        @invalid_type_message = invalid_type_message
+      end
+
+      def normalize
+        raise InvalidPolicyError, invalid_type_message unless source.is_a?(Hash)
+
+        source.each_with_object({}) do |(key, raw_policy), normalized|
+          policy = PolicyNormalizer.new(key, raw_policy, policy_class).normalize
+          normalized[policy.key] = policy
+        end.freeze
+      end
+
+      private
+
+      attr_reader :invalid_type_message, :policy_class, :source
+    end
+
+    # Immutable concurrency-cap policy keyed by a job concurrency group.
+    class ConcurrencyPolicy
+      attr_reader :key, :limit
+
+      def initialize(key:, limit:)
+        @key = Normalizers.identifier(:key, key)
+        @limit = Normalizers.positive_integer(:limit, limit)
+        freeze
+      end
+    end
+
+    # Immutable fixed-window rate-limit policy keyed by a job rate-limit group.
+    class RateLimitPolicy
+      attr_reader :key, :limit, :period
+
+      def initialize(key:, limit:, period:)
+        @key = Normalizers.identifier(:key, key)
+        @limit = Normalizers.positive_integer(:limit, limit)
+        @period = Normalizers.positive_period(period)
+        freeze
+      end
+    end
+
+    # Immutable registry of concurrency and rate-limit policies.
+    class PolicySet
+      attr_reader :concurrency, :rate_limits
+
+      def initialize(concurrency: {}, rate_limits: {})
+        @concurrency = PolicyHashNormalizer.new(
+          concurrency,
+          ConcurrencyPolicy,
+          'concurrency policies must be a Hash'
+        ).normalize
+        @rate_limits = PolicyHashNormalizer.new(
+          rate_limits,
+          RateLimitPolicy,
+          'rate limit policies must be a Hash'
+        ).normalize
+        freeze
+      end
+
+      def concurrency_policy_for(key)
+        key&.then { |present_key| concurrency[Normalizers.identifier(:key, present_key)] }
+      end
+
+      def rate_limit_policy_for(key)
+        key&.then { |present_key| rate_limits[Normalizers.identifier(:key, present_key)] }
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/backpressure.rb
+++ b/core/karya/lib/karya/backpressure.rb
@@ -120,7 +120,7 @@ module Karya
       end
     end
 
-    # Immutable fixed-window rate-limit policy keyed by a job rate-limit group.
+    # Immutable rolling-window rate-limit policy keyed by a job rate-limit group.
     class RateLimitPolicy
       attr_reader :key, :limit, :period
 

--- a/core/karya/lib/karya/backpressure.rb
+++ b/core/karya/lib/karya/backpressure.rb
@@ -51,7 +51,7 @@ module Karya
         return raw_policy if matching_policy_instance?
 
         policy_class.new(key:, **policy_attributes)
-      rescue ArgumentError
+      rescue ArgumentError, TypeError
         raise InvalidPolicyError, "#{policy_class.name.split('::').last} must be built from a Hash or policy instance"
       end
 
@@ -64,9 +64,26 @@ module Karya
       end
 
       def policy_attributes
-        return raw_policy if raw_policy.is_a?(Hash)
+        return normalized_hash_attributes if raw_policy.is_a?(Hash)
 
         {}
+      end
+
+      def normalized_hash_attributes
+        raw_policy.each_with_object({}) do |(attribute_key, value), normalized|
+          normalized[normalize_attribute_key(attribute_key)] = value
+        end
+      end
+
+      def normalize_attribute_key(attribute_key)
+        case attribute_key
+        when Symbol
+          attribute_key
+        when String
+          attribute_key.to_sym
+        else
+          raise InvalidPolicyError, 'policy attribute keys must be Symbols or Strings'
+        end
       end
     end
 

--- a/core/karya/lib/karya/backpressure.rb
+++ b/core/karya/lib/karya/backpressure.rb
@@ -29,7 +29,13 @@ module Karya
       end
 
       def positive_period(value)
-        Primitives::PositiveFiniteNumber.new(:period, value, error_class: InvalidPolicyError).normalize
+        normalized_value = Primitives::PositiveFiniteNumber.new(:period, value, error_class: InvalidPolicyError).normalize
+        non_finite_decimal_or_float = [Float, BigDecimal].any? do |type|
+          normalized_value.is_a?(type) && !normalized_value.finite?
+        end
+        raise InvalidPolicyError, 'period must be a positive finite number' if non_finite_decimal_or_float
+
+        normalized_value
       end
     end
 

--- a/core/karya/lib/karya/backpressure.rb
+++ b/core/karya/lib/karya/backpressure.rb
@@ -100,6 +100,7 @@ module Karya
 
         source.each_with_object({}) do |(key, raw_policy), normalized|
           policy = PolicyNormalizer.new(key, raw_policy, policy_class).normalize
+          reject_duplicate_policy_key(policy, normalized)
           normalized[policy.key] = policy
         end.freeze
       end
@@ -107,6 +108,20 @@ module Karya
       private
 
       attr_reader :invalid_type_message, :policy_class, :source
+
+      def reject_duplicate_policy_key(policy, normalized)
+        normalized_key = policy.key
+        return unless normalized.key?(normalized_key)
+
+        raise InvalidPolicyError, "duplicate #{policy_label} key #{normalized_key.inspect} after normalization"
+      end
+
+      def policy_label
+        policy_class.name.split('::').last
+                    .delete_suffix('Policy')
+                    .gsub(/([a-z0-9])([A-Z])/, '\1 \2')
+                    .downcase
+      end
     end
 
     # Immutable concurrency-cap policy keyed by a job concurrency group.

--- a/core/karya/lib/karya/job.rb
+++ b/core/karya/lib/karya/job.rb
@@ -16,20 +16,56 @@ module Karya
 
   # Immutable value object for the canonical queued job model.
   class Job
-    attr_reader :arguments, :attempt, :created_at, :handler, :id, :queue, :state, :updated_at
+    # Canonical immutable routing payload for one job instance.
+    Identity = Struct.new(:id, :queue, :handler, :arguments)
+    # Canonical immutable scheduling metadata for job selection policies.
+    Scheduling = Struct.new(:priority, :concurrency_key, :rate_limit_key)
+    # Canonical immutable lifecycle state for one job instance.
+    LifecycleState = Struct.new(:state, :attempt, :created_at, :updated_at, :lifecycle)
+    # Groups normalized constructor fields into lifecycle-safe components.
+    class Components
+      def initialize(attributes)
+        @attributes = attributes
+      end
+
+      def identity
+        Identity.new(
+          attributes.fetch(:id),
+          attributes.fetch(:queue),
+          attributes.fetch(:handler),
+          attributes.fetch(:arguments)
+        )
+      end
+
+      def scheduling
+        Scheduling.new(
+          attributes.fetch(:priority),
+          attributes.fetch(:concurrency_key),
+          attributes.fetch(:rate_limit_key)
+        )
+      end
+
+      def lifecycle_state
+        LifecycleState.new(
+          attributes.fetch(:state),
+          attributes.fetch(:attempt),
+          attributes.fetch(:created_at),
+          attributes.fetch(:updated_at),
+          attributes.fetch(:lifecycle)
+        )
+      end
+
+      private
+
+      attr_reader :attributes
+    end
 
     def initialize(**attributes)
-      normalized_attributes = Attributes.new(attributes).to_h
+      components = Components.new(Attributes.new(attributes).to_h)
 
-      @id = normalized_attributes.fetch(:id)
-      @queue = normalized_attributes.fetch(:queue)
-      @handler = normalized_attributes.fetch(:handler)
-      @arguments = normalized_attributes.fetch(:arguments)
-      @state = normalized_attributes.fetch(:state)
-      @attempt = normalized_attributes.fetch(:attempt)
-      @created_at = normalized_attributes.fetch(:created_at)
-      @lifecycle = normalized_attributes.fetch(:lifecycle)
-      @updated_at = normalized_attributes.fetch(:updated_at)
+      @identity = components.identity
+      @scheduling = components.scheduling
+      @lifecycle_state = components.lifecycle_state
 
       freeze
     end
@@ -48,6 +84,9 @@ module Karya
         queue:,
         handler:,
         arguments:,
+        priority:,
+        concurrency_key:,
+        rate_limit_key:,
         lifecycle:,
         state: normalized_next_state,
         attempt:,
@@ -60,10 +99,26 @@ module Karya
       lifecycle.terminal?(state)
     end
 
-    private_constant :Attributes, :ImmutableArguments
+    def id = identity.id
+    def queue = identity.queue
+    def handler = identity.handler
+    def arguments = identity.arguments
+    def priority = scheduling.priority
+    def concurrency_key = scheduling.concurrency_key
+    def rate_limit_key = scheduling.rate_limit_key
+    def state = lifecycle_state.state
+    def attempt = lifecycle_state.attempt
+    def created_at = lifecycle_state.created_at
+    def updated_at = lifecycle_state.updated_at
+
+    private_constant :Attributes, :Components, :ImmutableArguments
 
     private
 
-    attr_reader :lifecycle
+    attr_reader :identity, :lifecycle_state, :scheduling
+
+    def lifecycle
+      lifecycle_state.lifecycle
+    end
   end
 end

--- a/core/karya/lib/karya/job.rb
+++ b/core/karya/lib/karya/job.rb
@@ -34,7 +34,7 @@ module Karya
           attributes.fetch(:queue),
           attributes.fetch(:handler),
           attributes.fetch(:arguments)
-        )
+        ).freeze
       end
 
       def scheduling
@@ -42,7 +42,7 @@ module Karya
           attributes.fetch(:priority),
           attributes.fetch(:concurrency_key),
           attributes.fetch(:rate_limit_key)
-        )
+        ).freeze
       end
 
       def lifecycle_state
@@ -52,7 +52,7 @@ module Karya
           attributes.fetch(:created_at),
           attributes.fetch(:updated_at),
           attributes.fetch(:lifecycle)
-        )
+        ).freeze
       end
 
       private

--- a/core/karya/lib/karya/job/attributes.rb
+++ b/core/karya/lib/karya/job/attributes.rb
@@ -16,26 +16,17 @@ module Karya
       end
 
       def to_h
-        created_at = TimestampNormalizer.new(:created_at, required(:created_at)).normalize
-        attempt = optional(:attempt, 0)
-        lifecycle = Primitives::Lifecycle.new(
-          :lifecycle,
-          optional(:lifecycle, JobLifecycle.default_registry),
-          error_class: InvalidJobAttributeError
-        ).normalize
-        raise InvalidJobAttributeError, 'attempt must be a non-negative Integer' unless attempt.is_a?(Integer) && attempt >= 0
+        created_at = normalize_created_at
+        lifecycle = normalize_lifecycle
+        normalized_attempt = normalize_attempt
+        normalized_priority = normalize_priority
 
-        {
-          id: IdentifierNormalizer.new(:id, required(:id)).normalize,
-          queue: IdentifierNormalizer.new(:queue, required(:queue)).normalize,
-          handler: IdentifierNormalizer.new(:handler, required(:handler)).normalize,
-          arguments: ImmutableArguments.new(optional(:arguments, {})).normalize,
-          lifecycle:,
-          state: lifecycle.normalize_state(required(:state)),
-          attempt:,
+        normalized_attributes(
           created_at:,
-          updated_at: TimestampNormalizer.new(:updated_at, optional(:updated_at, created_at)).normalize
-        }
+          lifecycle:,
+          attempt: normalized_attempt,
+          priority: normalized_priority
+        )
       end
 
       private
@@ -50,6 +41,57 @@ module Karya
 
       def optional(name, default)
         attributes.fetch(name, default)
+      end
+
+      def normalized_attributes(created_at:, lifecycle:, attempt:, priority:)
+        {
+          id: IdentifierNormalizer.new(:id, required(:id)).normalize,
+          queue: IdentifierNormalizer.new(:queue, required(:queue)).normalize,
+          handler: IdentifierNormalizer.new(:handler, required(:handler)).normalize,
+          arguments: ImmutableArguments.new(optional(:arguments, {})).normalize,
+          priority:,
+          concurrency_key: normalize_optional_identifier(:concurrency_key),
+          rate_limit_key: normalize_optional_identifier(:rate_limit_key),
+          lifecycle:,
+          state: lifecycle.normalize_state(required(:state)),
+          attempt:,
+          created_at:,
+          updated_at: normalize_updated_at(created_at)
+        }
+      end
+
+      def normalize_attempt
+        attempt = optional(:attempt, 0)
+        raise InvalidJobAttributeError, 'attempt must be a non-negative Integer' unless attempt.is_a?(Integer) && attempt >= 0
+
+        attempt
+      end
+
+      def normalize_priority
+        priority = optional(:priority, 0)
+        raise InvalidJobAttributeError, 'priority must be an Integer' unless priority.is_a?(Integer)
+
+        priority
+      end
+
+      def normalize_created_at
+        TimestampNormalizer.new(:created_at, required(:created_at)).normalize
+      end
+
+      def normalize_updated_at(created_at)
+        TimestampNormalizer.new(:updated_at, optional(:updated_at, created_at)).normalize
+      end
+
+      def normalize_lifecycle
+        Primitives::Lifecycle.new(
+          :lifecycle,
+          optional(:lifecycle, JobLifecycle.default_registry),
+          error_class: InvalidJobAttributeError
+        ).normalize
+      end
+
+      def normalize_optional_identifier(name)
+        OptionalIdentifierNormalizer.new(name, optional(name, nil)).normalize
       end
 
       # Normalizes required identifier-like fields into frozen, non-blank strings.
@@ -89,7 +131,28 @@ module Karya
         attr_reader :name, :value
       end
 
-      private_constant :IdentifierNormalizer, :TimestampNormalizer
+      # Normalizes optional identifier-like fields into frozen, non-blank strings or nil.
+      class OptionalIdentifierNormalizer
+        def initialize(name, value)
+          @name = name
+          @value = value
+        end
+
+        def normalize
+          value&.then do
+            normalized_value = value.to_s.strip
+            return normalized_value.freeze unless normalized_value.empty?
+
+            raise InvalidJobAttributeError, "#{name} must be present"
+          end
+        end
+
+        private
+
+        attr_reader :name, :value
+      end
+
+      private_constant :IdentifierNormalizer, :OptionalIdentifierNormalizer, :TimestampNormalizer
     end
   end
 end

--- a/core/karya/lib/karya/queue_store/in_memory.rb
+++ b/core/karya/lib/karya/queue_store/in_memory.rb
@@ -144,7 +144,7 @@ module Karya
 
       attr_reader :policy_set, :state, :token_generator
 
-      private_constant :LeaseDuration
+      private_constant :LeaseDuration, :HandlerMatcher
 
       def validate_enqueue(job)
         raise InvalidEnqueueError, 'job must be a Karya::Job' unless job.is_a?(Job)

--- a/core/karya/lib/karya/queue_store/in_memory.rb
+++ b/core/karya/lib/karya/queue_store/in_memory.rb
@@ -74,7 +74,7 @@ module Karya
         normalized_lease_duration = LeaseDuration.new(lease_duration).normalize
 
         @mutex.synchronize do
-          expire_reservations_locked(normalized_now)
+          perform_reserve_maintenance(normalized_now)
 
           matched_queue, matched_job_index, matched_job_id = find_reserved_job(normalized_queues, handler_matcher, normalized_now)
           return nil unless matched_job_id
@@ -163,7 +163,12 @@ module Karya
 
         expired_reserved_jobs = expired_reservations.map { |reservation| requeue_expired_reservation(reservation, now) }
         expired_running_jobs = expired_executions.map { |reservation| requeue_expired_execution(reservation, now) }
+        prune_stale_rate_limit_admissions(now)
         expired_reserved_jobs + expired_running_jobs
+      end
+
+      def perform_reserve_maintenance(now)
+        expire_reservations_locked(now)
       end
 
       def requeue_reservation(reservation, now)

--- a/core/karya/lib/karya/queue_store/in_memory.rb
+++ b/core/karya/lib/karya/queue_store/in_memory.rb
@@ -9,25 +9,37 @@ require 'securerandom'
 require 'bigdecimal'
 
 require_relative 'base'
+require_relative 'in_memory/backpressure_support'
+require_relative 'in_memory/handler_matcher'
+require_relative 'in_memory/lease_duration'
+require_relative 'in_memory/store_state'
 require_relative '../job'
 require_relative '../primitives/identifier'
 require_relative '../primitives/queue_list'
 require_relative '../reservation'
+require_relative '../backpressure'
 
 module Karya
   module QueueStore
     # Single-process reference implementation for queue submission and reservation behavior.
     class InMemory
       include Base
+      include BackpressureSupport
 
       DEFAULT_EXPIRED_TOMBSTONE_LIMIT = 1024
       RESERVE_QUEUES_ERROR_MESSAGE = 'provide exactly one of queue or queues'
 
-      def initialize(token_generator: -> { SecureRandom.uuid }, expired_tombstone_limit: DEFAULT_EXPIRED_TOMBSTONE_LIMIT)
+      def initialize(
+        token_generator: -> { SecureRandom.uuid },
+        expired_tombstone_limit: DEFAULT_EXPIRED_TOMBSTONE_LIMIT,
+        policy_set: Backpressure::PolicySet.new
+      )
         valid_tombstone_limit = expired_tombstone_limit.is_a?(Integer) && expired_tombstone_limit >= 0
         raise InvalidQueueStoreOperationError, 'expired_tombstone_limit must be a finite non-negative Integer' unless valid_tombstone_limit
+        raise InvalidQueueStoreOperationError, 'policy_set must be a Karya::Backpressure::PolicySet' unless policy_set.is_a?(Backpressure::PolicySet)
 
         @token_generator = token_generator
+        @policy_set = policy_set
         @reservation_token_sequence = 0
         @mutex = Mutex.new
         @state = StoreState.new(expired_tombstone_limit:)
@@ -64,7 +76,7 @@ module Karya
         @mutex.synchronize do
           expire_reservations_locked(normalized_now)
 
-          matched_queue, matched_job_index, matched_job_id = find_reserved_job(normalized_queues, handler_matcher)
+          matched_queue, matched_job_index, matched_job_id = find_reserved_job(normalized_queues, handler_matcher, normalized_now)
           return nil unless matched_job_id
 
           jobs_by_id = state.jobs_by_id
@@ -81,6 +93,7 @@ module Karya
           queue_job_ids.delete_at(matched_job_index)
           state.delete_queue(matched_queue) if queue_job_ids.empty?
           jobs_by_id[reserved_job.id] = reserved_job
+          record_rate_limit_admission(reserved_job, normalized_now)
           state.reserve(reservation)
           reservation
         end
@@ -129,144 +142,7 @@ module Karya
 
       private
 
-      attr_reader :state, :token_generator
-
-      # Encapsulates subscription handler matching for reservation scans.
-      class HandlerMatcher
-        def initialize(handler_names)
-          if handler_names.nil?
-            @match_all = true
-            @handler_names = {}.freeze
-            return
-          end
-
-          raise InvalidQueueStoreOperationError, 'handler_names must be an Array' unless handler_names.is_a?(Array)
-
-          @match_all = false
-          @handler_names = normalize_present_handler_names(handler_names)
-        end
-
-        def include?(handler_name)
-          match_all || handler_names.include?(handler_name)
-        end
-
-        private
-
-        attr_reader :handler_names, :match_all
-
-        def normalize_present_handler_names(handler_names)
-          normalized_names = handler_names.map do |name|
-            Primitives::Identifier.new(:handler, name, error_class: InvalidQueueStoreOperationError).normalize
-          end
-          raise InvalidQueueStoreOperationError, 'handler_names must be present' if normalized_names.empty?
-
-          normalized_names.to_h { |name| [name, true] }.freeze
-        end
-      end
-
-      # Internal mutable state for the single-process queue store.
-      class StoreState
-        attr_reader :executions_by_token,
-                    :execution_tokens_in_order,
-                    :expired_reservation_tokens,
-                    :expired_reservation_tokens_in_order,
-                    :jobs_by_id,
-                    :queued_job_ids_by_queue,
-                    :reservation_tokens_in_order,
-                    :reservations_by_token
-
-        def initialize(expired_tombstone_limit:)
-          @executions_by_token = {}
-          @execution_tokens_in_order = []
-          @expired_reservation_tokens = {}
-          @expired_reservation_tokens_in_order = []
-          @expired_tombstone_limit = expired_tombstone_limit
-          @jobs_by_id = {}
-          @queued_job_ids_by_queue = {}
-          @reservation_tokens_in_order = []
-          @reservations_by_token = {}
-        end
-
-        def queue_job_ids_for(queue)
-          queued_job_ids_by_queue[queue] ||= []
-        end
-
-        def delete_queue(queue)
-          queued_job_ids_by_queue.delete(queue)
-        end
-
-        def reserve(reservation)
-          reservation_token = reservation.token
-          reservations_by_token[reservation_token] = reservation
-          reservation_tokens_in_order << reservation_token
-        end
-
-        def activate_execution(reservation_token, reservation)
-          reservations_by_token.delete(reservation_token)
-          delete_reservation_token(reservation_token)
-          executions_by_token[reservation_token] = reservation
-          execution_tokens_in_order << reservation_token
-        end
-
-        def delete_reservation_token(reservation_token)
-          reservation_index = reservation_tokens_in_order.index(reservation_token)
-          reservation_tokens_in_order.delete_at(reservation_index) if reservation_index
-        end
-
-        def delete_execution_token(reservation_token)
-          execution_index = execution_tokens_in_order.index(reservation_token)
-          execution_tokens_in_order.delete_at(execution_index) if execution_index
-        end
-
-        def mark_expired(reservation_token)
-          return if expired_reservation_tokens.key?(reservation_token)
-
-          expired_reservation_tokens[reservation_token] = true
-          expired_reservation_tokens_in_order << reservation_token
-          prune_expired_reservation_tokens
-        end
-
-        def reservation_token_in_use?(reservation_token)
-          reservations_by_token.key?(reservation_token) ||
-            executions_by_token.key?(reservation_token) ||
-            expired_reservation_tokens.key?(reservation_token)
-        end
-
-        private
-
-        def prune_expired_reservation_tokens
-          while expired_reservation_tokens_in_order.length > @expired_tombstone_limit
-            oldest_token = expired_reservation_tokens_in_order.shift
-            expired_reservation_tokens.delete(oldest_token)
-          end
-        end
-      end
-
-      # Validates and normalizes lease durations accepted by the queue store.
-      class LeaseDuration
-        def initialize(value)
-          @value = value
-        end
-
-        def normalize
-          raise InvalidQueueStoreOperationError, 'lease_duration must be a positive number' unless valid?
-
-          value
-        end
-
-        private
-
-        attr_reader :value
-
-        def valid?
-          case value
-          when Integer, Float, Rational, BigDecimal
-            value.positive? && (value.is_a?(Integer) || value.finite?)
-          else
-            false
-          end
-        end
-      end
+      attr_reader :policy_set, :state, :token_generator
 
       private_constant :LeaseDuration
 
@@ -366,23 +242,33 @@ module Karya
         Primitives::QueueList.new(reserve_queues, error_class: InvalidQueueStoreOperationError).normalize
       end
 
-      def find_reserved_job(queues, handler_matcher)
+      def find_reserved_job(queues, handler_matcher, now)
         queues.each do |queue|
-          matched_job_index, matched_job_id = matching_job_for(queue, handler_matcher)
+          matched_job_index, matched_job_id = matching_job_for(queue, handler_matcher, now)
           return [queue, matched_job_index, matched_job_id] if matched_job_id
         end
 
         nil
       end
 
-      def matching_job_for(queue, handler_matcher)
+      def matching_job_for(queue, handler_matcher, now)
         queue_job_ids = state.queued_job_ids_by_queue.fetch(queue, [])
+        selected_job = nil
+
         queue_job_ids.each_with_index do |job_id, index|
           queued_job = state.jobs_by_id.fetch(job_id)
-          return [index, job_id] if handler_matcher.include?(queued_job.handler)
+          queued_job_priority = queued_job.priority
+          next unless handler_matcher.include?(queued_job.handler)
+          next if concurrency_blocked?(queued_job)
+          next if rate_limited?(queued_job, now)
+          next if selected_job && queued_job_priority <= selected_job.fetch(:priority)
+
+          selected_job = { id: job_id, index:, priority: queued_job_priority }
         end
 
-        nil
+        return nil unless selected_job
+
+        [selected_job.fetch(:index), selected_job.fetch(:id)]
       end
 
       def finalize_execution(reservation_token:, now:, next_state:)

--- a/core/karya/lib/karya/queue_store/in_memory.rb
+++ b/core/karya/lib/karya/queue_store/in_memory.rb
@@ -12,6 +12,7 @@ require_relative 'base'
 require_relative 'in_memory/backpressure_support'
 require_relative 'in_memory/handler_matcher'
 require_relative 'in_memory/lease_duration'
+require_relative 'in_memory/reserve_scan_state'
 require_relative 'in_memory/store_state'
 require_relative '../job'
 require_relative '../primitives/identifier'
@@ -67,36 +68,16 @@ module Karya
       end
 
       def reserve(worker_id:, lease_duration:, now:, queue: nil, queues: nil, handler_names: nil)
-        normalized_queues = normalize_reserve_queues(queue:, queues:)
-        handler_matcher = HandlerMatcher.new(handler_names)
-        normalized_worker_id = normalize_identifier(:worker_id, worker_id, error_class: InvalidQueueStoreOperationError)
-        normalized_now = normalize_time(:now, now, error_class: InvalidQueueStoreOperationError)
-        normalized_lease_duration = LeaseDuration.new(lease_duration).normalize
+        reserve_request = normalize_reserve_request(
+          worker_id:,
+          lease_duration:,
+          now:,
+          queue:,
+          queues:,
+          handler_names:
+        )
 
-        @mutex.synchronize do
-          perform_reserve_maintenance(normalized_now)
-
-          matched_queue, matched_job_index, matched_job_id = find_reserved_job(normalized_queues, handler_matcher, normalized_now)
-          return nil unless matched_job_id
-
-          jobs_by_id = state.jobs_by_id
-          queue_job_ids = state.queued_job_ids_by_queue.fetch(matched_queue)
-          queued_job = jobs_by_id.fetch(matched_job_id)
-          reserved_job = queued_job.transition_to(:reserved, updated_at: normalized_now)
-          reservation = build_reservation(
-            reserved_job:,
-            worker_id: normalized_worker_id,
-            reserved_at: normalized_now,
-            lease_duration: normalized_lease_duration
-          )
-
-          queue_job_ids.delete_at(matched_job_index)
-          state.delete_queue(matched_queue) if queue_job_ids.empty?
-          jobs_by_id[reserved_job.id] = reserved_job
-          record_rate_limit_admission(reserved_job, normalized_now)
-          state.reserve(reservation)
-          reservation
-        end
+        @mutex.synchronize { reserve_matching_job(reserve_request) }
       end
 
       def release(reservation_token:, now:)
@@ -144,7 +125,7 @@ module Karya
 
       attr_reader :policy_set, :state, :token_generator
 
-      private_constant :LeaseDuration, :HandlerMatcher
+      private_constant :LeaseDuration, :HandlerMatcher, :ReserveScanState
 
       def validate_enqueue(job)
         raise InvalidEnqueueError, 'job must be a Karya::Job' unless job.is_a?(Job)
@@ -169,6 +150,7 @@ module Karya
 
       def perform_reserve_maintenance(now)
         expire_reservations_locked(now)
+        build_reserve_scan_state
       end
 
       def requeue_reservation(reservation, now)
@@ -247,33 +229,73 @@ module Karya
         Primitives::QueueList.new(reserve_queues, error_class: InvalidQueueStoreOperationError).normalize
       end
 
-      def find_reserved_job(queues, handler_matcher, now)
+      def normalize_reserve_request(worker_id:, lease_duration:, now:, queue:, queues:, handler_names:)
+        {
+          handler_matcher: HandlerMatcher.new(handler_names),
+          lease_duration: LeaseDuration.new(lease_duration).normalize,
+          now: normalize_time(:now, now, error_class: InvalidQueueStoreOperationError),
+          queues: normalize_reserve_queues(queue:, queues:),
+          worker_id: normalize_identifier(:worker_id, worker_id, error_class: InvalidQueueStoreOperationError)
+        }
+      end
+
+      def reserve_matching_job(reserve_request)
+        now = reserve_request.fetch(:now)
+        reserve_scan_state = perform_reserve_maintenance(now)
+        matched_queue, matched_job_index, matched_job_id =
+          find_reserved_job(reserve_request.fetch(:queues), reserve_request.fetch(:handler_matcher), reserve_scan_state)
+        return nil unless matched_job_id
+
+        jobs_by_id = state.jobs_by_id
+        queue_job_ids = state.queued_job_ids_by_queue.fetch(matched_queue)
+        queued_job = jobs_by_id.fetch(matched_job_id)
+        reserved_job = queued_job.transition_to(:reserved, updated_at: now)
+        reservation = build_reservation(
+          reserved_job:,
+          worker_id: reserve_request.fetch(:worker_id),
+          reserved_at: now,
+          lease_duration: reserve_request.fetch(:lease_duration)
+        )
+
+        queue_job_ids.delete_at(matched_job_index)
+        state.delete_queue(matched_queue) if queue_job_ids.empty?
+        jobs_by_id[reserved_job.id] = reserved_job
+        record_rate_limit_admission(reserved_job, now)
+        state.reserve(reservation)
+        reservation
+      end
+
+      def find_reserved_job(queues, handler_matcher, reserve_scan_state)
         queues.each do |queue|
-          matched_job_index, matched_job_id = matching_job_for(queue, handler_matcher, now)
+          matched_job_index, matched_job_id = matching_job_for(queue, handler_matcher, reserve_scan_state)
           return [queue, matched_job_index, matched_job_id] if matched_job_id
         end
 
         nil
       end
 
-      def matching_job_for(queue, handler_matcher, now)
+      def matching_job_for(queue, handler_matcher, reserve_scan_state)
         queue_job_ids = state.queued_job_ids_by_queue.fetch(queue, [])
-        selected_job = nil
+        selected_job_id = nil
+        selected_job_index = nil
+        selected_job_priority = nil
 
         queue_job_ids.each_with_index do |job_id, index|
           queued_job = state.jobs_by_id.fetch(job_id)
           queued_job_priority = queued_job.priority
           next unless handler_matcher.include?(queued_job.handler)
-          next if concurrency_blocked?(queued_job)
-          next if rate_limited?(queued_job, now)
-          next if selected_job && queued_job_priority <= selected_job.fetch(:priority)
+          next if reserve_scan_state.concurrency_blocked?(queued_job)
+          next if reserve_scan_state.rate_limited?(queued_job)
+          next if selected_job_priority && queued_job_priority <= selected_job_priority
 
-          selected_job = { id: job_id, index:, priority: queued_job_priority }
+          selected_job_id = job_id
+          selected_job_index = index
+          selected_job_priority = queued_job_priority
         end
 
-        return nil unless selected_job
+        return nil unless selected_job_id
 
-        [selected_job.fetch(:index), selected_job.fetch(:id)]
+        [selected_job_index, selected_job_id]
       end
 
       def finalize_execution(reservation_token:, now:, next_state:)

--- a/core/karya/lib/karya/queue_store/in_memory/backpressure_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/backpressure_support.rb
@@ -12,31 +12,6 @@ module Karya
       module BackpressureSupport
         private
 
-        def concurrency_blocked?(job)
-          policy = policy_set.concurrency_policy_for(job.concurrency_key)
-          return false unless policy
-
-          active_job_count_for(policy.key) >= policy.limit
-        end
-
-        def active_job_count_for(concurrency_key)
-          count_jobs_with_key(state.reservations_by_token, concurrency_key) +
-            count_jobs_with_key(state.executions_by_token, concurrency_key)
-        end
-
-        def count_jobs_with_key(leases_by_token, concurrency_key)
-          leases_by_token.each_value.count do |reservation|
-            state.jobs_by_id.fetch(reservation.job_id).concurrency_key == concurrency_key
-          end
-        end
-
-        def rate_limited?(job, now)
-          policy = policy_set.rate_limit_policy_for(job.rate_limit_key)
-          return false unless policy
-
-          prune_rate_limit_admissions(policy.key, policy, now, delete_empty: true).length >= policy.limit
-        end
-
         def record_rate_limit_admission(job, now)
           policy = policy_set.rate_limit_policy_for(job.rate_limit_key)
           return unless policy
@@ -45,7 +20,7 @@ module Karya
         end
 
         def prune_stale_rate_limit_admissions(now)
-          state.rate_limit_admissions_by_key.each_key do |rate_limit_key|
+          state.rate_limit_admissions_by_key.dup.each_key do |rate_limit_key|
             policy = policy_set.rate_limit_policy_for(rate_limit_key)
             unless policy
               state.delete_rate_limit_key(rate_limit_key)
@@ -54,6 +29,10 @@ module Karya
 
             prune_rate_limit_admissions(rate_limit_key, policy, now, delete_empty: true)
           end
+        end
+
+        def build_reserve_scan_state
+          ReserveScanState.new(policy_set:, state:)
         end
 
         def prune_rate_limit_admissions(rate_limit_key, policy, now, delete_empty:)

--- a/core/karya/lib/karya/queue_store/in_memory/backpressure_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/backpressure_support.rb
@@ -20,7 +20,8 @@ module Karya
         end
 
         def prune_stale_rate_limit_admissions(now)
-          state.rate_limit_admissions_by_key.dup.each_key do |rate_limit_key|
+          rate_limit_keys = state.rate_limit_admissions_by_key.keys
+          rate_limit_keys.each do |rate_limit_key|
             policy = policy_set.rate_limit_policy_for(rate_limit_key)
             unless policy
               state.delete_rate_limit_key(rate_limit_key)

--- a/core/karya/lib/karya/queue_store/in_memory/backpressure_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/backpressure_support.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class InMemory
+      # Backpressure policy helpers used during reservation scans.
+      module BackpressureSupport
+        private
+
+        def concurrency_blocked?(job)
+          policy = policy_set.concurrency_policy_for(job.concurrency_key)
+          return false unless policy
+
+          active_job_count_for(policy.key) >= policy.limit
+        end
+
+        def active_job_count_for(concurrency_key)
+          count_jobs_with_key(state.reservations_by_token, concurrency_key) +
+            count_jobs_with_key(state.executions_by_token, concurrency_key)
+        end
+
+        def count_jobs_with_key(leases_by_token, concurrency_key)
+          leases_by_token.each_value.count do |reservation|
+            state.jobs_by_id.fetch(reservation.job_id).concurrency_key == concurrency_key
+          end
+        end
+
+        def rate_limited?(job, now)
+          policy = policy_set.rate_limit_policy_for(job.rate_limit_key)
+          return false unless policy
+
+          prune_rate_limit_admissions(policy.key, policy, now, delete_empty: true).length >= policy.limit
+        end
+
+        def record_rate_limit_admission(job, now)
+          policy = policy_set.rate_limit_policy_for(job.rate_limit_key)
+          return unless policy
+
+          prune_rate_limit_admissions(policy.key, policy, now, delete_empty: false) << now
+        end
+
+        def prune_rate_limit_admissions(rate_limit_key, policy, now, delete_empty:)
+          admissions = state.rate_limit_admissions_for(rate_limit_key)
+          cutoff_time = now - policy.period
+          admissions.reject! { |admission_time| admission_time <= cutoff_time }
+          if delete_empty && admissions.empty?
+            state.delete_rate_limit_key(rate_limit_key)
+            admissions = []
+          end
+
+          admissions
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/in_memory/backpressure_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/backpressure_support.rb
@@ -44,6 +44,18 @@ module Karya
           prune_rate_limit_admissions(policy.key, policy, now, delete_empty: false) << now
         end
 
+        def prune_stale_rate_limit_admissions(now)
+          state.rate_limit_admissions_by_key.each_key do |rate_limit_key|
+            policy = policy_set.rate_limit_policy_for(rate_limit_key)
+            unless policy
+              state.delete_rate_limit_key(rate_limit_key)
+              next
+            end
+
+            prune_rate_limit_admissions(rate_limit_key, policy, now, delete_empty: true)
+          end
+        end
+
         def prune_rate_limit_admissions(rate_limit_key, policy, now, delete_empty:)
           admissions = state.rate_limit_admissions_for(rate_limit_key)
           cutoff_time = now - policy.period

--- a/core/karya/lib/karya/queue_store/in_memory/handler_matcher.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/handler_matcher.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class InMemory
+      # Encapsulates subscription handler matching for reservation scans.
+      class HandlerMatcher
+        def initialize(handler_names)
+          if handler_names.nil?
+            @match_all = true
+            @handler_names = {}.freeze
+            return
+          end
+
+          raise InvalidQueueStoreOperationError, 'handler_names must be an Array' unless handler_names.is_a?(Array)
+
+          @match_all = false
+          @handler_names = normalize_present_handler_names(handler_names)
+        end
+
+        def include?(handler_name)
+          match_all || handler_names.include?(handler_name)
+        end
+
+        private
+
+        attr_reader :handler_names, :match_all
+
+        def normalize_present_handler_names(handler_names)
+          normalized_names = handler_names.map do |name|
+            Primitives::Identifier.new(:handler, name, error_class: InvalidQueueStoreOperationError).normalize
+          end
+          raise InvalidQueueStoreOperationError, 'handler_names must be present' if normalized_names.empty?
+
+          normalized_names.to_h { |name| [name, true] }.freeze
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/in_memory/lease_duration.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/lease_duration.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class InMemory
+      # Validates and normalizes lease durations accepted by the queue store.
+      class LeaseDuration
+        def initialize(value)
+          @value = value
+        end
+
+        def normalize
+          raise InvalidQueueStoreOperationError, 'lease_duration must be a positive number' unless valid?
+
+          value
+        end
+
+        private
+
+        attr_reader :value
+
+        def valid?
+          case value
+          when Integer, Float, Rational, BigDecimal
+            value.positive? && (value.is_a?(Integer) || value.finite?)
+          else
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/in_memory/lease_duration.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/lease_duration.rb
@@ -26,11 +26,21 @@ module Karya
 
         def valid?
           case value
-          when Integer, Float, Rational, BigDecimal
-            value.positive? && (value.is_a?(Integer) || value.finite?)
+          when Integer, Rational
+            positive_rational_or_integer?
+          when Float, BigDecimal
+            positive_finite_float_or_decimal?
           else
             false
           end
+        end
+
+        def positive_rational_or_integer?
+          value.positive?
+        end
+
+        def positive_finite_float_or_decimal?
+          value.positive? && value.finite?
         end
       end
     end

--- a/core/karya/lib/karya/queue_store/in_memory/reserve_scan_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/reserve_scan_state.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class InMemory
+      # Snapshot of backpressure state reused during one reserve scan.
+      class ReserveScanState
+        def initialize(policy_set:, state:)
+          @state = state
+          @concurrency_counts = Hash.new(0)
+          accumulate_concurrency_counts(@state.reservations_by_token)
+          accumulate_concurrency_counts(@state.executions_by_token)
+          @concurrency_limits = policy_set.concurrency.transform_values(&:limit)
+          @rate_limit_counts = state.rate_limit_admissions_by_key.transform_values(&:length)
+          @rate_limit_limits = policy_set.rate_limits.transform_values(&:limit)
+        end
+
+        def concurrency_blocked?(job)
+          concurrency_key = job.concurrency_key
+          return false unless concurrency_key
+
+          limit = @concurrency_limits[concurrency_key]
+          limit && @concurrency_counts.fetch(concurrency_key, 0) >= limit
+        end
+
+        def rate_limited?(job)
+          rate_limit_key = job.rate_limit_key
+          return false unless rate_limit_key
+
+          limit = @rate_limit_limits[rate_limit_key]
+          limit && @rate_limit_counts.fetch(rate_limit_key, 0) >= limit
+        end
+
+        private
+
+        def accumulate_concurrency_counts(leases_by_token)
+          jobs_by_id = @state.jobs_by_id
+
+          leases_by_token.each_value do |reservation|
+            concurrency_key = jobs_by_id.fetch(reservation.job_id).concurrency_key
+            next unless concurrency_key
+
+            @concurrency_counts[concurrency_key] += 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/in_memory/reserve_scan_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/reserve_scan_state.rb
@@ -25,7 +25,9 @@ module Karya
           return false unless concurrency_key
 
           limit = @concurrency_limits[concurrency_key]
-          limit && @concurrency_counts.fetch(concurrency_key, 0) >= limit
+          return false unless limit
+
+          @concurrency_counts.fetch(concurrency_key, 0) >= limit
         end
 
         def rate_limited?(job)
@@ -33,7 +35,9 @@ module Karya
           return false unless rate_limit_key
 
           limit = @rate_limit_limits[rate_limit_key]
-          limit && @rate_limit_counts.fetch(rate_limit_key, 0) >= limit
+          return false unless limit
+
+          @rate_limit_counts.fetch(rate_limit_key, 0) >= limit
         end
 
         private

--- a/core/karya/lib/karya/queue_store/in_memory/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/store_state.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class InMemory
+      # Internal mutable state for the single-process queue store.
+      class StoreState
+        attr_reader :executions_by_token,
+                    :execution_tokens_in_order,
+                    :expired_reservation_tokens,
+                    :expired_reservation_tokens_in_order,
+                    :jobs_by_id,
+                    :rate_limit_admissions_by_key,
+                    :queued_job_ids_by_queue,
+                    :reservation_tokens_in_order,
+                    :reservations_by_token
+
+        def initialize(expired_tombstone_limit:)
+          @executions_by_token = {}
+          @execution_tokens_in_order = []
+          @expired_reservation_tokens = {}
+          @expired_reservation_tokens_in_order = []
+          @expired_tombstone_limit = expired_tombstone_limit
+          @jobs_by_id = {}
+          @rate_limit_admissions_by_key = {}
+          @queued_job_ids_by_queue = {}
+          @reservation_tokens_in_order = []
+          @reservations_by_token = {}
+        end
+
+        def queue_job_ids_for(queue)
+          queued_job_ids_by_queue[queue] ||= []
+        end
+
+        def delete_queue(queue)
+          queued_job_ids_by_queue.delete(queue)
+        end
+
+        def rate_limit_admissions_for(key)
+          rate_limit_admissions_by_key[key] ||= []
+        end
+
+        def delete_rate_limit_key(key)
+          rate_limit_admissions_by_key.delete(key)
+        end
+
+        def reserve(reservation)
+          reservation_token = reservation.token
+          reservations_by_token[reservation_token] = reservation
+          reservation_tokens_in_order << reservation_token
+        end
+
+        def activate_execution(reservation_token, reservation)
+          reservations_by_token.delete(reservation_token)
+          delete_reservation_token(reservation_token)
+          executions_by_token[reservation_token] = reservation
+          execution_tokens_in_order << reservation_token
+        end
+
+        def delete_reservation_token(reservation_token)
+          reservation_index = reservation_tokens_in_order.index(reservation_token)
+          reservation_tokens_in_order.delete_at(reservation_index) if reservation_index
+        end
+
+        def delete_execution_token(reservation_token)
+          execution_index = execution_tokens_in_order.index(reservation_token)
+          execution_tokens_in_order.delete_at(execution_index) if execution_index
+        end
+
+        def mark_expired(reservation_token)
+          return if expired_reservation_tokens.key?(reservation_token)
+
+          expired_reservation_tokens[reservation_token] = true
+          expired_reservation_tokens_in_order << reservation_token
+          prune_expired_reservation_tokens
+        end
+
+        def reservation_token_in_use?(reservation_token)
+          reservations_by_token.key?(reservation_token) ||
+            executions_by_token.key?(reservation_token) ||
+            expired_reservation_tokens.key?(reservation_token)
+        end
+
+        private
+
+        def prune_expired_reservation_tokens
+          while expired_reservation_tokens_in_order.length > @expired_tombstone_limit
+            oldest_token = expired_reservation_tokens_in_order.shift
+            expired_reservation_tokens.delete(oldest_token)
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/sig/karya/backpressure.rbs
+++ b/core/karya/sig/karya/backpressure.rbs
@@ -33,8 +33,8 @@ module Karya
       attr_reader rate_limits: Hash[String, RateLimitPolicy]
 
       def initialize: (
-        ?concurrency: Hash[Karya::state_name | Integer, ConcurrencyPolicy | Hash[Symbol, Integer]],
-        ?rate_limits: Hash[Karya::state_name | Integer, RateLimitPolicy | Hash[Symbol, Integer | Karya::lease_duration_value]]
+        ?concurrency: Hash[Karya::state_name | Integer, ConcurrencyPolicy | Hash[Symbol | String, Integer]],
+        ?rate_limits: Hash[Karya::state_name | Integer, RateLimitPolicy | Hash[Symbol | String, Integer | Karya::lease_duration_value]]
       ) -> void
 
       def concurrency_policy_for: ((Karya::state_name | Integer)? key) -> ConcurrencyPolicy?

--- a/core/karya/sig/karya/backpressure.rbs
+++ b/core/karya/sig/karya/backpressure.rbs
@@ -1,0 +1,44 @@
+module Karya
+  module Backpressure
+    class InvalidPolicyError < Error
+    end
+
+    class ConcurrencyPolicy
+      @key: String
+      @limit: Integer
+
+      attr_reader key: String
+      attr_reader limit: Integer
+
+      def initialize: (key: Karya::state_name | Integer, limit: Integer) -> void
+    end
+
+    class RateLimitPolicy
+      @key: String
+      @limit: Integer
+      @period: Karya::lease_duration_value
+
+      attr_reader key: String
+      attr_reader limit: Integer
+      attr_reader period: Karya::lease_duration_value
+
+      def initialize: (key: Karya::state_name | Integer, limit: Integer, period: Karya::lease_duration_value) -> void
+    end
+
+    class PolicySet
+      @concurrency: Hash[String, ConcurrencyPolicy]
+      @rate_limits: Hash[String, RateLimitPolicy]
+
+      attr_reader concurrency: Hash[String, ConcurrencyPolicy]
+      attr_reader rate_limits: Hash[String, RateLimitPolicy]
+
+      def initialize: (
+        ?concurrency: Hash[Karya::state_name | Integer, ConcurrencyPolicy | Hash[Symbol, Integer]],
+        ?rate_limits: Hash[Karya::state_name | Integer, RateLimitPolicy | Hash[Symbol, Integer | Karya::lease_duration_value]]
+      ) -> void
+
+      def concurrency_policy_for: ((Karya::state_name | Integer)? key) -> ConcurrencyPolicy?
+      def rate_limit_policy_for: ((Karya::state_name | Integer)? key) -> RateLimitPolicy?
+    end
+  end
+end

--- a/core/karya/sig/karya/job.rbs
+++ b/core/karya/sig/karya/job.rbs
@@ -38,6 +38,7 @@ module Karya
       attr_reader attempt: Integer
       attr_reader created_at: Time
       attr_reader updated_at: Time
+      attr_reader lifecycle: JobLifecycle::Registry
     end
 
     @identity: Identity
@@ -90,6 +91,6 @@ module Karya
     attr_reader scheduling: Scheduling
     attr_reader lifecycle_state: LifecycleState
 
-    attr_reader lifecycle: JobLifecycle::Registry
+    def lifecycle: () -> JobLifecycle::Registry
   end
 end

--- a/core/karya/sig/karya/job.rbs
+++ b/core/karya/sig/karya/job.rbs
@@ -12,6 +12,9 @@ module Karya
     @handler: String
 
     @arguments: job_arguments
+    @priority: Integer
+    @concurrency_key: String?
+    @rate_limit_key: String?
 
     @state: state_name
 
@@ -26,14 +29,17 @@ module Karya
     attr_reader arguments: job_arguments
 
     attr_reader attempt: Integer
+    attr_reader concurrency_key: String?
 
     attr_reader created_at: Time
 
     attr_reader handler: String
 
     attr_reader id: String
+    attr_reader priority: Integer
 
     attr_reader queue: String
+    attr_reader rate_limit_key: String?
 
     attr_reader state: state_name
 
@@ -44,6 +50,9 @@ module Karya
       queue: state_name,
       handler: state_name,
       ?arguments: Hash[state_name, job_argument],
+      ?priority: Integer,
+      ?concurrency_key: state_name?,
+      ?rate_limit_key: state_name?,
       state: state_name,
       ?attempt: Integer,
       created_at: Time,

--- a/core/karya/sig/karya/job.rbs
+++ b/core/karya/sig/karya/job.rbs
@@ -5,26 +5,44 @@ module Karya
 
   # Immutable value object for the canonical queued job model.
   class Job
-    @id: String
+    class Identity
+      @id: String
+      @queue: String
+      @handler: String
+      @arguments: job_arguments
 
-    @queue: String
+      attr_reader id: String
+      attr_reader queue: String
+      attr_reader handler: String
+      attr_reader arguments: job_arguments
+    end
 
-    @handler: String
+    class Scheduling
+      @priority: Integer
+      @concurrency_key: String?
+      @rate_limit_key: String?
 
-    @arguments: job_arguments
-    @priority: Integer
-    @concurrency_key: String?
-    @rate_limit_key: String?
+      attr_reader priority: Integer
+      attr_reader concurrency_key: String?
+      attr_reader rate_limit_key: String?
+    end
 
-    @state: state_name
+    class LifecycleState
+      @state: state_name
+      @attempt: Integer
+      @created_at: Time
+      @updated_at: Time
+      @lifecycle: JobLifecycle::Registry
 
-    @attempt: Integer
+      attr_reader state: state_name
+      attr_reader attempt: Integer
+      attr_reader created_at: Time
+      attr_reader updated_at: Time
+    end
 
-    @created_at: Time
-
-    @lifecycle: JobLifecycle::Registry
-
-    @updated_at: Time
+    @identity: Identity
+    @scheduling: Scheduling
+    @lifecycle_state: LifecycleState
 
     attr_reader arguments: job_arguments
 
@@ -67,6 +85,10 @@ module Karya
     def terminal?: () -> bool
 
     private
+
+    attr_reader identity: Identity
+    attr_reader scheduling: Scheduling
+    attr_reader lifecycle_state: LifecycleState
 
     attr_reader lifecycle: JobLifecycle::Registry
   end

--- a/core/karya/sig/karya/job/attributes.rbs
+++ b/core/karya/sig/karya/job/attributes.rbs
@@ -6,7 +6,7 @@ module Karya
 
       def initialize: (Hash[Symbol, Karya::job_attribute_value] attributes) -> void
 
-      def to_h: () -> { id: String, queue: String, handler: String, arguments: Karya::job_arguments, lifecycle: Karya::lifecycle, state: Karya::state_name, attempt: Integer, created_at: Time, updated_at: Time }
+      def to_h: () -> { id: String, queue: String, handler: String, arguments: Karya::job_arguments, priority: Integer, concurrency_key: String?, rate_limit_key: String?, lifecycle: Karya::lifecycle, state: Karya::state_name, attempt: Integer, created_at: Time, updated_at: Time }
 
       private
 
@@ -14,7 +14,7 @@ module Karya
 
       def required: (Symbol name) -> Karya::job_attribute_value
 
-      def optional: (Symbol name, Karya::job_argument | Integer | Time | Karya::lifecycle) -> (Karya::job_argument | Integer | Time | Karya::lifecycle)
+      def optional: (Symbol name, Karya::job_argument | Integer | Time | Karya::lifecycle | Karya::state_name?) -> (Karya::job_argument | Integer | Time | Karya::lifecycle | Karya::state_name?)
 
       # Normalizes required identifier-like fields into frozen, non-blank strings.
       class IdentifierNormalizer
@@ -48,6 +48,15 @@ module Karya
         attr_reader name: Symbol
 
         attr_reader value: Time
+      end
+
+      class OptionalIdentifierNormalizer
+        @name: Symbol
+        @value: Karya::state_name?
+
+        def initialize: (Symbol name, Karya::state_name? value) -> void
+
+        def normalize: () -> String?
       end
     end
   end

--- a/core/karya/sig/karya/queue_store/in_memory.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory.rbs
@@ -42,6 +42,8 @@ module Karya
 
       private
 
+      attr_reader policy_set: Backpressure::PolicySet
+
       attr_reader state: StoreState
 
       attr_reader token_generator: Method | Proc
@@ -176,6 +178,8 @@ module Karya
 
       def ensure_unique_reservation_token: (String reservation_token) -> nil
 
+      def build_reserve_scan_state: () -> ReserveScanState
+
       def normalize_reserve_queues: (queue: Karya::state_name?, queues: Array[Karya::state_name]?) -> Array[String]
 
       def normalize_reserve_request: (
@@ -214,6 +218,8 @@ module Karya
       ) -> [Integer, String]?
 
       def record_rate_limit_admission: (Job job, Time now) -> Array[Time]?
+
+      def prune_stale_rate_limit_admissions: (Time now) -> void
 
       def prune_rate_limit_admissions: (String rate_limit_key, Backpressure::RateLimitPolicy policy, Time now, delete_empty: bool) -> Array[Time]
 

--- a/core/karya/sig/karya/queue_store/in_memory.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory.rbs
@@ -3,6 +3,7 @@ module Karya
     # Single-process reference implementation for queue submission and reservation behavior.
     class InMemory
       @token_generator: Method | Proc
+      @policy_set: Backpressure::PolicySet
 
       @reservation_token_sequence: Integer
 
@@ -16,7 +17,7 @@ module Karya
 
       RESERVE_QUEUES_ERROR_MESSAGE: String
 
-      def initialize: (?(Method | Proc) token_generator, ?Integer expired_tombstone_limit) -> void
+      def initialize: (?(Method | Proc) token_generator, ?Integer expired_tombstone_limit, ?Backpressure::PolicySet policy_set) -> void
 
       def enqueue: (job: Job, now: Time) -> Job
 
@@ -77,6 +78,7 @@ module Karya
         @expired_tombstone_limit: Integer
 
         @jobs_by_id: Hash[String, Job]
+        @rate_limit_admissions_by_key: Hash[String, Array[Time]]
 
         @queued_job_ids_by_queue: Hash[String, Array[String]]
 
@@ -93,6 +95,7 @@ module Karya
         attr_reader expired_reservation_tokens_in_order: Array[String]
 
         attr_reader jobs_by_id: Hash[String, Job]
+        attr_reader rate_limit_admissions_by_key: Hash[String, Array[Time]]
 
         attr_reader queued_job_ids_by_queue: Hash[String, Array[String]]
 
@@ -105,6 +108,10 @@ module Karya
         def queue_job_ids_for: (String queue) -> Array[String]
 
         def delete_queue: (String queue) -> Array[String]?
+
+        def rate_limit_admissions_for: (String key) -> Array[Time]
+
+        def delete_rate_limit_key: (String key) -> Array[Time]?
 
         def reserve: (Reservation reservation) -> Array[String]
 
@@ -160,9 +167,21 @@ module Karya
 
       def normalize_reserve_queues: (queue: Karya::state_name?, queues: Array[Karya::state_name]?) -> Array[String]
 
-      def find_reserved_job: (Array[String] queues, HandlerMatcher handler_matcher) -> [String, Integer, String]?
+      def find_reserved_job: (Array[String] queues, HandlerMatcher handler_matcher, Time now) -> [String, Integer, String]?
 
-      def matching_job_for: (String queue, HandlerMatcher handler_matcher) -> [Integer, String]?
+      def matching_job_for: (String queue, HandlerMatcher handler_matcher, Time now) -> [Integer, String]?
+
+      def concurrency_blocked?: (Job job) -> bool
+
+      def active_job_count_for: (String concurrency_key) -> Integer
+
+      def count_jobs_with_key: (Hash[String, Reservation] leases_by_token, String concurrency_key) -> Integer
+
+      def rate_limited?: (Job job, Time now) -> bool
+
+      def record_rate_limit_admission: (Job job, Time now) -> Array[Time]?
+
+      def prune_rate_limit_admissions: (String rate_limit_key, Backpressure::RateLimitPolicy policy, Time now) -> Array[Time]
 
       def finalize_execution: (reservation_token: Karya::state_name | Integer, now: Time, next_state: :succeeded | :failed) -> Job
 

--- a/core/karya/sig/karya/queue_store/in_memory.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory.rbs
@@ -17,7 +17,7 @@ module Karya
 
       RESERVE_QUEUES_ERROR_MESSAGE: String
 
-      def initialize: (?(Method | Proc) token_generator, ?Integer expired_tombstone_limit, ?Backpressure::PolicySet policy_set) -> void
+      def initialize: (?token_generator: (Method | Proc), ?expired_tombstone_limit: Integer, ?policy_set: Backpressure::PolicySet) -> void
 
       def enqueue: (job: Job, now: Time) -> Job
 
@@ -181,7 +181,7 @@ module Karya
 
       def record_rate_limit_admission: (Job job, Time now) -> Array[Time]?
 
-      def prune_rate_limit_admissions: (String rate_limit_key, Backpressure::RateLimitPolicy policy, Time now) -> Array[Time]
+      def prune_rate_limit_admissions: (String rate_limit_key, Backpressure::RateLimitPolicy policy, Time now, delete_empty: bool) -> Array[Time]
 
       def finalize_execution: (reservation_token: Karya::state_name | Integer, now: Time, next_state: :succeeded | :failed) -> Job
 

--- a/core/karya/sig/karya/queue_store/in_memory.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory.rbs
@@ -185,9 +185,21 @@ module Karya
         ?queue: Karya::state_name?,
         ?queues: Array[Karya::state_name]?,
         ?handler_names: Array[Karya::state_name]?
-      ) -> Hash[Symbol, untyped]
+      ) -> {
+        handler_matcher: HandlerMatcher,
+        lease_duration: Karya::lease_duration_value,
+        now: Time,
+        queues: Array[String],
+        worker_id: String
+      }
 
-      def reserve_matching_job: (Hash[Symbol, untyped] reserve_request) -> Reservation?
+      def reserve_matching_job: ({
+        handler_matcher: HandlerMatcher,
+        lease_duration: Karya::lease_duration_value,
+        now: Time,
+        queues: Array[String],
+        worker_id: String
+      } reserve_request) -> Reservation?
 
       def find_reserved_job: (
         Array[String] queues,

--- a/core/karya/sig/karya/queue_store/in_memory.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory.rbs
@@ -145,11 +145,22 @@ module Karya
         def valid?: () -> bool
       end
 
+      # Snapshot of backpressure state reused during one reserve scan.
+      class ReserveScanState
+        def initialize: (policy_set: Backpressure::PolicySet, state: StoreState) -> void
+
+        def concurrency_blocked?: (Job job) -> bool
+
+        def rate_limited?: (Job job) -> bool
+      end
+
       def validate_enqueue: (Job job) -> nil
 
       def next_token: () -> ::String
 
       def expire_reservations_locked: (Time now) -> Array[Job]
+
+      def perform_reserve_maintenance: (Time now) -> ReserveScanState
 
       def requeue_reservation: (Reservation reservation, Time now) -> Job
 
@@ -167,17 +178,28 @@ module Karya
 
       def normalize_reserve_queues: (queue: Karya::state_name?, queues: Array[Karya::state_name]?) -> Array[String]
 
-      def find_reserved_job: (Array[String] queues, HandlerMatcher handler_matcher, Time now) -> [String, Integer, String]?
+      def normalize_reserve_request: (
+        worker_id: Karya::state_name | Integer,
+        lease_duration: Karya::lease_duration_value,
+        now: Time,
+        ?queue: Karya::state_name?,
+        ?queues: Array[Karya::state_name]?,
+        ?handler_names: Array[Karya::state_name]?
+      ) -> Hash[Symbol, untyped]
 
-      def matching_job_for: (String queue, HandlerMatcher handler_matcher, Time now) -> [Integer, String]?
+      def reserve_matching_job: (Hash[Symbol, untyped] reserve_request) -> Reservation?
 
-      def concurrency_blocked?: (Job job) -> bool
+      def find_reserved_job: (
+        Array[String] queues,
+        HandlerMatcher handler_matcher,
+        ReserveScanState reserve_scan_state
+      ) -> [String, Integer, String]?
 
-      def active_job_count_for: (String concurrency_key) -> Integer
-
-      def count_jobs_with_key: (Hash[String, Reservation] leases_by_token, String concurrency_key) -> Integer
-
-      def rate_limited?: (Job job, Time now) -> bool
+      def matching_job_for: (
+        String queue,
+        HandlerMatcher handler_matcher,
+        ReserveScanState reserve_scan_state
+      ) -> [Integer, String]?
 
       def record_rate_limit_admission: (Job job, Time now) -> Array[Time]?
 

--- a/core/karya/spec/karya/backpressure/policy_set_spec.rb
+++ b/core/karya/spec/karya/backpressure/policy_set_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Karya::Backpressure::PolicySet do
     end.to raise_error(Karya::Backpressure::InvalidPolicyError, /period must be a positive finite number/)
   end
 
+  it 'rejects non-finite bigdecimal periods' do
+    expect do
+      described_class.new(rate_limits: { partner_api: { limit: 1, period: BigDecimal('Infinity') } })
+    end.to raise_error(Karya::Backpressure::InvalidPolicyError, /period must be a positive finite number/)
+  end
+
   it 'returns nil for missing lookup keys' do
     policy_set = described_class.new
 

--- a/core/karya/spec/karya/backpressure/policy_set_spec.rb
+++ b/core/karya/spec/karya/backpressure/policy_set_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe Karya::Backpressure::PolicySet do
     )
   end
 
+  it 'normalizes string attribute keys for policy hashes' do
+    policy_set = described_class.new(concurrency: { account_sync: { 'limit' => 2 } })
+
+    expect(policy_set.concurrency_policy_for('account_sync')&.limit).to eq(2)
+  end
+
+  it 'rejects unsupported policy attribute key types' do
+    expect do
+      described_class.new(concurrency: { account_sync: { 1 => 2 } })
+    end.to raise_error(Karya::Backpressure::InvalidPolicyError, /policy attribute keys must be Symbols or Strings/)
+  end
+
   it 'rejects non-hash policy registries' do
     expect do
       described_class.new(concurrency: [])

--- a/core/karya/spec/karya/backpressure/policy_set_spec.rb
+++ b/core/karya/spec/karya/backpressure/policy_set_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+RSpec.describe Karya::Backpressure::PolicySet do
+  it 'normalizes hash input into immutable policy objects' do
+    policy_set = described_class.new(
+      concurrency: { account_sync: { limit: 2 } },
+      rate_limits: { partner_api: { limit: 5, period: 60 } }
+    )
+
+    concurrency_policy = policy_set.concurrency_policy_for('account_sync')
+    rate_limit_policy = policy_set.rate_limit_policy_for('partner_api')
+
+    expect(concurrency_policy).to be_a(Karya::Backpressure::ConcurrencyPolicy)
+    expect(concurrency_policy.limit).to eq(2)
+    expect(rate_limit_policy).to be_a(Karya::Backpressure::RateLimitPolicy)
+    expect(rate_limit_policy.limit).to eq(5)
+    expect(rate_limit_policy.period).to eq(60)
+    expect(policy_set.concurrency).to be_frozen
+    expect(policy_set.rate_limits).to be_frozen
+  end
+
+  it 'rejects invalid concurrency limits' do
+    expect do
+      described_class.new(concurrency: { account_sync: { limit: 0 } })
+    end.to raise_error(Karya::Backpressure::InvalidPolicyError, /limit must be a positive Integer/)
+  end
+
+  it 'reuses matching policy instances without rebuilding them' do
+    policy = Karya::Backpressure::ConcurrencyPolicy.new(key: 'account_sync', limit: 2)
+
+    policy_set = described_class.new(concurrency: { account_sync: policy })
+
+    expect(policy_set.concurrency_policy_for('account_sync')).to equal(policy)
+  end
+
+  it 'rejects non-hash, non-policy values' do
+    expect do
+      described_class.new(concurrency: { account_sync: Object.new })
+    end.to raise_error(
+      Karya::Backpressure::InvalidPolicyError,
+      /ConcurrencyPolicy must be built from a Hash or policy instance/
+    )
+  end
+
+  it 'rejects non-hash policy registries' do
+    expect do
+      described_class.new(concurrency: [])
+    end.to raise_error(Karya::Backpressure::InvalidPolicyError, /concurrency policies must be a Hash/)
+  end
+
+  it 'rejects invalid rate-limit periods' do
+    expect do
+      described_class.new(rate_limits: { partner_api: { limit: 1, period: Float::INFINITY } })
+    end.to raise_error(Karya::Backpressure::InvalidPolicyError, /period must be a positive finite number/)
+  end
+
+  it 'returns nil for missing lookup keys' do
+    policy_set = described_class.new
+
+    expect(policy_set.concurrency_policy_for(nil)).to be_nil
+    expect(policy_set.rate_limit_policy_for(nil)).to be_nil
+  end
+end

--- a/core/karya/spec/karya/backpressure/policy_set_spec.rb
+++ b/core/karya/spec/karya/backpressure/policy_set_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Karya::Backpressure::PolicySet do
     end.to raise_error(Karya::Backpressure::InvalidPolicyError, /policy attribute keys must be Symbols or Strings/)
   end
 
+  it 'rejects duplicate normalized policy keys' do
+    expect do
+      described_class.new(concurrency: { :account_sync => { limit: 1 }, ' account_sync ' => { limit: 2 } })
+    end.to raise_error(Karya::Backpressure::InvalidPolicyError, /duplicate concurrency key "account_sync" after normalization/)
+  end
+
   it 'rejects non-hash policy registries' do
     expect do
       described_class.new(concurrency: [])

--- a/core/karya/spec/karya/job/attributes_spec.rb
+++ b/core/karya/spec/karya/job/attributes_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe 'Karya::Job::Attributes' do
       expect(result[:attempt]).to eq(0)
     end
 
+    it 'defaults priority to 0 and policy keys to nil' do
+      attributes = attributes_class.new(
+        id: 'job123',
+        queue: 'billing',
+        handler: 'BillingSync',
+        state: 'queued',
+        created_at: created_at
+      )
+
+      result = attributes.to_h
+
+      expect(result[:priority]).to eq(0)
+      expect(result[:concurrency_key]).to be_nil
+      expect(result[:rate_limit_key]).to be_nil
+    end
+
     it 'defaults updated_at to created_at when not provided' do
       attributes = attributes_class.new(
         id: 'job123',
@@ -85,6 +101,45 @@ RSpec.describe 'Karya::Job::Attributes' do
           attempt: '1'
         ).to_h
       end.to raise_error(Karya::InvalidJobAttributeError, 'attempt must be a non-negative Integer')
+    end
+
+    it 'raises InvalidJobAttributeError for non-integer priority' do
+      expect do
+        attributes_class.new(
+          id: 'job123',
+          queue: 'billing',
+          handler: 'BillingSync',
+          state: 'queued',
+          created_at: created_at,
+          priority: 'high'
+        ).to_h
+      end.to raise_error(Karya::InvalidJobAttributeError, 'priority must be an Integer')
+    end
+
+    it 'raises InvalidJobAttributeError for blank concurrency_key' do
+      expect do
+        attributes_class.new(
+          id: 'job123',
+          queue: 'billing',
+          handler: 'BillingSync',
+          state: 'queued',
+          created_at: created_at,
+          concurrency_key: ' '
+        ).to_h
+      end.to raise_error(Karya::InvalidJobAttributeError, 'concurrency_key must be present')
+    end
+
+    it 'raises InvalidJobAttributeError for blank rate_limit_key' do
+      expect do
+        attributes_class.new(
+          id: 'job123',
+          queue: 'billing',
+          handler: 'BillingSync',
+          state: 'queued',
+          created_at: created_at,
+          rate_limit_key: ''
+        ).to_h
+      end.to raise_error(Karya::InvalidJobAttributeError, 'rate_limit_key must be present')
     end
 
     it 'raises InvalidJobAttributeError for negative attempt' do

--- a/core/karya/spec/karya/job_spec.rb
+++ b/core/karya/spec/karya/job_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe Karya::Job do
         queue: 'billing',
         handler: :billing_sync,
         arguments: { 'account_id' => 42, metadata: { source: 'sync' }, tags: ['vip'] },
+        priority: 5,
+        concurrency_key: 'account-42',
+        rate_limit_key: 'partner-api',
         state: 'retry-pending',
         attempt: 2,
         created_at:,
@@ -32,6 +35,9 @@ RSpec.describe Karya::Job do
       expect(job.arguments).to be_frozen
       expect(job.arguments['metadata']).to be_frozen
       expect(job.arguments['tags']).to be_frozen
+      expect(job.priority).to eq(5)
+      expect(job.concurrency_key).to eq('account-42')
+      expect(job.rate_limit_key).to eq('partner-api')
       expect(job.state).to eq(:retry_pending)
       expect(job.attempt).to eq(2)
       expect(job.created_at).to eq(created_at)
@@ -168,6 +174,25 @@ RSpec.describe Karya::Job do
       expect(transitioned_job.arguments).to equal(job.arguments)
       expect(transitioned_job.arguments['metadata']).to equal(job.arguments['metadata'])
       expect(transitioned_job.arguments['tags']).to equal(job.arguments['tags'])
+    end
+
+    it 'preserves priority and policy keys across transitions' do
+      job = described_class.new(
+        id: 'job_123',
+        queue: 'billing',
+        handler: 'billing_sync',
+        priority: 9,
+        concurrency_key: 'account-9',
+        rate_limit_key: 'partner-api',
+        state: :reserved,
+        created_at:
+      )
+
+      transitioned_job = job.transition_to(:running, updated_at:)
+
+      expect(transitioned_job.priority).to eq(9)
+      expect(transitioned_job.concurrency_key).to eq('account-9')
+      expect(transitioned_job.rate_limit_key).to eq('partner-api')
     end
   end
 

--- a/core/karya/spec/karya/job_spec.rb
+++ b/core/karya/spec/karya/job_spec.rb
@@ -194,6 +194,23 @@ RSpec.describe Karya::Job do
       expect(transitioned_job.concurrency_key).to eq('account-9')
       expect(transitioned_job.rate_limit_key).to eq('partner-api')
     end
+
+    it 'freezes internal component structs to preserve immutability' do
+      job = described_class.new(
+        id: 'job_123',
+        queue: 'billing',
+        handler: 'billing_sync',
+        priority: 9,
+        concurrency_key: 'account-9',
+        rate_limit_key: 'partner-api',
+        state: :reserved,
+        created_at:
+      )
+
+      expect(job.instance_variable_get(:@identity)).to be_frozen
+      expect(job.instance_variable_get(:@scheduling)).to be_frozen
+      expect(job.instance_variable_get(:@lifecycle_state)).to be_frozen
+    end
   end
 
   describe '#terminal?' do

--- a/core/karya/spec/karya/queue_store/in_memory_initialization_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_initialization_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe Karya::QueueStore::InMemory do
   end
 
   describe '#initialize' do
+    it 'supports default initialization' do
+      store = described_class.new
+
+      expect(store).to be_a(described_class)
+    end
+
+    it 'uses the default token generator when reserving jobs' do
+      store = described_class.new
+      job = Karya::Job.new(
+        id: 'job-1',
+        queue: 'billing',
+        handler: 'billing_sync',
+        state: :submission,
+        created_at: created_at
+      )
+
+      store.enqueue(job:, now: created_at + 1)
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+
+      expect(reservation.token).to match(/\A[\w-]+:1\z/)
+    end
+
     it 'rejects negative expired tombstone limits' do
       expect do
         described_class.new(expired_tombstone_limit: -1)
@@ -47,6 +69,12 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect do
         described_class.new(expired_tombstone_limit: Float::INFINITY)
       end.to raise_error(Karya::InvalidQueueStoreOperationError, /finite non-negative Integer/)
+    end
+
+    it 'rejects invalid policy_set values' do
+      expect do
+        described_class.new(policy_set: Object.new)
+      end.to raise_error(Karya::InvalidQueueStoreOperationError, /policy_set must be a Karya::Backpressure::PolicySet/)
     end
   end
 

--- a/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
@@ -430,6 +430,18 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect(second.job_id).to eq('job-2')
     end
 
+    it 'ignores unconfigured rate-limit keys without recording admissions' do
+      store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, rate_limit_key: 'unconfigured'),
+        now: created_at + 1
+      )
+
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+
+      expect(reservation.job_id).to eq('job-1')
+      expect(store_state.rate_limit_admissions_by_key).to eq({})
+    end
+
     it 'returns a reservation lease with the reserved job metadata' do
       store.enqueue(job: submission_job(id: 'job-1', queue: 'billing', created_at:), now: created_at + 1)
 

--- a/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
@@ -187,15 +187,19 @@ RSpec.describe Karya::QueueStore::InMemory do
         now: created_at + 1
       )
       constrained_store.enqueue(
-        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, priority: 1),
+        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, priority: 9, concurrency_key: 'account_sync'),
         now: created_at + 2
       )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-3', queue: 'billing', created_at: created_at + 2, priority: 1),
+        now: created_at + 3
+      )
 
-      first = constrained_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
-      second = constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 4)
+      first = constrained_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 4)
+      second = constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 5)
 
       expect(first.job_id).to eq('job-1')
-      expect(second.job_id).to eq('job-2')
+      expect(second.job_id).to eq('job-3')
     end
 
     it 'skips blocked earlier queues and reserves from later queues' do
@@ -208,8 +212,12 @@ RSpec.describe Karya::QueueStore::InMemory do
         now: created_at + 1
       )
       constrained_store.enqueue(
-        job: submission_job(id: 'email-1', queue: 'email', created_at: created_at + 1, priority: 1),
+        job: submission_job(id: 'billing-2', queue: 'billing', created_at: created_at + 1, priority: 9, concurrency_key: 'account_sync'),
         now: created_at + 2
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'email-1', queue: 'email', created_at: created_at + 2, priority: 1),
+        now: created_at + 3
       )
 
       constrained_store.reserve(
@@ -217,7 +225,7 @@ RSpec.describe Karya::QueueStore::InMemory do
         handler_names: %w[billing_sync],
         worker_id: 'worker-1',
         lease_duration: 30,
-        now: created_at + 3
+        now: created_at + 4
       )
 
       reservation = constrained_store.reserve(
@@ -225,7 +233,7 @@ RSpec.describe Karya::QueueStore::InMemory do
         handler_names: %w[billing_sync],
         worker_id: 'worker-2',
         lease_duration: 30,
-        now: created_at + 4
+        now: created_at + 5
       )
 
       expect(reservation.job_id).to eq('email-1')
@@ -332,6 +340,31 @@ RSpec.describe Karya::QueueStore::InMemory do
 
       expect(first.job_id).to eq('job-1')
       expect(second).to be_nil
+    end
+
+    it 'skips rate-limited higher-priority jobs and reserves a later eligible job' do
+      limited_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(rate_limits: { partner_api: { limit: 1, period: 60 } })
+      )
+      limited_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, priority: 10, rate_limit_key: 'partner_api'),
+        now: created_at + 1
+      )
+      limited_store.enqueue(
+        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, priority: 9, rate_limit_key: 'partner_api'),
+        now: created_at + 2
+      )
+      limited_store.enqueue(
+        job: submission_job(id: 'job-3', queue: 'billing', created_at: created_at + 2, priority: 1),
+        now: created_at + 3
+      )
+
+      first = limited_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 4)
+      second = limited_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 5)
+
+      expect(first.job_id).to eq('job-1')
+      expect(second.job_id).to eq('job-3')
     end
 
     it 'reopens rate-limit capacity after the window expires' do

--- a/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
@@ -563,6 +563,14 @@ RSpec.describe Karya::QueueStore::InMemory do
       end.to raise_error(Karya::InvalidQueueStoreOperationError, /lease_duration must be a positive number/)
     end
 
+    it 'accepts Rational lease durations' do
+      store.enqueue(job: submission_job(id: 'job-1', queue: 'billing', created_at:), now: created_at + 1)
+
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: Rational(3, 2), now: created_at + 2)
+
+      expect(reservation.expires_at).to eq(created_at + Rational(7, 2))
+    end
+
     it 'rejects blank identifiers for reserve input' do
       expect do
         store.reserve(queue: ' ', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)

--- a/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
@@ -6,17 +6,21 @@
 # LICENSE file in the root directory of this source tree.
 
 RSpec.describe Karya::QueueStore::InMemory do
-  subject(:store) { described_class.new(token_generator: token_generator) }
+  subject(:store) { described_class.new(token_generator: token_generator, policy_set:) }
 
   let(:token_sequence) { %w[lease-1 lease-2 lease-3 lease-4].each }
   let(:token_generator) { -> { token_sequence.next } }
   let(:created_at) { Time.utc(2026, 3, 27, 12, 0, 0) }
+  let(:policy_set) { Karya::Backpressure::PolicySet.new }
 
-  def submission_job(id:, queue:, created_at:, handler: 'billing_sync')
+  def submission_job(id:, queue:, created_at:, handler: 'billing_sync', priority: 0, concurrency_key: nil, rate_limit_key: nil)
     Karya::Job.new(
       id:,
       queue:,
       handler:,
+      priority:,
+      concurrency_key:,
+      rate_limit_key:,
       state: :submission,
       created_at:
     )
@@ -73,6 +77,41 @@ RSpec.describe Karya::QueueStore::InMemory do
 
       expect(first.job_id).to eq('job-1')
       expect(second.job_id).to eq('job-2')
+    end
+
+    it 'reserves higher priority jobs first within the same queue' do
+      store.enqueue(job: submission_job(id: 'job-1', queue: 'billing', created_at:, priority: 1), now: created_at + 1)
+      store.enqueue(job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, priority: 10), now: created_at + 2)
+
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+
+      expect(reservation.job_id).to eq('job-2')
+    end
+
+    it 'keeps FIFO order for jobs with the same priority' do
+      store.enqueue(job: submission_job(id: 'job-1', queue: 'billing', created_at:, priority: 5), now: created_at + 1)
+      store.enqueue(job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, priority: 5), now: created_at + 2)
+
+      first = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+      second = store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 4)
+
+      expect(first.job_id).to eq('job-1')
+      expect(second.job_id).to eq('job-2')
+    end
+
+    it 'keeps queue order ahead of cross-queue priority' do
+      store.enqueue(job: submission_job(id: 'billing-1', queue: 'billing', created_at:, priority: 1), now: created_at + 1)
+      store.enqueue(job: submission_job(id: 'email-1', queue: 'email', created_at: created_at + 1, priority: 99), now: created_at + 2)
+
+      reservation = store.reserve(
+        queues: %w[billing email],
+        handler_names: %w[billing_sync],
+        worker_id: 'worker-1',
+        lease_duration: 30,
+        now: created_at + 3
+      )
+
+      expect(reservation.job_id).to eq('billing-1')
     end
 
     it 'reserves first matching job from subscribed queues in declared order' do
@@ -136,6 +175,199 @@ RSpec.describe Karya::QueueStore::InMemory do
 
       expect(reservation).to be_nil
       expect(stored_job('job-1').state).to eq(:queued)
+    end
+
+    it 'skips blocked higher-priority jobs and reserves lower-priority eligible jobs' do
+      constrained_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, priority: 10, concurrency_key: 'account_sync'),
+        now: created_at + 1
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, priority: 1),
+        now: created_at + 2
+      )
+
+      first = constrained_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+      second = constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 4)
+
+      expect(first.job_id).to eq('job-1')
+      expect(second.job_id).to eq('job-2')
+    end
+
+    it 'skips blocked earlier queues and reserves from later queues' do
+      constrained_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'billing-1', queue: 'billing', created_at:, priority: 10, concurrency_key: 'account_sync'),
+        now: created_at + 1
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'email-1', queue: 'email', created_at: created_at + 1, priority: 1),
+        now: created_at + 2
+      )
+
+      constrained_store.reserve(
+        queues: %w[billing email],
+        handler_names: %w[billing_sync],
+        worker_id: 'worker-1',
+        lease_duration: 30,
+        now: created_at + 3
+      )
+
+      reservation = constrained_store.reserve(
+        queues: %w[billing email],
+        handler_names: %w[billing_sync],
+        worker_id: 'worker-2',
+        lease_duration: 30,
+        now: created_at + 4
+      )
+
+      expect(reservation.job_id).to eq('email-1')
+    end
+
+    it 'reopens concurrency capacity after release' do
+      constrained_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, concurrency_key: 'account_sync'),
+        now: created_at + 1
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, concurrency_key: 'account_sync'),
+        now: created_at + 2
+      )
+
+      first = constrained_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+      expect(constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 4)).to be_nil
+
+      constrained_store.release(reservation_token: first.token, now: created_at + 5)
+
+      second = constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 6)
+      expect(second.job_id).to eq('job-2')
+    end
+
+    it 'reopens concurrency capacity after execution completion' do
+      constrained_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, concurrency_key: 'account_sync'),
+        now: created_at + 1
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, concurrency_key: 'account_sync'),
+        now: created_at + 2
+      )
+
+      first = constrained_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+      constrained_store.start_execution(reservation_token: first.token, now: created_at + 4)
+      expect(constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 5)).to be_nil
+
+      constrained_store.complete_execution(reservation_token: first.token, now: created_at + 6)
+
+      second = constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 7)
+      expect(second.job_id).to eq('job-2')
+    end
+
+    it 'reopens concurrency capacity after expiration' do
+      constrained_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, concurrency_key: 'account_sync'),
+        now: created_at + 1
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, concurrency_key: 'account_sync'),
+        now: created_at + 2
+      )
+
+      constrained_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 1, now: created_at + 3)
+
+      replacement = constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 5)
+      expect(replacement.job_id).to eq('job-2')
+    end
+
+    it 'ignores concurrency caps for jobs without a configured concurrency_key' do
+      constrained_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
+      )
+      constrained_store.enqueue(job: submission_job(id: 'job-1', queue: 'billing', created_at:), now: created_at + 1)
+      constrained_store.enqueue(job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1), now: created_at + 2)
+
+      first = constrained_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+      second = constrained_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 4)
+
+      expect(first.job_id).to eq('job-1')
+      expect(second.job_id).to eq('job-2')
+    end
+
+    it 'blocks reservations after a rate-limit window reaches capacity' do
+      limited_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(rate_limits: { partner_api: { limit: 1, period: 60 } })
+      )
+      limited_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, rate_limit_key: 'partner_api'),
+        now: created_at + 1
+      )
+      limited_store.enqueue(
+        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, rate_limit_key: 'partner_api'),
+        now: created_at + 2
+      )
+
+      first = limited_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+      second = limited_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 4)
+
+      expect(first.job_id).to eq('job-1')
+      expect(second).to be_nil
+    end
+
+    it 'reopens rate-limit capacity after the window expires' do
+      limited_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(rate_limits: { partner_api: { limit: 1, period: 10 } })
+      )
+      limited_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, rate_limit_key: 'partner_api'),
+        now: created_at + 1
+      )
+      limited_store.enqueue(
+        job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1, rate_limit_key: 'partner_api'),
+        now: created_at + 2
+      )
+
+      first = limited_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+      expect(first.job_id).to eq('job-1')
+
+      second = limited_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 14)
+      expect(second.job_id).to eq('job-2')
+    end
+
+    it 'ignores rate limits for jobs without a configured rate_limit_key' do
+      limited_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(rate_limits: { partner_api: { limit: 1, period: 60 } })
+      )
+      limited_store.enqueue(job: submission_job(id: 'job-1', queue: 'billing', created_at:), now: created_at + 1)
+      limited_store.enqueue(job: submission_job(id: 'job-2', queue: 'billing', created_at: created_at + 1), now: created_at + 2)
+
+      first = limited_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 3)
+      second = limited_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 4)
+
+      expect(first.job_id).to eq('job-1')
+      expect(second.job_id).to eq('job-2')
     end
 
     it 'returns a reservation lease with the reserved job metadata' do

--- a/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
@@ -388,6 +388,33 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect(second.job_id).to eq('job-2')
     end
 
+    it 'prunes stale rate-limit admission keys during reserve maintenance' do
+      limited_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(rate_limits: { partner_api: { limit: 1, period: 10 } })
+      )
+      limited_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, rate_limit_key: 'partner_api'),
+        now: created_at + 1
+      )
+
+      limited_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+
+      expect(limited_store.instance_variable_get(:@state).rate_limit_admissions_by_key.keys).to eq(['partner_api'])
+
+      limited_store.reserve(queue: 'missing', worker_id: 'worker-2', lease_duration: 30, now: created_at + 20)
+
+      expect(limited_store.instance_variable_get(:@state).rate_limit_admissions_by_key).to eq({})
+    end
+
+    it 'removes orphaned rate-limit admission keys during reserve maintenance' do
+      store_state.rate_limit_admissions_by_key['orphan'] = [created_at]
+
+      store.reserve(queue: 'missing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 20)
+
+      expect(store_state.rate_limit_admissions_by_key).to eq({})
+    end
+
     it 'ignores rate limits for jobs without a configured rate_limit_key' do
       limited_store = described_class.new(
         token_generator: token_generator,

--- a/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_reserve_spec.rb
@@ -321,6 +321,21 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect(second.job_id).to eq('job-2')
     end
 
+    it 'ignores unconfigured concurrency keys during reserve scans' do
+      constrained_store = described_class.new(
+        token_generator: token_generator,
+        policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
+      )
+      constrained_store.enqueue(
+        job: submission_job(id: 'job-1', queue: 'billing', created_at:, concurrency_key: 'unconfigured'),
+        now: created_at + 1
+      )
+
+      reservation = constrained_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+
+      expect(reservation.job_id).to eq('job-1')
+    end
+
     it 'blocks reservations after a rate-limit window reaches capacity' do
       limited_store = described_class.new(
         token_generator: token_generator,

--- a/core/karya/spec/karya/worker_integration_spec.rb
+++ b/core/karya/spec/karya/worker_integration_spec.rb
@@ -6,19 +6,23 @@
 # LICENSE file in the root directory of this source tree.
 
 RSpec.describe Karya::Worker, :integration do
-  let(:queue_store) { Karya::QueueStore::InMemory.new(token_generator: -> { 'lease-token' }) }
+  let(:queue_store) { Karya::QueueStore::InMemory.new(token_generator: -> { 'lease-token' }, policy_set:) }
   let(:worker_id) { 'worker-1' }
   let(:queue_name) { 'billing' }
   let(:base_time) { Time.utc(2026, 4, 7, 12, 0, 0) }
   let(:current_time) { [base_time, base_time + 1, base_time + 2, base_time + 3].each }
+  let(:policy_set) { Karya::Backpressure::PolicySet.new }
 
-  def enqueue_submission_job(id:, handler: 'billing_sync')
+  def enqueue_submission_job(id:, handler: 'billing_sync', priority: 0, concurrency_key: nil, rate_limit_key: nil)
     queue_store.enqueue(
       job: Karya::Job.new(
         id:,
         queue: queue_name,
         handler:,
         arguments: { 'account_id' => 42 },
+        priority:,
+        concurrency_key:,
+        rate_limit_key:,
         state: :submission,
         created_at: base_time
       ),
@@ -75,5 +79,56 @@ RSpec.describe Karya::Worker, :integration do
     expect(result.state).to eq(:failed)
     expect(result.attempt).to eq(1)
     expect(stored_job('job-failure').state).to eq(:failed)
+  end
+
+  it 'executes an eligible lower-priority job when a higher-priority job is concurrency-blocked' do
+    constrained_store = Karya::QueueStore::InMemory.new(
+      token_generator: -> { 'lease-token' },
+      policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
+    )
+    constrained_store.enqueue(
+      job: Karya::Job.new(
+        id: 'job-blocked',
+        queue: queue_name,
+        handler: 'billing_sync',
+        arguments: { 'account_id' => 42 },
+        priority: 10,
+        concurrency_key: 'account_sync',
+        state: :submission,
+        created_at: base_time
+      ),
+      now: base_time
+    )
+    constrained_store.enqueue(
+      job: Karya::Job.new(
+        id: 'job-eligible',
+        queue: queue_name,
+        handler: 'billing_sync',
+        arguments: { 'account_id' => 42 },
+        priority: 1,
+        state: :submission,
+        created_at: base_time + 1
+      ),
+      now: base_time + 1
+    )
+
+    first_reservation = constrained_store.reserve(queue: queue_name, worker_id: worker_id, lease_duration: 30, now: base_time + 2)
+    worker_clock = [base_time + 3, base_time + 4, base_time + 5, base_time + 6].each
+    worker = described_class.new(
+      queue_store: constrained_store,
+      worker_id: 'worker-2',
+      queues: [queue_name],
+      handlers: { 'billing_sync' => ->(account_id:) { expect(account_id).to eq(42) } },
+      lease_duration: 30,
+      clock: -> { worker_clock.next }
+    )
+
+    result = worker.work_once
+    state = constrained_store.instance_variable_get(:@state)
+
+    expect(first_reservation.job_id).to eq('job-blocked')
+    expect(result.id).to eq('job-eligible')
+    expect(state.jobs_by_id.fetch('job-blocked').state).to eq(:reserved)
+    expect(state.jobs_by_id.fetch('job-eligible').state).to eq(:succeeded)
   end
 end

--- a/core/karya/spec/karya/worker_integration_spec.rb
+++ b/core/karya/spec/karya/worker_integration_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Karya::Worker, :integration do
     expect(stored_job('job-failure').state).to eq(:failed)
   end
 
-  it 'executes an eligible lower-priority job when a higher-priority job is concurrency-blocked' do
+  it 'executes an eligible lower-priority job when a queued higher-priority job is concurrency-blocked' do
     constrained_store = Karya::QueueStore::InMemory.new(
       token_generator: -> { 'lease-token' },
       policy_set: Karya::Backpressure::PolicySet.new(concurrency: { account_sync: { limit: 1 } })
@@ -101,19 +101,32 @@ RSpec.describe Karya::Worker, :integration do
     )
     constrained_store.enqueue(
       job: Karya::Job.new(
+        id: 'job-blocked-queued',
+        queue: queue_name,
+        handler: 'billing_sync',
+        arguments: { 'account_id' => 42 },
+        priority: 9,
+        concurrency_key: 'account_sync',
+        state: :submission,
+        created_at: base_time + 1
+      ),
+      now: base_time + 1
+    )
+    constrained_store.enqueue(
+      job: Karya::Job.new(
         id: 'job-eligible',
         queue: queue_name,
         handler: 'billing_sync',
         arguments: { 'account_id' => 42 },
         priority: 1,
         state: :submission,
-        created_at: base_time + 1
+        created_at: base_time + 2
       ),
-      now: base_time + 1
+      now: base_time + 2
     )
 
-    first_reservation = constrained_store.reserve(queue: queue_name, worker_id: worker_id, lease_duration: 30, now: base_time + 2)
-    worker_clock = [base_time + 3, base_time + 4, base_time + 5, base_time + 6].each
+    first_reservation = constrained_store.reserve(queue: queue_name, worker_id: worker_id, lease_duration: 30, now: base_time + 3)
+    worker_clock = [base_time + 4, base_time + 5, base_time + 6, base_time + 7].each
     worker = described_class.new(
       queue_store: constrained_store,
       worker_id: 'worker-2',
@@ -129,6 +142,7 @@ RSpec.describe Karya::Worker, :integration do
     expect(first_reservation.job_id).to eq('job-blocked')
     expect(result.id).to eq('job-eligible')
     expect(state.jobs_by_id.fetch('job-blocked').state).to eq(:reserved)
+    expect(state.jobs_by_id.fetch('job-blocked-queued').state).to eq(:queued)
     expect(state.jobs_by_id.fetch('job-eligible').state).to eq(:succeeded)
   end
 end

--- a/docs/pages/reliability/backpressure.md
+++ b/docs/pages/reliability/backpressure.md
@@ -25,9 +25,9 @@ rate limits, concurrency caps, paused state, or backend-specific constraints.
 
 In `core/karya`, backpressure policy is modeled through
 `Karya::Backpressure::PolicySet`. Concurrency policies cap active `reserved` and
-`running` jobs sharing one `concurrency_key`. Rate-limit policies use fixed
-windows keyed by `rate_limit_key` and consume capacity when reservation
-succeeds.
+`running` jobs sharing one `concurrency_key`. Rate-limit policies use rolling
+(sliding) windows keyed by `rate_limit_key`, evaluating capacity over the most
+recent period and consuming capacity when reservation succeeds.
 
 ## Common Scenarios
 

--- a/docs/pages/reliability/backpressure.md
+++ b/docs/pages/reliability/backpressure.md
@@ -16,11 +16,18 @@ behavior under constrained capacity.
 - starvation prevention
 - concurrency groups and scoped rate limits
 - overload handling and automated recovery hooks
+- queue-local priority ordering inside otherwise eligible work
 
 ## Operator Expectations
 
 Operators need to understand whether delay comes from queue pressure,
 rate limits, concurrency caps, paused state, or backend-specific constraints.
+
+In `core/karya`, backpressure policy is modeled through
+`Karya::Backpressure::PolicySet`. Concurrency policies cap active `reserved` and
+`running` jobs sharing one `concurrency_key`. Rate-limit policies use fixed
+windows keyed by `rate_limit_key` and consume capacity when reservation
+succeeds.
 
 ## Common Scenarios
 

--- a/docs/pages/runtime/job-model.md
+++ b/docs/pages/runtime/job-model.md
@@ -26,6 +26,8 @@ A canonical job instance carries these behavior-level expectations:
 - lifecycle metadata that callers, workers, and operator surfaces can inspect
   consistently
 - one canonical current state for the job instance at any point in time
+- optional scheduling metadata such as `priority`, `concurrency_key`, and
+  `rate_limit_key` for runtime backpressure decisions
 
 Application code defines what the job does. Karya owns the queue placement,
 lifecycle, reservation, execution, and operator-visible state around that work.
@@ -158,6 +160,9 @@ job = Karya::Job.new(
   queue: 'billing',
   handler: 'billing_sync',
   arguments: { account_id: 42, source: 'dashboard' },
+  priority: 10,
+  concurrency_key: 'account-42',
+  rate_limit_key: 'partner-api',
   state: :queued,
   created_at: created_at
 )
@@ -169,6 +174,11 @@ reserved_job = job.transition_to(:reserved, updated_at: Time.utc(2026, 3, 26, 12
 reserved_job.state
 # => :reserved
 ```
+
+`priority` defaults to `0`. Higher numbers win within same queue, while worker
+subscription queue order still decides which queue is scanned first.
+`concurrency_key` and `rate_limit_key` are optional identifiers that let queue
+stores apply configured backpressure policies without mutating handler input.
 
 Lifecycle extensions are also explicit. Follow-on runtime work can register a
 new state and link it to the base lifecycle without redefining the canonical

--- a/docs/pages/runtime/workers.md
+++ b/docs/pages/runtime/workers.md
@@ -14,7 +14,9 @@ Routing stays explicit through `job.queue`. Worker subscription is the
 combination of an ordered queue list and a handler registry. A worker reserves
 only jobs whose queue and handler both match that subscription. Unmatched jobs
 stay queued until a compatible worker exists. Queue order is subscription
-preference, not a fairness guarantee.
+preference, not a fairness guarantee. Within one queue, higher-priority jobs may
+be selected ahead of lower-priority jobs when the queue store supports
+priorities.
 
 ## Worker Responsibilities
 
@@ -23,6 +25,8 @@ preference, not a fairness guarantee.
 - move jobs from `queued` to `reserved` and then into `running` only through
   valid lifecycle transitions
 - execute work while respecting timeouts, expirations, and cancellation
+- skip jobs blocked by active concurrency caps or rate-limit windows when an
+  eligible queued job still exists
 - participate in graceful shutdown and drain behavior
 
 ## Supervision And Lifecycle
@@ -101,6 +105,11 @@ Use multiple processes or threads only with a queue store that is safe to
 share across processes and thread-safe handlers.
 `Karya::QueueStore::InMemory` is single-process and is shown here only for local
 examples.
+
+Backpressure policies are configured on the queue store, not through `karya
+worker` flags in this milestone. Jobs may carry `priority`,
+`concurrency_key`, and `rate_limit_key`, and the queue store decides whether a
+matching policy exists for those keys.
 
 `Karya.configure_logger` and `Karya.configure_instrumenter` define process-wide
 defaults. If a process hosts multiple runtimes, inject explicit `logger:` and

--- a/docs/pages/runtime/workers.md
+++ b/docs/pages/runtime/workers.md
@@ -106,8 +106,8 @@ share across processes and thread-safe handlers.
 `Karya::QueueStore::InMemory` is single-process and is shown here only for local
 examples.
 
-Backpressure policies are configured on the queue store, not through `karya
-worker` flags in this milestone. Jobs may carry `priority`,
+Backpressure policies are configured on the queue store, not through `karya worker`
+flags in this milestone. Jobs may carry `priority`,
 `concurrency_key`, and `rate_limit_key`, and the queue store decides whether a
 matching policy exists for those keys.
 


### PR DESCRIPTION
- Introduced `Karya::Backpressure::PolicySet` to manage concurrency and rate-limiting policies.
- Added `priority`, `concurrency_key`, and `rate_limit_key` attributes to `Karya::Job` for enhanced job management.
- Implemented `Karya::QueueStore::InMemory` to prioritize jobs based on their attributes while reserving.
- Created tests to validate the behavior of job reservations under various priority and concurrency scenarios.
- Updated documentation to reflect the new backpressure features and job model enhancements.

closes: #39 