### PR TITLE
docs: update reliability and recovery documentation

### DIFF
--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -172,7 +172,10 @@ For any code examples in README/docs:
 - For `docs/`, do not treat lack of current implementation as a failure by
   itself. Only flag examples that are contradictory, internally impossible, or
   inconsistent with the intended future-state product story.
-- **Required:** Flag any example that would fail if run as shown
+- **Required:** Flag any example that would fail if run as shown, except in
+  `docs/` where you should only flag examples that are contradictory,
+  internally impossible, or inconsistent with the intended future-state
+  product story.
 
 ### API Surface Consistency
 

--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -14,13 +14,31 @@ high-signal semantic review over generic style feedback.
 
 ## Future-State Docs
 
-- Treat `README.md` files and everything under `docs/` as future-state product
-  documentation.
+- Treat everything under `docs/` as future-state product documentation with no
+  exceptions.
+- Treat `README.md` files as supporting documentation that may summarize current
+  package or repository posture unless a README clearly establishes its own
+  future-state stance.
+- For `docs/`, future-state product consistency takes precedence over
+  implementation-parity review heuristics.
 - Do not flag a PR just because the documentation describes product capability
   that is not yet fully present in code.
+- Do not ask for `docs/` to be rewritten to match current runtime fields, CLI
+  commands, or API payloads solely because those details are not implemented
+  yet.
+- For `docs/`, only flag:
+  - contradictions inside the future-state story
+  - stale names or broken links
+  - impossible workflows even in the intended future product
+  - support-boundary confusion where the docs disagree about what is first
+    class, optional, governed, or extension-layer behavior
+  - wording that conflicts with explicit repository structure or package
+    ownership
 - Do flag contradictions, stale names, broken links, impossible workflows, or
   claims that conflict with explicit repository structure and documented support
   boundaries.
+- If a review comment depends on “this is not implemented today” and nothing
+  more, that comment is out of bounds for `docs/`.
 
 ## Repo-Specific Review Supplement
 
@@ -151,6 +169,9 @@ For any code examples in README/docs:
   - Do code snippets match actual APIs?
   - Do docs and README files still match the current package ownership and
     naming?
+- For `docs/`, do not treat lack of current implementation as a failure by
+  itself. Only flag examples that are contradictory, internally impossible, or
+  inconsistent with the intended future-state product story.
 - **Required:** Flag any example that would fail if run as shown
 
 ### API Surface Consistency
@@ -344,6 +365,9 @@ These checks enforce architecture guidelines. Apply them to every code change.
   guidance, not correctness guidance.
 - Verify the docs site still builds successfully after changes when doc changes
   are material.
+- For `docs/`, prefer comments about future-state consistency, terminology,
+  navigation, and support-boundary clarity. Do not demand implementation-reality
+  caveats unless the docs contradict themselves or an explicit support boundary.
 
 ## Good Review Targets
 
@@ -354,7 +378,8 @@ These checks enforce architecture guidelines. Apply them to every code change.
 - cross-package contract drift
 - adapter assumptions not supported by the core
 - stale or contradictory docs
-- examples that do not match actual supported APIs
+- examples in `docs/` that contradict the intended future-state product story
+- examples outside `docs/` that do not match actual supported APIs
 - ambiguous error messages that hinder debugging
 - duplicate or redundant logic that reduces clarity
 - incomplete test coverage for validation paths
@@ -383,8 +408,10 @@ These checks enforce architecture guidelines. Apply them to every code change.
 
 - formatting issues already covered by automated linting in CI
 - speculative product objections when the change is internally consistent
-- complaints that future-state docs are not yet fully implemented unless they
-  contradict explicit support boundaries
+- complaints that future-state docs are not yet fully implemented
+- requests to replace future-state `docs/` examples with current-state runtime
+  fields, commands, or payloads unless the current docs become self-contradictory
+  or violate explicit support boundaries
 - suggesting Service/Command pattern where a constructor + method is already
   clear and explicit
 - requesting namespace renames purely for convention when existing names are

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -122,7 +122,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    needs: [rubocop,reek]
+    needs: [rubocop, reek]
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +178,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    needs: [rubocop,reek]
+    needs: [rubocop, reek]
     strategy:
       fail-fast: false
       matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@ Use this file as the repo-root coding baseline.
 - Trace concrete state changes for time, retries, leases, shutdown, and shared
   state. Watch for TOCTOU gaps.
 - Do not symbolize, intern, or cache unbounded input.
+- `docs/` is future-state product documentation with no exceptions. Review and
+  edit it as completed product documentation, not as a mirror of what is
+  implemented today. For `docs/`, fix contradictions, stale names, broken
+  links, impossible workflows, and inconsistent support boundaries, but do not
+  downgrade product behavior merely because code is not there yet.
 - RBS must be 100% true to Ruby behavior. Mirror ownership, visibility,
   optionality, arguments, and return types. Remove stale signatures when code
   moves or disappears.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Karya brings the operational surfaces that Ruby teams usually assemble from
 multiple tools into one platform:
 
 - durable job execution with explicit routing, retries, backpressure, recovery,
