### PR TITLE
feat: enhance job retry and uniqueness handling

### DIFF
--- a/core/karya/spec/e2e/karya/cli_worker_spec.rb
+++ b/core/karya/spec/e2e/karya/cli_worker_spec.rb
@@ -118,4 +118,55 @@ RSpec.describe Karya::CLI, :e2e, :integration do
       end
     end
   end
+
+  it 'retries a failed job and succeeds on a later attempt through exe/karya worker' do
+    Dir.mktmpdir('karya-cli-retry-e2e') do |directory|
+      state_file = File.join(directory, 'runtime.json')
+      marker_file = File.join(directory, 'attempts.json')
+      boot_file = write_boot_file(
+        directory:,
+        handler_class_name: 'CliWorkerRetryHandler',
+        marker_path: marker_file,
+        prelude_source: "attempts = 0\n",
+        job_attributes_source: <<~RUBY.strip,
+          arguments: { 'account_id' => 42, 'marker_path' => #{marker_file.inspect} },
+          retry_policy: Karya::RetryPolicy.new(max_attempts: 2, base_delay: 0, multiplier: 1),
+          state: :submission,
+          created_at: now
+        RUBY
+        handler_body: <<~RUBY.strip
+          attempts = (File.exist?(marker_path) ? JSON.parse(File.read(marker_path)).fetch('attempts') : 0) + 1
+          File.write(marker_path, JSON.generate('account_id' => account_id, 'attempts' => attempts))
+          raise 'boom' if attempts == 1
+        RUBY
+      )
+
+      stdout, stderr, status = run_cli(
+        'worker',
+        'billing',
+        '--require',
+        boot_file,
+        '--handler',
+        'billing_sync=CliWorkerRetryHandler',
+        '--worker-id',
+        'worker-cli-retry-e2e',
+        '--processes',
+        '1',
+        '--threads',
+        '1',
+        '--poll-interval',
+        '0',
+        '--max-iterations',
+        '2',
+        '--state-file',
+        state_file
+      )
+
+      expect(status.exitstatus).to eq(0), -> { "stdout:\n#{stdout}\n\nstderr:\n#{stderr}" }
+      expect(JSON.parse(File.read(marker_file))).to include('account_id' => 42, 'attempts' => 2)
+
+      runtime_state = read_runtime_state(state_file)
+      expect(runtime_state.fetch('snapshot').fetch('phase')).to eq('stopped')
+    end
+  end
 end

--- a/core/karya/spec/e2e/karya/cli_worker_spec.rb
+++ b/core/karya/spec/e2e/karya/cli_worker_spec.rb
@@ -127,9 +127,9 @@ RSpec.describe Karya::CLI, :e2e, :integration do
         directory:,
         handler_class_name: 'CliWorkerRetryHandler',
         marker_path: marker_file,
-        prelude_source: "attempts = 0\n",
+        prelude_source: "INITIAL_ACCOUNT_ID = 42\n",
         job_attributes_source: <<~RUBY.strip,
-          arguments: { 'account_id' => 42, 'marker_path' => #{marker_file.inspect} },
+          arguments: { 'account_id' => INITIAL_ACCOUNT_ID, 'marker_path' => #{marker_file.inspect} },
           retry_policy: Karya::RetryPolicy.new(max_attempts: 2, base_delay: 0, multiplier: 1),
           state: :submission,
           created_at: now

--- a/core/karya/spec/e2e/spec_helper.rb
+++ b/core/karya/spec/e2e/spec_helper.rb
@@ -19,9 +19,23 @@ module KaryaE2EHelpers
     ['bundle', 'exec', RbConfig.ruby, '-Ilib', 'exe/karya', *args]
   end
 
-  def write_boot_file(directory:, handler_class_name:, handler_body:, marker_path: nil, queue: 'billing', job_id: 'job-1')
+  def write_boot_file(
+    directory:,
+    handler_class_name:,
+    handler_body:,
+    marker_path: nil,
+    queue: 'billing',
+    job_id: 'job-1',
+    job_attributes_source: nil,
+    prelude_source: nil
+  )
     handler_file = File.join(directory, 'worker_boot.rb')
     marker_literal = marker_path&.inspect || 'nil'
+    job_attributes = job_attributes_source || <<~RUBY.strip
+      arguments: { 'account_id' => 42, 'marker_path' => #{marker_literal} },
+      state: :submission,
+      created_at: now
+    RUBY
     File.write(
       handler_file,
       <<~RUBY
@@ -30,14 +44,13 @@ module KaryaE2EHelpers
         now = Time.utc(2026, 4, 7, 12, 0, 0)
         queue_store = Karya::QueueStore::InMemory.new(token_generator: -> { 'lease-token' })
         Karya.configure_queue_store(queue_store)
+        #{prelude_source}
         queue_store.enqueue(
           job: Karya::Job.new(
             id: #{job_id.inspect},
             queue: #{queue.inspect},
             handler: 'billing_sync',
-            arguments: { 'account_id' => 42, 'marker_path' => #{marker_literal} },
-            state: :submission,
-            created_at: now
+            #{job_attributes}
           ),
           now: now
         )

--- a/core/karya/spec/karya/queue_store/in_memory_recovery_integration_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_recovery_integration_spec.rb
@@ -54,4 +54,62 @@ RSpec.describe Karya::QueueStore::InMemory, :integration do
     expect(stored_job('job-execution').state).to eq(:reserved)
     expect(stored_job('job-execution').attempt).to eq(1)
   end
+
+  it 'keeps recovered until-terminal uniqueness blocked until the recovered job completes' do
+    store.enqueue(
+      job: Karya::Job.new(
+        id: 'job-1',
+        queue: 'billing',
+        handler: 'billing_sync',
+        arguments: { 'account_id' => 42 },
+        uniqueness_key: 'billing:account-42',
+        uniqueness_scope: :until_terminal,
+        state: :submission,
+        created_at: base_time
+      ),
+      now: base_time
+    )
+    reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 1, now: base_time + 1)
+    store.start_execution(reservation_token: reservation.token, now: base_time + 1.5)
+
+    report = store.recover_in_flight(now: base_time + 5)
+    recovered_job = report.recovered_running_jobs.find { |job| job.id == 'job-1' }
+
+    expect(recovered_job&.state).to eq(:queued)
+    expect do
+      store.enqueue(
+        job: Karya::Job.new(
+          id: 'job-2',
+          queue: 'billing',
+          handler: 'billing_sync',
+          arguments: { 'account_id' => 42 },
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :until_terminal,
+          state: :submission,
+          created_at: base_time + 5
+        ),
+        now: base_time + 5
+      )
+    end.to raise_error(Karya::DuplicateUniquenessKeyError, /billing:account-42/)
+
+    replacement = store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 5, now: base_time + 6)
+    store.start_execution(reservation_token: replacement.token, now: base_time + 6.5)
+    store.complete_execution(reservation_token: replacement.token, now: base_time + 7)
+
+    expect do
+      store.enqueue(
+        job: Karya::Job.new(
+          id: 'job-2',
+          queue: 'billing',
+          handler: 'billing_sync',
+          arguments: { 'account_id' => 42 },
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :until_terminal,
+          state: :submission,
+          created_at: base_time + 7
+        ),
+        now: base_time + 7
+      )
+    end.not_to raise_error
+  end
 end

--- a/core/karya/spec/karya/queue_store/in_memory_recovery_integration_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_recovery_integration_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Karya::QueueStore::InMemory, :integration do
     end.to raise_error(Karya::DuplicateUniquenessKeyError, /billing:account-42/)
 
     replacement = store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 5, now: base_time + 6)
+    expect(replacement.job_id).to eq('job-1')
     store.start_execution(reservation_token: replacement.token, now: base_time + 6.5)
     store.complete_execution(reservation_token: replacement.token, now: base_time + 7)
 

--- a/core/karya/spec/karya/worker_integration_spec.rb
+++ b/core/karya/spec/karya/worker_integration_spec.rb
@@ -311,4 +311,48 @@ RSpec.describe Karya::Worker, :integration do
     expect(state.jobs_by_id.fetch('job-blocked-queued').state).to eq(:queued)
     expect(state.jobs_by_id.fetch('job-eligible').state).to eq(:succeeded)
   end
+
+  it 'reserves from later subscribed queue when earlier queue only has unsupported handlers' do
+    queue_store.enqueue(
+      job: Karya::Job.new(
+        id: 'job-unsupported',
+        queue: 'billing',
+        handler: 'billing_sync',
+        arguments: { 'account_id' => 42 },
+        state: :submission,
+        created_at: base_time
+      ),
+      now: base_time
+    )
+    queue_store.enqueue(
+      job: Karya::Job.new(
+        id: 'job-supported',
+        queue: 'email',
+        handler: 'email_sync',
+        arguments: { 'account_id' => 42 },
+        state: :submission,
+        created_at: base_time + 1
+      ),
+      now: base_time + 1
+    )
+
+    worker = described_class.new(
+      queue_store:,
+      worker_id:,
+      queues: %w[billing email],
+      handlers: {
+        'email_sync' => lambda do |account_id:|
+          expect(account_id).to eq(42)
+        end
+      },
+      lease_duration: 30,
+      clock: -> { current_time.next }
+    )
+
+    result = worker.work_once
+
+    expect(result.id).to eq('job-supported')
+    expect(stored_job('job-supported').state).to eq(:succeeded)
+    expect(stored_job('job-unsupported').state).to eq(:queued)
+  end
 end


### PR DESCRIPTION
- Added a test for retrying a failed job through the CLI worker, ensuring it succeeds on subsequent attempts.
- Updated the `write_boot_file` method to accept job attributes and prelude source for better flexibility in job handling.
- Introduced a test to verify that recovered jobs maintain uniqueness constraints until completion.
- Implemented a test to check that jobs from later subscribed queues are reserved when earlier queues have unsupported handlers.

closes: #65