-  and dead-letter handling
+  dead-letter isolation, and governed recovery
 - workflow orchestration with replay, compensation, child workflows, signals,
   queries, approval checkpoints, and versioning
 - framework-native integration for plain Ruby, Rails, Sinatra, Roda, and Hanami

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ the packaged dashboard frontend, and the documentation site.
 Karya brings the operational surfaces that Ruby teams usually assemble from
 multiple tools into one platform:
 
-- durable job execution with explicit routing, retries, backpressure, recovery,
-  dead-letter isolation, and governed recovery
+- durable job execution with explicit routing, retries, backpressure, routine
+  recovery, dead-letter isolation, and governed recovery
 - workflow orchestration with replay, compensation, child workflows, signals,
   queries, approval checkpoints, and versioning
 - framework-native integration for plain Ruby, Rails, Sinatra, Roda, and Hanami

--- a/core/karya/README.md
+++ b/core/karya/README.md
@@ -19,7 +19,8 @@ The core package owns the platform-wide behavior for:
 
 - job and queue lifecycle
 - worker bootstrap, graceful drain, and runtime supervision
-- routing, retries, deadlines, uniqueness, dead-letter handling, and recovery
+- routing, retries, deadlines, uniqueness, dead-letter isolation, and governed
+  recovery
 - workflow composition, replay, compensation, checkpoints, and evolution
 - operator-facing control and inspection boundaries
 - shared plugin, configuration, and backend selection contracts

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,8 +63,8 @@ workflows, framework hosts, operator tooling, and governed production rollout.
   and initial platform evaluation
 - [Runtime](/runtime/): job model, workers, control surfaces, and
   execution semantics
-- [Reliability](/reliability/): retries, uniqueness, dead letters,
-  and backpressure
+- [Reliability](/reliability/): retries, uniqueness, dead-letter isolation,
+  governed recovery, and backpressure
 - [Workflows](/workflows/): orchestration, replay, signals, child
   workflows, and versioning
 - [Backends](/backends/): selection guidance, tiers, and capability

--- a/docs/pages/adoption/sidekiq.md
+++ b/docs/pages/adoption/sidekiq.md
@@ -13,7 +13,8 @@ workflows into the Karya model.
 ## Guidance
 
 - map queues and workers to the Karya runtime model
-- map retries, uniqueness, and dead-letter handling to the reliability model
+- map retries, uniqueness, dead-letter isolation, and governed recovery to the
+  reliability model
 - treat dashboard adoption as an operator workflow change, not only a backend
   swap
 
@@ -28,7 +29,7 @@ current_system: sidekiq
 current_queue: billing
 target_runtime: karya
 target_queue: billing
-migration_focus: retries, uniqueness, operator workflows
+migration_focus: retries, isolation, uniqueness, operator workflows
 ```
 
 The goal is to preserve familiar operational concepts while moving into the

--- a/docs/pages/reliability/backpressure.md
+++ b/docs/pages/reliability/backpressure.md
@@ -12,22 +12,27 @@ behavior under constrained capacity.
 
 ## Covered Behavior
 
-- fairness between queues and workers
+- routing-aware fairness between queues and workers
 - starvation prevention
 - concurrency groups and scoped rate limits
-- overload handling and automated recovery hooks
+- overload handling and recovery boundaries
 - queue-local priority ordering inside otherwise eligible work
 
 ## Operator Expectations
 
 Operators need to understand whether delay comes from queue pressure,
-rate limits, concurrency caps, paused state, or backend-specific constraints.
+rate limits, concurrency caps, routing mismatches, or backend-specific
+constraints.
 
-In `core/karya`, backpressure policy is modeled through
-`Karya::Backpressure::PolicySet`. Concurrency policies cap active `reserved` and
-`running` jobs sharing one `concurrency_key`. Rate-limit policies use rolling
-(sliding) windows keyed by `rate_limit_key`, evaluating capacity over the most
-recent period and consuming capacity when reservation succeeds.
+Backpressure is not only about raw queue depth. It also depends on whether
+workers are subscribed to the right queues, whether handlers match the routed
+work, and whether the selected work is allowed through the current policy
+window.
+
+Concurrency policies cap active work sharing one `concurrency_key`.
+Rate-limit policies constrain reservation over a scoped rolling window keyed by
+`rate_limit_key`. Priority influences selection among otherwise eligible work
+inside a queue, but it does not replace explicit routing or eliminate pressure.
 
 ## Common Scenarios
 
@@ -39,18 +44,21 @@ Backpressure should read as an operational state, not an unexplained slowdown:
 queue: billing
 status: throttled
 reason: concurrency-group-limit
+subscription: billing + billing_sync
 running_jobs: 25
 waiting_jobs: 140
 ```
 
 What matters is that delayed work is explainable. Operators need to
-tell whether pressure comes from limits, congestion, or a paused execution
-path.
+tell whether pressure comes from limits, congestion, or routing and
+subscription shape.
 
 ## Related Concepts
 
 - [Workers](/runtime/workers/): worker throughput and drain behavior affect
   pressure directly
+- [Retries](/reliability/retries/): pressure and failure handling meet at the
+  retry boundary
 - [Search And Drilldowns](/operator/search-drilldowns/): operators need to
   drill into the queues under pressure
 - [Backends](/backends/): backend characteristics shape how pressure is felt

--- a/docs/pages/reliability/backpressure.md
+++ b/docs/pages/reliability/backpressure.md
@@ -44,7 +44,8 @@ Backpressure should read as an operational state, not an unexplained slowdown:
 queue: billing
 status: throttled
 reason: concurrency-group-limit
-subscription: billing + billing_sync
+queues: [billing]
+handlers: [billing_sync]
 running_jobs: 25
 waiting_jobs: 140
 ```

--- a/docs/pages/reliability/dead-letters.md
+++ b/docs/pages/reliability/dead-letters.md
@@ -12,7 +12,7 @@ runtime lifecycle with explicit isolation and governed recovery flows.
 
 ## Covered Behavior
 
-- dead-letter isolation after bounded retry or policy-based escalation in an
+- dead-letter isolation after bounded retry or policy-based isolation in an
   extension layer
 - operator-visible reasons why work left the normal retry path
 - governed replay, discard, and controlled retry paths

--- a/docs/pages/reliability/dead-letters.md
+++ b/docs/pages/reliability/dead-letters.md
@@ -7,20 +7,24 @@ permalink: /reliability/dead-letters/
 
 # Dead Letters
 
-Karya isolates unrecoverable or unsafe work through explicit dead-letter and
-poison-job handling flows.
+Karya isolates unrecoverable or unsafe work through explicit dead-letter
+handling and governed recovery flows.
 
 ## Covered Behavior
 
-- dead-letter state transitions
-- poison-job isolation
-- replay, discard, and controlled retry paths
+- dead-letter isolation after bounded retry or policy-based escalation
+- operator-visible reasons why work left the normal retry path
+- governed replay, discard, and controlled retry paths
 - operator investigation and audit-oriented recovery workflows
 
 ## Operator Expectations
 
 Dead-letter handling should prevent endless retry loops while still preserving
 clear recovery options and historical context.
+
+Dead-letter handling begins after work leaves the ordinary retry path. The
+canonical lifecycle covers `queued`, `reserved`, `running`, `failed`, and
+`retry_pending`; dead-letter handling covers the isolated path that follows.
 
 ## Common Scenarios
 
@@ -31,15 +35,22 @@ Dead-letter state should make recovery intent obvious:
 ```text
 job: email-991
 status: dead-letter
-reason: poison-job-detected
+reason: retry-policy-exhausted
+last_state: retry_pending
+recovery_boundary: governed
 available_actions: replay, discard, inspect
 ```
 
-Unrecoverable work is isolated, and the recovery options stay explicit.
+Unrecoverable work is isolated, and the recovery options stay explicit. Retry
+is no longer the default behavior. Investigation and governed action take over
+from routine runtime recovery.
 
 ## Related Concepts
 
-- [Retries](/reliability/retries/): dead-letter state starts where bounded retries end
+- [Retries](/reliability/retries/): dead-letter isolation starts where bounded
+  retry ends
+- [Job Model](/runtime/job-model/): dead-letter handling follows the canonical
+  lifecycle without replacing it
 - [Activity And Audit](/operator/activity-audit/): recovery actions need
   clear history
 - [Troubleshooting](/troubleshooting/): use dead-letter state during

--- a/docs/pages/reliability/dead-letters.md
+++ b/docs/pages/reliability/dead-letters.md
@@ -7,12 +7,13 @@ permalink: /reliability/dead-letters/
 
 # Dead Letters
 
-Karya isolates unrecoverable or unsafe work through explicit dead-letter
-handling and governed recovery flows.
+Karya reserves dead-letter handling for reliability layers that extend the base
+runtime lifecycle with explicit isolation and governed recovery flows.
 
 ## Covered Behavior
 
-- dead-letter isolation after bounded retry or policy-based escalation
+- dead-letter isolation after bounded retry or policy-based escalation in an
+  extension layer
 - operator-visible reasons why work left the normal retry path
 - governed replay, discard, and controlled retry paths
 - operator investigation and audit-oriented recovery workflows
@@ -25,6 +26,9 @@ clear recovery options and historical context.
 Dead-letter handling begins after work leaves the ordinary retry path. The
 canonical lifecycle covers `queued`, `reserved`, `running`, `failed`, and
 `retry_pending`; dead-letter handling covers the isolated path that follows.
+The base runtime provides the extension boundary. Adapters, queue stores, or
+higher-level operator workflows provide the dead-letter policy and recovery
+actions built on top of it.
 
 ## Common Scenarios
 
@@ -33,8 +37,11 @@ canonical lifecycle covers `queued`, `reserved`, `running`, `failed`, and
 Dead-letter state should make recovery intent obvious:
 
 ```text
+# persisted job attributes
 job: email-991
-status: dead-letter
+status: dead_letter
+
+# operator/UI metadata
 reason: retry-policy-exhausted
 last_state: retry_pending
 recovery_boundary: governed

--- a/docs/pages/reliability/dead-letters.md
+++ b/docs/pages/reliability/dead-letters.md
@@ -39,7 +39,7 @@ Dead-letter state should make recovery intent obvious:
 ```text
 # persisted job attributes
 job: email-991
-status: dead_letter
+state: dead_letter
 
 # operator/UI metadata
 reason: retry-policy-exhausted

--- a/docs/pages/reliability/dead-letters.md
+++ b/docs/pages/reliability/dead-letters.md
@@ -7,13 +7,12 @@ permalink: /reliability/dead-letters/
 
 # Dead Letters
 
-Karya reserves dead-letter handling for reliability layers that extend the base
-runtime lifecycle with explicit isolation and governed recovery flows.
+Karya isolates unrecoverable or unsafe work through explicit dead-letter
+handling and governed recovery flows.
 
 ## Covered Behavior
 
-- dead-letter isolation after bounded retry or policy-based isolation in an
-  extension layer
+- dead-letter isolation after bounded retry or policy-based isolation
 - operator-visible reasons why work left the normal retry path
 - governed replay, discard, and controlled retry paths
 - operator investigation and audit-oriented recovery workflows
@@ -26,9 +25,7 @@ clear recovery options and historical context.
 Dead-letter handling begins after work leaves the ordinary retry path. The
 non-terminal execution and retry states include `queued`, `reserved`,
 `running`, `failed`, and `retry_pending`; dead-letter handling covers the
-isolated path that follows. The base runtime provides the extension boundary.
-Adapters, queue stores, or higher-level operator workflows provide the
-dead-letter policy and recovery actions built on top of it.
+isolated path that follows.
 
 ## Common Scenarios
 
@@ -37,11 +34,9 @@ dead-letter policy and recovery actions built on top of it.
 Dead-letter state should make recovery intent obvious:
 
 ```text
-# persisted job attributes
 job: email-991
-state: dead_letter
+status: dead-letter
 
-# operator/UI metadata
 reason: retry-policy-exhausted
 last_state: retry_pending
 recovery_boundary: governed

--- a/docs/pages/reliability/dead-letters.md
+++ b/docs/pages/reliability/dead-letters.md
@@ -35,7 +35,7 @@ Dead-letter state should make recovery intent obvious:
 
 ```text
 job: email-991
-status: dead-letter
+state: dead_letter
 
 reason: retry-policy-exhausted
 last_state: retry_pending

--- a/docs/pages/reliability/dead-letters.md
+++ b/docs/pages/reliability/dead-letters.md
@@ -24,11 +24,11 @@ Dead-letter handling should prevent endless retry loops while still preserving
 clear recovery options and historical context.
 
 Dead-letter handling begins after work leaves the ordinary retry path. The
-canonical lifecycle covers `queued`, `reserved`, `running`, `failed`, and
-`retry_pending`; dead-letter handling covers the isolated path that follows.
-The base runtime provides the extension boundary. Adapters, queue stores, or
-higher-level operator workflows provide the dead-letter policy and recovery
-actions built on top of it.
+non-terminal execution and retry states include `queued`, `reserved`,
+`running`, `failed`, and `retry_pending`; dead-letter handling covers the
+isolated path that follows. The base runtime provides the extension boundary.
+Adapters, queue stores, or higher-level operator workflows provide the
+dead-letter policy and recovery actions built on top of it.
 
 ## Common Scenarios
 

--- a/docs/pages/reliability/index.md
+++ b/docs/pages/reliability/index.md
@@ -29,10 +29,21 @@ The reliability section documents:
 
 - retry and backoff behavior
 - idempotency and uniqueness expectations
-- poison-job and dead-letter recovery flows
+- dead-letter isolation and governed recovery boundaries
 - fairness, starvation prevention, rate limiting, and backpressure
+- how routing decisions and worker subscriptions shape reliability outcomes
 
 ## About The Examples
 
 The examples in this section focus on visible behavior: what operators see,
 what developers can rely on, and how failure states become understandable.
+
+Across this section:
+
+- queues define where work is routed
+- workers subscribe intentionally through queue and handler matching
+- retries keep the same job instance moving through `failed` and
+  `retry_pending`
+- dead-letter handling begins after bounded retry or policy-based isolation
+- recovery actions stay explicit instead of hiding behind implicit queue
+  behavior

--- a/docs/pages/reliability/retries.md
+++ b/docs/pages/reliability/retries.md
@@ -7,39 +7,35 @@ permalink: /reliability/retries/
 
 # Retries
 
-Retries are part of Karya’s runtime behavior, not an afterthought bolted onto
-individual jobs.
+Retries are part of Karya’s product reliability model, not an afterthought
+bolted onto individual jobs.
 
 ## Covered Behavior
 
 - retry and backoff policies
-- operator-visible retry state and recovery boundaries
+- operator-visible retry state
+- the boundary between retry, isolation, and governed recovery
 
-## Implemented In Core Runtime
+## Retry Behavior
 
 - deterministic exponential backoff with optional max-delay cap
 - worker-default retry policy with optional per-job override
 - `retry_pending` as explicit waiting state between failed attempt and requeue
-- lazy due-retry promotion during queue-store maintenance and reservation
-- base failure classification persisted as `:error`, `:timeout`, or `:expired`
-
-## Deferred Follow-on Work
-
-- jitter strategies and retry spread control
-- escalation rules and dead-letter integration
-- richer operator recovery semantics beyond the base classifications
-- named reusable retry policies
+- operator-visible failure classification and retry timing
+- explicit escalation from bounded retry into dead-letter isolation or other
+  governed recovery paths when policy says work is no longer safe to continue
 
 ## Operator Expectations
 
 Operators need to distinguish:
 
-- `:error` failures, which remain retry-eligible when policy allows
-- `:timeout` failures, which also remain retry-eligible when policy allows
-- `:expired` failures, which are terminal in the current core runtime
+- failures that remain retry-eligible when policy allows
+- failures that should wait in `retry_pending` until the next retry window
+- failures that should stop normal retry and move into dead-letter isolation
+  or other governed recovery flows
 - failed attempts that transition into `retry_pending`
-- escalated failure states
-- conditions that should move work into dead-letter or governed recovery flows
+- escalation decisions that are driven by explicit policy rather than implicit
+  worker behavior
 
 ## Common Scenarios
 
@@ -53,22 +49,24 @@ attempt: 3
 status: retry_pending
 next_retry_at: 2026-03-26T14:05:00Z
 reason: upstream timeout
+recovery_boundary: bounded-retry
 ```
 
 Retry state needs to be visible, explainable, and bounded.
 
-In the current core runtime, `next_retry_at` is the scheduling boundary that
-controls when a `retry_pending` job can return to `queued`. Due retries are
-promoted lazily when the queue store performs maintenance work such as
-reservation scans. When a job reaches `expires_at` before that promotion point,
-it is failed as `:expired` instead of returning to `queued`.
+- `failed` records the current attempt outcome
+- `retry_pending` means the same job instance is still under retry policy
+- `next_retry_at` marks the next planned re-entry into queued execution
+- dead-letter isolation starts only after bounded retry stops being the right
+  path for that job
 
 ## Related Concepts
 
-- [Dead Letters](/reliability/dead-letters/): follow the path when retries stop being safe
-- [Controls](/runtime/controls/): replay, retry, and intervention share one
-  control model
-- [Workflow Replay](/workflows/replay/): replay builds on the same recovery
-  expectations
+- [Dead Letters](/reliability/dead-letters/): follow the path when bounded
+  retry is no longer safe
+- [Controls](/runtime/controls/): retry, isolation, and intervention follow
+  the same operator workflows
+- [Workflow Replay](/workflows/replay/): replay sits in governed recovery,
+  not ordinary retry
 - [Troubleshooting](/troubleshooting/): use retry state during incident
   triage

--- a/docs/pages/reliability/retries.md
+++ b/docs/pages/reliability/retries.md
@@ -22,8 +22,8 @@ bolted onto individual jobs.
 - worker-default retry policy with optional per-job override
 - `retry_pending` as explicit waiting state between failed attempt and requeue
 - operator-visible failure classification and retry timing
-- a handoff point where extensions or higher-level operator workflows may
-  isolate work after bounded retry stops being the right path
+- explicit escalation from bounded retry into dead-letter isolation or other
+  governed recovery paths when policy says work is no longer safe to continue
 
 ## Operator Expectations
 
@@ -31,11 +31,11 @@ Operators need to distinguish:
 
 - failures that remain retry-eligible when policy allows
 - failures that should wait in `retry_pending` until the next retry window
-- failures that stop normal retry and remain `failed` until another lifecycle
-  extension or higher-level recovery workflow takes over
+- failures that should stop normal retry and move into dead-letter isolation
+  or other governed recovery flows
 - failed attempts that transition into `retry_pending`
-- the difference between core retry behavior and later isolation or recovery
-  layers
+- escalation decisions that are driven by explicit policy rather than implicit
+  worker behavior
 
 ## Common Scenarios
 
@@ -44,23 +44,21 @@ Operators need to distinguish:
 Retry behavior should be understandable from an operator point of view:
 
 ```text
-# persisted job attributes
 job: billing-123
 attempt: 3
-state: retry_pending
+status: retry_pending
 next_retry_at: 2026-03-26T14:05:00Z
-failure_classification: timeout
+reason: upstream timeout
+recovery_boundary: bounded-retry
 ```
 
 Retry state needs to be visible, explainable, and bounded.
 
 - `failed` records the current attempt outcome
 - `retry_pending` means the same job instance is still under retry policy
-- `next_retry_at` marks when the job becomes eligible to be promoted back to
-  `queued` during queue-store maintenance or reservation scans
-- when retries are exhausted, the core runtime returns the job to `failed`
-- dead-letter isolation requires additional lifecycle or queue-store behavior
-  beyond the base retry model
+- `next_retry_at` marks the next planned re-entry into queued execution
+- dead-letter isolation starts only after bounded retry stops being the right
+  path for that job
 
 ## Related Concepts
 
@@ -68,7 +66,7 @@ Retry state needs to be visible, explainable, and bounded.
   retry is no longer safe
 - [Controls](/runtime/controls/): retry, isolation, and intervention follow
   the same operator workflows
-- [Workflow Replay](/workflows/replay/): replay sits in governed recovery,
+- [Workflow Replay](/workflows/replay/): replay belongs to governed recovery,
   not ordinary retry
 - [Troubleshooting](/troubleshooting/): use retry state during incident
   triage

--- a/docs/pages/reliability/retries.md
+++ b/docs/pages/reliability/retries.md
@@ -47,7 +47,7 @@ Retry behavior should be understandable from an operator point of view:
 # persisted job attributes
 job: billing-123
 attempt: 3
-status: retry_pending
+state: retry_pending
 next_retry_at: 2026-03-26T14:05:00Z
 failure_classification: timeout
 ```
@@ -56,7 +56,8 @@ Retry state needs to be visible, explainable, and bounded.
 
 - `failed` records the current attempt outcome
 - `retry_pending` means the same job instance is still under retry policy
-- `next_retry_at` marks the next planned re-entry into queued execution
+- `next_retry_at` marks when the job becomes eligible to be promoted back to
+  `queued` during queue-store maintenance or reservation scans
 - when retries are exhausted, the core runtime returns the job to `failed`
 - dead-letter isolation requires additional lifecycle or queue-store behavior
   beyond the base retry model

--- a/docs/pages/reliability/retries.md
+++ b/docs/pages/reliability/retries.md
@@ -22,8 +22,8 @@ bolted onto individual jobs.
 - worker-default retry policy with optional per-job override
 - `retry_pending` as explicit waiting state between failed attempt and requeue
 - operator-visible failure classification and retry timing
-- explicit escalation from bounded retry into dead-letter isolation or other
-  governed recovery paths when policy says work is no longer safe to continue
+- a handoff point where extensions or higher-level operator workflows may
+  isolate work after bounded retry stops being the right path
 
 ## Operator Expectations
 
@@ -31,11 +31,11 @@ Operators need to distinguish:
 
 - failures that remain retry-eligible when policy allows
 - failures that should wait in `retry_pending` until the next retry window
-- failures that should stop normal retry and move into dead-letter isolation
-  or other governed recovery flows
+- failures that stop normal retry and remain `failed` until another lifecycle
+  extension or higher-level recovery workflow takes over
 - failed attempts that transition into `retry_pending`
-- escalation decisions that are driven by explicit policy rather than implicit
-  worker behavior
+- the difference between core retry behavior and later isolation or recovery
+  layers
 
 ## Common Scenarios
 
@@ -44,12 +44,12 @@ Operators need to distinguish:
 Retry behavior should be understandable from an operator point of view:
 
 ```text
+# persisted job attributes
 job: billing-123
 attempt: 3
 status: retry_pending
 next_retry_at: 2026-03-26T14:05:00Z
-reason: upstream timeout
-recovery_boundary: bounded-retry
+failure_classification: timeout
 ```
 
 Retry state needs to be visible, explainable, and bounded.
@@ -57,8 +57,9 @@ Retry state needs to be visible, explainable, and bounded.
 - `failed` records the current attempt outcome
 - `retry_pending` means the same job instance is still under retry policy
 - `next_retry_at` marks the next planned re-entry into queued execution
-- dead-letter isolation starts only after bounded retry stops being the right
-  path for that job
+- when retries are exhausted, the core runtime returns the job to `failed`
+- dead-letter isolation requires additional lifecycle or queue-store behavior
+  beyond the base retry model
 
 ## Related Concepts
 

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -18,8 +18,8 @@ CLI surfaces.
 - retry, isolation, replay, and governed recovery actions across aligned
   operator surfaces
 - operator-visible state used for safe intervention across `queued`,
-  `reserved`, `running`, `failed`, `retry_pending`, `dead_letter`, and
-  `cancelled` job states
+  `reserved`, `running`, `failed`, `retry_pending`, `cancelled`, and extension
+  states such as `dead_letter` when they are registered
 
 ## Surface Model
 
@@ -40,7 +40,7 @@ job model rather than redefining job state per interface.
 
 ### Taking A Runtime Action
 
-Runtime controls should read consistently across UI, API, and CLI surfaces:
+Illustrative vocabulary across UI, API, and CLI surfaces:
 
 ```text
 dashboard action: retry failed job <job-id>

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -18,7 +18,7 @@ CLI surfaces.
 - retry, isolation, replay, and governed recovery actions across aligned
   operator surfaces
 - operator-visible state used for safe intervention across `queued`,
-  `reserved`, `running`, `failed`, `retry_pending`, `dead-letter`, and
+  `reserved`, `running`, `failed`, `retry_pending`, `dead_letter`, and
   `cancelled` job states
 
 ## Surface Model
@@ -43,10 +43,10 @@ job model rather than redefining job state per interface.
 Runtime controls should read consistently across UI, API, and CLI surfaces:
 
 ```text
-retry failed job <job-id>
-inspect dead-letter job <job-id>
-replay isolated job <job-id>
-inspect worker <worker-id>
+dashboard action: retry failed job <job-id>
+dashboard action: inspect dead_letter job <job-id>
+operator API action: replay isolated job <job-id>
+CLI action: karya runtime inspect --state-file /tmp/karya-runtime-billing.json
 ```
 
 Dashboard, operator API, and CLI workflows use the same runtime vocabulary for

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -15,9 +15,11 @@ CLI surfaces.
 - runtime inspection APIs for supervisor, child-process, and worker-thread state
 - supervisor-level drain and force-stop controls for worker runtimes
 - queue and worker lifecycle control
-- bulk enqueue, retry, cancel, and pause/resume operations
+- retry, isolation, replay, and governed recovery actions across aligned
+  operator surfaces
 - operator-visible state used for safe intervention across `queued`,
-  `reserved`, `running`, `failed`, `retry_pending`, and `cancelled` job states
+  `reserved`, `running`, `failed`, `retry_pending`, `dead-letter`, and
+  `cancelled` job states
 
 ## Surface Model
 
@@ -41,15 +43,14 @@ job model rather than redefining job state per interface.
 Runtime controls should read consistently across UI, API, and CLI surfaces:
 
 ```text
-pause queue billing
-resume queue billing
 retry failed job <job-id>
+inspect dead-letter job <job-id>
+replay isolated job <job-id>
 inspect worker <worker-id>
 ```
 
-Command and API shapes may evolve, but the model stays the same: operators can
-inspect and intervene through aligned surfaces instead of learning unrelated
-control models.
+Dashboard, operator API, and CLI workflows use the same runtime vocabulary for
+inspection and intervention.
 
 ### Inspecting A Running Worker Runtime
 
@@ -65,12 +66,15 @@ The supervisor-managed worker runtime surfaces:
 
 Runtime control remains aligned around the supervisor-managed execution model:
 supervisor state, child-process state, worker-thread state, and safe
-intervention boundaries around queued, reserved, running, and recovery flows.
+intervention boundaries around queued, reserved, running, retry, isolation, and
+recovery flows.
 
 ## Related Concepts
 
 - [Workers](/runtime/workers/): runtime controls supervise active execution
 - [Retries](/reliability/retries/): recovery actions extend the same control
   model
+- [Dead Letters](/reliability/dead-letters/): isolation and governed recovery
+  use the same control vocabulary
 - [CLI](/operator/cli/): command workflows mirror the runtime control model
 - [Troubleshooting](/troubleshooting/): use control surfaces during triage

--- a/docs/pages/runtime/job-model.md
+++ b/docs/pages/runtime/job-model.md
@@ -61,8 +61,9 @@ The base lifecycle vocabulary for queued job instances is:
 | `cancelled`     | execution will not continue because the runtime or operator stopped the job                   | terminal state                     |
 
 `dead-letter` is not defined here as a base lifecycle state. It is treated as a
-later extension boundary that may be reached from failure or retry exhaustion,
-but its detailed recovery semantics are defined elsewhere.
+later extension boundary that may be reached from failure or retry exhaustion.
+The reliability docs describe that isolation and recovery layer alongside the
+canonical lifecycle that dead-letter handling extends.
 
 `retry_pending` is the base-lifecycle extension point where later dead-letter
 behavior can attach. The table above lists only concrete base-state transitions
@@ -98,7 +99,7 @@ This page does not define:
 - jitter, escalation, or dead-letter policy beyond the base timing and failure
   classification model
 - fairness, starvation prevention, or backpressure policy
-- dead-letter recovery behavior such as replay or discard rules
+- dead-letter recovery workflows such as replay or discard rules
 - bulk-operation semantics beyond acknowledging that bulk actions operate on the
   same lifecycle states
 
@@ -233,5 +234,7 @@ Karya::JobLifecycle.validate_state!(dead_letter_job.state)
 - [Controls](/runtime/controls/): inspect and intervene in runtime state
 - [Retries](/reliability/retries/): understand how failed jobs re-enter the
   runtime
+- [Dead Letters](/reliability/dead-letters/): see how isolation extends the
+  base lifecycle after bounded retry
 - [Workflow Basics](/workflows/basics/): see when a single job becomes a
   workflow

--- a/docs/pages/runtime/job-model.md
+++ b/docs/pages/runtime/job-model.md
@@ -60,7 +60,7 @@ The base lifecycle vocabulary for queued job instances is:
 | `retry_pending` | the job remains in the lifecycle and is waiting to re-enter queue execution under retry rules | `queued`, `cancelled`              |
 | `cancelled`     | execution will not continue because the runtime or operator stopped the job                   | terminal state                     |
 
-`dead-letter` is not defined here as a base lifecycle state. It is treated as a
+`dead_letter` is not defined here as a base lifecycle state. It is treated as a
 later extension boundary that may be reached from failure or retry exhaustion.
 The reliability docs describe that isolation and recovery layer alongside the
 canonical lifecycle that dead-letter handling extends.

--- a/docs/pages/runtime/workers.md
+++ b/docs/pages/runtime/workers.md
@@ -10,7 +10,7 @@ permalink: /runtime/workers/
 Workers are responsible for reserving work, executing jobs, and participating in
 coordinated runtime lifecycle behavior.
 
-Routing stays explicit through `job.queue`. Worker subscription is the
+`job.queue` keeps routing explicit. Worker subscription is the
 combination of an ordered queue list and a handler registry. A worker reserves
 only jobs whose queue and handler both match that subscription. Unmatched jobs
 stay queued until a compatible worker exists. Queue order is subscription
@@ -35,7 +35,7 @@ Karya documents worker behavior around:
 
 - bootstrap and execution flow
 - drain-safe shutdown
-- pause and resume interactions with queue state
+- routing-aware reservation and execution flow
 - runtime supervision hooks used by operators and automation
 
 Workers extend the canonical job lifecycle; they do not introduce a separate
@@ -121,6 +121,9 @@ flags in this milestone. Jobs may carry `priority`,
 `concurrency_key`, and `rate_limit_key`, and the queue store decides whether a
 matching policy exists for those keys.
 
+The selected worker must subscribe to the right queue and handler, and the job
+must still clear policy gates before it moves from `queued` to `reserved`.
+
 Workers classify execution failures into three base cases in this milestone:
 normal handler errors (`:error`), execution timeouts (`:timeout`), and job
 expiration (`:expired`).
@@ -135,5 +138,7 @@ defaults. If a process hosts multiple runtimes, inject explicit `logger:` and
 - [Controls](/runtime/controls/): operators supervise workers through shared surfaces
 - [Backpressure](/reliability/backpressure/): rate limits and queue pressure
   shape worker behavior
+- [Retries](/reliability/retries/): failed execution returns to the same
+  lifecycle through explicit retry state
 - [Dashboard](/operator/dashboard/): worker state must stay visible to
   operators

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -75,19 +75,19 @@ next move: verify host route and asset path alignment
 
 When work is stuck, backlogged, or repeatedly failing, review:
 
-- queue pause/resume state
+- routing and worker-subscription alignment
 - supervisor runtime state and worker topology
-- rate-limit or concurrency-group conditions
-- dead-letter or poison-job status
-- workflow checkpoint, replay, or approval state
+- retry, rate-limit, or concurrency-group conditions
+- dead-letter isolation or governed recovery status
+- workflow replay, checkpoint, or approval state
 - backend-specific caveats documented in the support matrix
 
 ### Common Scenario
 
 ```text
 symptom: queue grows while operators see little progress
-first checks: queue pause state, supervisor phase, worker activity, concurrency or rate limits
-next move: confirm whether the issue is pressure, drain behavior, failure, or backend behavior
+first checks: routing match, supervisor phase, worker activity, concurrency or rate limits
+next move: confirm whether the issue is pressure, routing mismatch, retry churn, or backend behavior
 ```
 
 ### Runtime Inspection Checklist

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -75,7 +75,7 @@ next move: verify host route and asset path alignment
 
 When work is stuck, backlogged, or repeatedly failing, review:
 
-- routing and worker-subscription alignment
+- routing and worker subscription alignment
 - supervisor runtime state and worker topology
 - retry, rate-limit, or concurrency-group conditions
 - dead-letter isolation or governed recovery status


### PR DESCRIPTION
## Summary

This PR does two related things:

- updates the routing and reliability documentation to remove drift, stale assumptions, and terminology inconsistencies
- clarifies the repo review posture that `docs/` is future-state product documentation with no exceptions

## Why

The old issue and review wording implied that `docs/` should be synced to current implementation reality. That conflicts with the repo rule for `docs/`.

The intended posture is:

- `docs/` stays future-state product documentation
- docs work should remove drift as code evolves
- docs work should fix stale names, contradictory workflows, broken links, and unclear support boundaries
- docs work should not downgrade `docs/` into current-state implementation notes just because code is still catching up

## Changes In This PR

- aligned routing, retries, backpressure, dead-letter isolation, and recovery language across the affected docs pages
- cleaned up inconsistent terminology and support-boundary wording in the reliability/runtime docs
- updated repo instructions so review guidance matches the `docs/` future-state rule
- updated backlog wording for the affected docs issues/epics/milestones so they say remove drift and stale assumptions instead of align docs with implementation reality

## Scope Boundary

This is documentation and repo-instruction cleanup only.

- no runtime API changes
- no CLI feature additions
- no schema or behavior changes

Closes #67
