### PR TITLE
feat: implement uniqueness decision and snapshot features

### DIFF
--- a/core/karya/.reek.yml
+++ b/core/karya/.reek.yml
@@ -46,7 +46,6 @@ detectors:
       - Karya::Worker#execute_handler
       - Karya::QueueStore::InMemory::ExecutionSupport#finalized_execution_job
       - Karya::QueueStore::InMemory#store_and_requeue_if_needed
-      - Karya::QueueStore::InMemory::UniquenessSupport#duplicate_exists_for?
       - Karya::QueueStore::InMemory::UniquenessSupport#effective_retry_pending_uniqueness_job
       - Karya::QueueStore::InMemory::BackpressureSnapshotSupport#snapshot_concurrency
       - Karya::QueueStore::InMemory::BackpressureSnapshotSupport#snapshot_rate_limits

--- a/core/karya/lib/karya/queue_store/in_memory.rb
+++ b/core/karya/lib/karya/queue_store/in_memory.rb
@@ -92,14 +92,8 @@ module Karya
         @mutex.synchronize do
           validate_enqueue(job)
 
-          job_id = job.id
-          idempotency_key = job.idempotency_key
-          uniqueness_key = job.uniqueness_key
-          jobs_by_id = state.jobs_by_id
-          raise DuplicateJobError, "job #{job_id.inspect} is already present in the queue store" if jobs_by_id.key?(job_id)
-
-          raise_duplicate_idempotency_key_error(job_id:, idempotency_key:) if idempotency_conflict?(job)
-          raise_duplicate_uniqueness_key_error(job_id:, uniqueness_key:) if uniqueness_conflict?(job, now: normalized_now)
+          duplicate_decision = build_uniqueness_decision(job, normalized_now)
+          raise_duplicate_enqueue_error(duplicate_decision) if duplicate_decision.fetch(:action) == :reject
           expire_reservations_locked(normalized_now)
 
           queued_job = job.transition_to(:queued, updated_at: normalized_now)
@@ -216,6 +210,31 @@ module Karya
         @mutex.synchronize do
           prepare_reliability_snapshot(normalized_now)
           build_reliability_snapshot(normalized_now)
+        end
+      end
+
+      # Inspection helper exposed only by QueueStore::InMemory.
+      # It is not part of QueueStore::Base, and other queue-store backends are
+      # not expected to implement it. Callers that need backend-portable queue
+      # store behavior must not rely on this API.
+      def uniqueness_decision(job:, now:)
+        normalized_now = normalize_time(:now, now, error_class: InvalidEnqueueError)
+
+        @mutex.synchronize do
+          validate_enqueue(job)
+          build_uniqueness_decision(job, normalized_now)
+        end
+      end
+
+      # Inspection helper exposed only by QueueStore::InMemory.
+      # It is not part of QueueStore::Base, and other queue-store backends are
+      # not expected to implement it. Callers that need backend-portable queue
+      # store behavior must not rely on this API.
+      def uniqueness_snapshot(now:)
+        normalized_now = normalize_time(:now, now, error_class: InvalidQueueStoreOperationError)
+
+        @mutex.synchronize do
+          build_uniqueness_snapshot(normalized_now)
         end
       end
 

--- a/core/karya/lib/karya/queue_store/in_memory/uniqueness_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/uniqueness_support.rb
@@ -34,9 +34,133 @@ module Karya
           end
         end
 
-        private_constant :DuplicateKeySummary
+        # Frozen inspectable result for a candidate enqueue.
+        class Decision
+          def initialize(job:, now:)
+            @captured_at = now.dup.freeze
+            @job_id = job.id
+            @uniqueness_scope = job.uniqueness_scope
+          end
+
+          def accept
+            to_h(
+              action: :accept,
+              result: :accepted,
+              key_type: nil,
+              key: nil,
+              conflicting_job_id: nil
+            )
+          end
+
+          def reject(result:, key_type:, key:, conflicting_job_id:)
+            to_h(action: :reject, result:, key_type:, key:, conflicting_job_id:)
+          end
+
+          private
+
+          def to_h(action:, result:, key_type:, key:, conflicting_job_id:)
+            {
+              captured_at: @captured_at,
+              job_id: @job_id,
+              action:,
+              result:,
+              key_type:,
+              key:,
+              conflicting_job_id:,
+              uniqueness_scope: @uniqueness_scope
+            }.freeze
+          end
+        end
+
+        # Frozen snapshot entry for one idempotency key owner.
+        class IdempotencyKeySnapshot
+          def initialize(job:, key:)
+            @key = key
+            @job_id = job.id
+            @queue = job.queue
+            @handler = job.handler
+            @state = job.state
+            @created_at = job.created_at
+            @updated_at = job.updated_at
+          end
+
+          def to_h
+            {
+              key: @key,
+              job_id: @job_id,
+              queue: @queue,
+              handler: @handler,
+              state: @state,
+              created_at: @created_at,
+              updated_at: @updated_at
+            }.freeze
+          end
+        end
+
+        # Frozen snapshot entry for one effective uniqueness blocker.
+        class UniquenessKeySnapshot
+          def initialize(job:, effective_job:, key:, blocked_scopes:)
+            @key = key
+            @job_id = job.id
+            @queue = job.queue
+            @handler = job.handler
+            @state = job.state
+            @effective_state = effective_job.state
+            @uniqueness_scope = effective_job.uniqueness_scope
+            @blocked_incoming_scopes = blocked_scopes
+          end
+
+          def to_h
+            {
+              key: @key,
+              job_id: @job_id,
+              queue: @queue,
+              handler: @handler,
+              state: @state,
+              effective_state: @effective_state,
+              uniqueness_scope: @uniqueness_scope,
+              blocked_incoming_scopes: @blocked_incoming_scopes
+            }.freeze
+          end
+        end
+
+        # Finds an existing job matching a candidate key and caller-supplied predicate.
+        class DuplicateSearch
+          def initialize(jobs_by_id:, job:, key:, key_name:, exclude_job_id:)
+            @jobs_by_id = jobs_by_id
+            @job_id = job.id
+            @key = key
+            @key_name = key_name
+            @exclude_job_id = exclude_job_id
+            @skipped_job_ids = [@exclude_job_id, @job_id]
+          end
+
+          def call
+            return nil unless @key
+
+            @jobs_by_id.each_value do |existing_job|
+              existing_job_id = existing_job.id
+              next if skip_job_id?(existing_job_id)
+              next unless existing_job.public_send(@key_name) == @key
+              return existing_job if yield(existing_job)
+            end
+
+            nil
+          end
+
+          private
+
+          def skip_job_id?(existing_job_id)
+            @skipped_job_ids.include?(existing_job_id)
+          end
+        end
+
+        private_constant :Decision, :DuplicateKeySummary, :DuplicateSearch, :IdempotencyKeySnapshot, :UniquenessKeySnapshot
 
         private
+
+        UNIQUENESS_SCOPES = %i[queued active until_terminal].freeze
+        private_constant :UNIQUENESS_SCOPES
 
         def store_job(job:)
           job_id = job.id
@@ -45,23 +169,117 @@ module Karya
           job
         end
 
-        def uniqueness_conflict?(job, exclude_job_id: nil, now: nil)
-          duplicate_exists_for?(
+        def build_uniqueness_decision(job, now)
+          duplicate_job = duplicate_job_id(job)
+          if duplicate_job
+            return Decision.new(job:, now:).reject(
+              result: :duplicate_job_id,
+              key_type: :job_id,
+              key: job.id,
+              conflicting_job_id: duplicate_job.id
+            ).to_h
+          end
+
+          idempotency_duplicate = duplicate_idempotency_job(job)
+          if idempotency_duplicate
+            return Decision.new(job:, now:).reject(
+              result: :duplicate_idempotency_key,
+              key_type: :idempotency_key,
+              key: job.idempotency_key,
+              conflicting_job_id: idempotency_duplicate.id
+            ).to_h
+          end
+
+          uniqueness_duplicate = duplicate_uniqueness_job(job, now)
+          if uniqueness_duplicate
+            return Decision.new(job:, now:).reject(
+              result: :duplicate_uniqueness_key,
+              key_type: :uniqueness_key,
+              key: job.uniqueness_key,
+              conflicting_job_id: uniqueness_duplicate.id
+            ).to_h
+          end
+
+          Decision.new(job:, now:).accept
+        end
+
+        def duplicate_job_id(job)
+          state.jobs_by_id[job.id]
+        end
+
+        def duplicate_idempotency_job(job, exclude_job_id: nil)
+          duplicate_search(job, key: job.idempotency_key, key_name: :idempotency_key, exclude_job_id:).call { true }
+        end
+
+        def duplicate_uniqueness_job(job, now, exclude_job_id: nil)
+          duplicate_search(
             job,
             key: job.uniqueness_key,
             key_name: :uniqueness_key,
             exclude_job_id:
-          ) do |existing_job, candidate_job|
+          ).call do |existing_job|
             effective_existing_job = effective_uniqueness_job(existing_job, now)
             next false unless effective_existing_job
-            next false unless effective_existing_job.uniqueness_scope && candidate_job.uniqueness_scope
+            next false unless effective_existing_job.uniqueness_scope && job.uniqueness_scope
 
-            uniqueness_conflict_between?(effective_existing_job, candidate_job)
+            uniqueness_conflict_between?(effective_existing_job, job)
           end
         end
 
-        def idempotency_conflict?(job, exclude_job_id: nil)
-          duplicate_exists_for?(job, key: job.idempotency_key, key_name: :idempotency_key, exclude_job_id:) { true }
+        def duplicate_search(job, key:, key_name:, exclude_job_id:)
+          DuplicateSearch.new(jobs_by_id: state.jobs_by_id, job:, key:, key_name:, exclude_job_id:)
+        end
+
+        def build_uniqueness_snapshot(now)
+          {
+            captured_at: now.dup.freeze,
+            idempotency_keys: snapshot_idempotency_keys,
+            uniqueness_keys: snapshot_uniqueness_keys(now)
+          }.freeze
+        end
+
+        def snapshot_idempotency_keys
+          state.jobs_by_id.each_value.with_object({}) do |job, snapshot|
+            idempotency_key = job.idempotency_key
+            next unless idempotency_key
+
+            snapshot[idempotency_key] = IdempotencyKeySnapshot.new(job:, key: idempotency_key).to_h
+          end.freeze
+        end
+
+        def snapshot_uniqueness_keys(now)
+          state.jobs_by_id.each_value.with_object({}) do |job, snapshot|
+            uniqueness_key = job.uniqueness_key
+            next unless uniqueness_key
+
+            effective_job = effective_uniqueness_job(job, now)
+            next unless effective_job&.uniqueness_scope
+
+            blocked_scopes = blocked_incoming_scopes(effective_job)
+            next if blocked_scopes.empty?
+
+            blockers = snapshot[uniqueness_key] ||= []
+            blockers << UniquenessKeySnapshot.new(job:, effective_job:, key: uniqueness_key, blocked_scopes:).to_h
+          end.transform_values!(&:freeze).freeze
+        end
+
+        def blocked_incoming_scopes(existing_job)
+          UNIQUENESS_SCOPES.select { |incoming_scope| uniqueness_scope_conflicts?(existing_job, incoming_scope) }.freeze
+        end
+
+        def uniqueness_scope_conflicts?(existing_job, incoming_scope)
+          existing_state = existing_job.state
+          incoming_state = :queued
+          existing_scope = existing_job.uniqueness_scope
+          incoming_currently_blocks = uniqueness_scope_blocks_state?(incoming_scope, incoming_state)
+          existing_currently_blocks = uniqueness_scope_blocks_state?(existing_scope, existing_state)
+
+          (incoming_currently_blocks && uniqueness_scope_blocks_state?(incoming_scope, existing_state)) ||
+            (existing_currently_blocks && uniqueness_scope_blocks_state?(existing_scope, incoming_state))
+        end
+
+        def uniqueness_conflict?(job, exclude_job_id: nil, now: nil)
+          !!duplicate_uniqueness_job(job, now, exclude_job_id:)
         end
 
         def uniqueness_conflict_between?(existing_job, incoming_job)
@@ -111,20 +329,6 @@ module Karya
           else
             job
           end
-        end
-
-        def duplicate_exists_for?(job, key:, key_name:, exclude_job_id:)
-          return false unless key
-
-          jobs_by_id = state.jobs_by_id
-          jobs_by_id.each_value do |existing_job|
-            existing_job_id = existing_job.id
-            next if existing_job_id == exclude_job_id || existing_job_id == job.id
-            next unless existing_job.public_send(key_name) == key
-            return true if yield(existing_job, job)
-          end
-
-          false
         end
 
         def effective_queued_uniqueness_job(job, now)
@@ -184,6 +388,19 @@ module Karya
           end
 
           job.transition_to(:cancelled, updated_at:, next_retry_at: nil, failure_classification: nil)
+        end
+
+        def raise_duplicate_enqueue_error(duplicate_decision)
+          job_id = duplicate_decision.fetch(:job_id)
+          key = duplicate_decision.fetch(:key)
+          case duplicate_decision.fetch(:result)
+          when :duplicate_job_id
+            raise DuplicateJobError, "job #{job_id.inspect} is already present in the queue store"
+          when :duplicate_idempotency_key
+            raise_duplicate_idempotency_key_error(job_id:, idempotency_key: key)
+          when :duplicate_uniqueness_key
+            raise_duplicate_uniqueness_key_error(job_id:, uniqueness_key: key)
+          end
         end
 
         def raise_duplicate_uniqueness_key_error(job_id:, uniqueness_key:)

--- a/core/karya/sig/karya.rbs
+++ b/core/karya/sig/karya.rbs
@@ -171,6 +171,19 @@ module Karya
   type retry_jitter_strategy = :none | :full | :equal | "none" | "full" | "equal"
   type uniqueness_scope = :queued | :active | :until_terminal
   type uniqueness_scope_input = uniqueness_scope | "queued" | "active" | "until_terminal"
+  type uniqueness_decision_action = :accept | :reject
+  type uniqueness_decision_result = :accepted | :duplicate_job_id | :duplicate_idempotency_key | :duplicate_uniqueness_key
+  type uniqueness_decision_key_type = :job_id | :idempotency_key | :uniqueness_key
+  type uniqueness_decision = {
+    captured_at: Time,
+    job_id: String,
+    action: uniqueness_decision_action,
+    result: uniqueness_decision_result,
+    key_type: uniqueness_decision_key_type?,
+    key: String?,
+    conflicting_job_id: String?,
+    uniqueness_scope: uniqueness_scope?
+  }
   type failure_classification = :error | :timeout | :expired
   type failure_classification_input = failure_classification | "error" | "timeout" | "expired"
   type circuit_breaker_state = :closed | :open | :half_open
@@ -201,6 +214,30 @@ module Karya
     captured_at: Time,
     circuit_breakers: Hash[String, circuit_breaker_snapshot],
     stuck_jobs: Hash[String, stuck_job_snapshot]
+  }
+  type idempotency_key_snapshot = {
+    key: String,
+    job_id: String,
+    queue: String,
+    handler: String,
+    state: state_name,
+    created_at: Time,
+    updated_at: Time?
+  }
+  type uniqueness_key_snapshot = {
+    key: String,
+    job_id: String,
+    queue: String,
+    handler: String,
+    state: state_name,
+    effective_state: state_name,
+    uniqueness_scope: uniqueness_scope,
+    blocked_incoming_scopes: Array[uniqueness_scope]
+  }
+  type uniqueness_snapshot = {
+    captured_at: Time,
+    idempotency_keys: Hash[String, idempotency_key_snapshot],
+    uniqueness_keys: Hash[String, Array[uniqueness_key_snapshot]]
   }
   type backpressure_concurrency_snapshot = { scope: Backpressure::Scope, limit: Integer, active_count: Integer, blocked_count: Integer }
   type backpressure_rate_limit_snapshot = {

--- a/core/karya/sig/karya/queue_store/in_memory.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory.rbs
@@ -74,6 +74,18 @@ module Karya
       # store behavior must not rely on this API.
       def reliability_snapshot: (now: Time) -> Karya::reliability_snapshot
 
+      # Inspection helper exposed only by QueueStore::InMemory.
+      # It is not part of QueueStore::Base, and other queue-store backends are
+      # not expected to implement it. Callers that need backend-portable queue
+      # store behavior must not rely on this API.
+      def uniqueness_decision: (job: Job, now: Time) -> Karya::uniqueness_decision
+
+      # Inspection helper exposed only by QueueStore::InMemory.
+      # It is not part of QueueStore::Base, and other queue-store backends are
+      # not expected to implement it. Callers that need backend-portable queue
+      # store behavior must not rely on this API.
+      def uniqueness_snapshot: (now: Time) -> Karya::uniqueness_snapshot
+
       private
 
       attr_reader circuit_breaker_policy_set: CircuitBreaker::PolicySet
@@ -387,13 +399,120 @@ module Karya
           def preview: () -> String
         end
 
+        class Decision
+          @captured_at: Time
+          @job_id: String
+          @uniqueness_scope: Karya::uniqueness_scope?
+
+          def initialize: (job: Job, now: Time) -> void
+
+          def accept: () -> Karya::uniqueness_decision
+
+          def reject: (
+            result: Karya::uniqueness_decision_result,
+            key_type: Karya::uniqueness_decision_key_type,
+            key: String,
+            conflicting_job_id: String
+          ) -> Karya::uniqueness_decision
+
+          private
+
+          def to_h: (
+            action: Karya::uniqueness_decision_action,
+            result: Karya::uniqueness_decision_result,
+            key_type: Karya::uniqueness_decision_key_type?,
+            key: String?,
+            conflicting_job_id: String?
+          ) -> Karya::uniqueness_decision
+        end
+
+        class IdempotencyKeySnapshot
+          @key: String
+          @job_id: String
+          @queue: String
+          @handler: String
+          @state: Karya::state_name
+          @created_at: Time
+          @updated_at: Time?
+
+          def initialize: (job: Job, key: String) -> void
+
+          def to_h: () -> Karya::idempotency_key_snapshot
+        end
+
+        class UniquenessKeySnapshot
+          @key: String
+          @job_id: String
+          @queue: String
+          @handler: String
+          @state: Karya::state_name
+          @effective_state: Karya::state_name
+          @uniqueness_scope: Karya::uniqueness_scope
+          @blocked_incoming_scopes: Array[Karya::uniqueness_scope]
+
+          def initialize: (
+            job: Job,
+            effective_job: Job,
+            key: String,
+            blocked_scopes: Array[Karya::uniqueness_scope]
+          ) -> void
+
+          def to_h: () -> Karya::uniqueness_key_snapshot
+        end
+
+        class DuplicateSearch
+          @jobs_by_id: Hash[String, Job]
+          @job_id: String
+          @key: String?
+          @key_name: :idempotency_key | :uniqueness_key
+          @exclude_job_id: String?
+          @skipped_job_ids: Array[String?]
+
+          def initialize: (
+            jobs_by_id: Hash[String, Job],
+            job: Job,
+            key: String?,
+            key_name: :idempotency_key | :uniqueness_key,
+            exclude_job_id: String?
+          ) -> void
+
+          def call: () { (Job existing_job) -> bool } -> Job?
+
+          private
+
+          def skip_job_id?: (String existing_job_id) -> bool
+        end
+
         private
 
         def store_job: (job: Job) -> Job
 
-        def uniqueness_conflict?: (Job job, ?exclude_job_id: String?, ?now: Time?) -> bool
+        def build_uniqueness_decision: (Job job, Time now) -> Karya::uniqueness_decision
 
-        def idempotency_conflict?: (Job job, ?exclude_job_id: String?) -> bool
+        def duplicate_job_id: (Job job) -> Job?
+
+        def duplicate_idempotency_job: (Job job, ?exclude_job_id: String?) -> Job?
+
+        def duplicate_uniqueness_job: (Job job, Time? now, ?exclude_job_id: String?) -> Job?
+
+        def duplicate_search: (
+          Job job,
+          key: String?,
+          key_name: :idempotency_key | :uniqueness_key,
+          exclude_job_id: String?
+        ) -> DuplicateSearch
+
+        def build_uniqueness_snapshot: (Time now) -> Karya::uniqueness_snapshot
+
+        def snapshot_idempotency_keys: () -> Hash[String, Karya::idempotency_key_snapshot]
+
+        def snapshot_uniqueness_keys: (Time now) -> Hash[String, Array[Karya::uniqueness_key_snapshot]]
+
+        def blocked_incoming_scopes: (Job existing_job) -> Array[Karya::uniqueness_scope]
+
+        def uniqueness_scope_conflicts?: (Job existing_job, Karya::uniqueness_scope incoming_scope) -> bool
+
+        def uniqueness_conflict?: (Job job, ?exclude_job_id: String?, ?now: Time?) -> bool
 
         def uniqueness_conflict_between?: (Job existing_job, Job incoming_job) -> bool
 
@@ -411,13 +530,6 @@ module Karya
 
         def effective_running_uniqueness_job: (Job job, Time now) -> Job
 
-        def duplicate_exists_for?: (
-          Job job,
-          key: String?,
-          key_name: :idempotency_key | :uniqueness_key,
-          exclude_job_id: String?
-        ) { (Job, Job) -> bool } -> bool
-
         def lease_expired_for_uniqueness?: (Hash[String, Reservation] leases_by_token, String job_id, Time now) -> bool
 
         def resolve_reentry_uniqueness: (Job job, ?now: Time?) -> Job
@@ -425,6 +537,8 @@ module Karya
         def resolve_reentry_and_store: (Job job, ?now: Time?) -> Job
 
         def reentry_conflict_job: (Job job) -> Job
+
+        def raise_duplicate_enqueue_error: (Karya::uniqueness_decision duplicate_decision) -> nil
 
         def raise_duplicate_uniqueness_key_error: (job_id: String, uniqueness_key: String) -> nil
 

--- a/core/karya/spec/karya/queue_store/in_memory_uniqueness_inspection_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_uniqueness_inspection_spec.rb
@@ -1,0 +1,389 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+RSpec.describe Karya::QueueStore::InMemory do
+  subject(:store) { described_class.new(token_generator: token_generator) }
+
+  let(:token_sequence) { %w[lease-1 lease-2 lease-3 lease-4 lease-5 lease-6].each }
+  let(:token_generator) { -> { token_sequence.next } }
+  let(:created_at) { Time.utc(2026, 4, 21, 12, 0, 0) }
+  let(:retry_policy) { Karya::RetryPolicy.new(max_attempts: 3, base_delay: 5, multiplier: 1) }
+
+  def submission_job(
+    id:,
+    created_at:,
+    queue: 'billing',
+    handler: 'billing_sync',
+    idempotency_key: nil,
+    uniqueness_key: nil,
+    uniqueness_scope: nil,
+    expires_at: nil
+  )
+    Karya::Job.new(
+      id:,
+      queue:,
+      handler:,
+      idempotency_key:,
+      uniqueness_key:,
+      uniqueness_scope:,
+      expires_at:,
+      state: :submission,
+      created_at:
+    )
+  end
+
+  def stored_job(id)
+    store_state.jobs_by_id.fetch(id)
+  end
+
+  def store_state
+    store.instance_variable_get(:@state)
+  end
+
+  def expect_deep_frozen(value)
+    expect(value).to be_frozen
+    case value
+    when Hash
+      value.each do |key, nested_value|
+        expect(key).to be_frozen if key.is_a?(String)
+        expect_deep_frozen(nested_value)
+      end
+    when Array
+      value.each { |nested_value| expect_deep_frozen(nested_value) }
+    end
+  end
+
+  describe '#uniqueness_decision' do
+    it 'returns an accepted decision for non-conflicting work' do
+      decision = store.uniqueness_decision(
+        job: submission_job(id: 'job-1', created_at:),
+        now: created_at + 1
+      )
+
+      expect(decision).to eq(
+        captured_at: created_at + 1,
+        job_id: 'job-1',
+        action: :accept,
+        result: :accepted,
+        key_type: nil,
+        key: nil,
+        conflicting_job_id: nil,
+        uniqueness_scope: nil
+      )
+      expect_deep_frozen(decision)
+    end
+
+    it 'reports duplicate job ids before key conflicts' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          idempotency_key: 'submit-123',
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :active
+        ),
+        now: created_at + 1
+      )
+
+      decision = store.uniqueness_decision(
+        job: submission_job(
+          id: 'job-1',
+          created_at: created_at + 2,
+          idempotency_key: 'submit-123',
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :active
+        ),
+        now: created_at + 3
+      )
+
+      expect(decision).to include(
+        action: :reject,
+        result: :duplicate_job_id,
+        key_type: :job_id,
+        key: 'job-1',
+        conflicting_job_id: 'job-1'
+      )
+    end
+
+    it 'reports duplicate idempotency before uniqueness conflicts' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          idempotency_key: 'submit-123',
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :active
+        ),
+        now: created_at + 1
+      )
+
+      decision = store.uniqueness_decision(
+        job: submission_job(
+          id: 'job-2',
+          created_at: created_at + 2,
+          idempotency_key: 'submit-123',
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :active
+        ),
+        now: created_at + 3
+      )
+
+      expect(decision).to include(
+        action: :reject,
+        result: :duplicate_idempotency_key,
+        key_type: :idempotency_key,
+        key: 'submit-123',
+        conflicting_job_id: 'job-1'
+      )
+    end
+
+    it 'reports duplicate uniqueness conflicts' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :queued
+        ),
+        now: created_at + 1
+      )
+
+      decision = store.uniqueness_decision(
+        job: submission_job(
+          id: 'job-2',
+          created_at: created_at + 2,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :active
+        ),
+        now: created_at + 3
+      )
+
+      expect(decision).to include(
+        action: :reject,
+        result: :duplicate_uniqueness_key,
+        key_type: :uniqueness_key,
+        key: 'billing:account-42',
+        conflicting_job_id: 'job-1',
+        uniqueness_scope: :active
+      )
+    end
+
+    it 'does not mutate due retry-pending jobs while computing a decision' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :queued
+        ),
+        now: created_at + 1
+      )
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+      store.start_execution(reservation_token: reservation.token, now: created_at + 3)
+      store.fail_execution(
+        reservation_token: reservation.token,
+        now: created_at + 4,
+        failure_classification: :error,
+        retry_policy:
+      )
+
+      decision = store.uniqueness_decision(
+        job: submission_job(
+          id: 'job-2',
+          created_at: created_at + 10,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :queued
+        ),
+        now: created_at + 10
+      )
+
+      expect(decision).to include(result: :duplicate_uniqueness_key, conflicting_job_id: 'job-1')
+      expect(stored_job('job-1').state).to eq(:retry_pending)
+      expect(store_state.retry_pending_job_ids).to eq(['job-1'])
+    end
+
+    it 'does not recover expired reserved leases while computing a decision' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :queued
+        ),
+        now: created_at + 1
+      )
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 2, now: created_at + 2)
+
+      decision = store.uniqueness_decision(
+        job: submission_job(
+          id: 'job-2',
+          created_at: created_at + 5,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :active
+        ),
+        now: created_at + 5
+      )
+
+      expect(decision).to include(result: :duplicate_uniqueness_key, conflicting_job_id: 'job-1')
+      expect(stored_job('job-1').state).to eq(:reserved)
+      expect(store_state.reservations_by_token).to include(reservation.token)
+    end
+
+    it 'ignores accepted decisions when duplicate error raising is asked directly' do
+      decision = store.uniqueness_decision(
+        job: submission_job(id: 'job-1', created_at:),
+        now: created_at + 1
+      )
+
+      expect(store.send(:raise_duplicate_enqueue_error, decision)).to be_nil
+    end
+  end
+
+  describe '#uniqueness_snapshot' do
+    it 'includes idempotency blockers after terminal completion' do
+      store.enqueue(
+        job: submission_job(id: 'job-1', created_at:, idempotency_key: 'submit-123'),
+        now: created_at + 1
+      )
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+      store.start_execution(reservation_token: reservation.token, now: created_at + 3)
+      store.complete_execution(reservation_token: reservation.token, now: created_at + 4)
+
+      snapshot = store.uniqueness_snapshot(now: created_at + 5)
+
+      expect(snapshot[:idempotency_keys].fetch('submit-123')).to include(
+        key: 'submit-123',
+        job_id: 'job-1',
+        queue: 'billing',
+        handler: 'billing_sync',
+        state: :succeeded,
+        created_at:
+      )
+      expect_deep_frozen(snapshot)
+    end
+
+    it 'excludes expired queued uniqueness jobs without mutating them' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :queued,
+          expires_at: created_at + 2
+        ),
+        now: created_at + 1
+      )
+
+      snapshot = store.uniqueness_snapshot(now: created_at + 3)
+
+      expect(snapshot[:uniqueness_keys]).to be_empty
+      expect(stored_job('job-1').state).to eq(:queued)
+    end
+
+    it 'excludes terminal uniqueness jobs that no longer block incoming scopes' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :active
+        ),
+        now: created_at + 1
+      )
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+      store.start_execution(reservation_token: reservation.token, now: created_at + 3)
+      store.complete_execution(reservation_token: reservation.token, now: created_at + 4)
+
+      snapshot = store.uniqueness_snapshot(now: created_at + 5)
+
+      expect(snapshot[:uniqueness_keys]).to be_empty
+      expect(stored_job('job-1').state).to eq(:succeeded)
+    end
+
+    it 'reports due retry-pending blockers as effectively queued without mutating them' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :queued
+        ),
+        now: created_at + 1
+      )
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+      store.start_execution(reservation_token: reservation.token, now: created_at + 3)
+      store.fail_execution(
+        reservation_token: reservation.token,
+        now: created_at + 4,
+        failure_classification: :error,
+        retry_policy:
+      )
+
+      snapshot = store.uniqueness_snapshot(now: created_at + 10)
+      blocker = snapshot[:uniqueness_keys].fetch('billing:account-42').first
+
+      expect(blocker).to include(
+        job_id: 'job-1',
+        state: :retry_pending,
+        effective_state: :queued,
+        uniqueness_scope: :queued,
+        blocked_incoming_scopes: %i[queued active until_terminal]
+      )
+      expect(stored_job('job-1').state).to eq(:retry_pending)
+    end
+
+    it 'reports expired running blockers as effectively queued without mutating them' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :active
+        ),
+        now: created_at + 1
+      )
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 2, now: created_at + 2)
+      store.start_execution(reservation_token: reservation.token, now: created_at + 3)
+
+      snapshot = store.uniqueness_snapshot(now: created_at + 6)
+      blocker = snapshot[:uniqueness_keys].fetch('billing:account-42').first
+
+      expect(blocker).to include(
+        job_id: 'job-1',
+        state: :running,
+        effective_state: :queued,
+        uniqueness_scope: :active,
+        blocked_incoming_scopes: %i[queued active until_terminal]
+      )
+      expect(stored_job('job-1').state).to eq(:running)
+      expect(store_state.executions_by_token).to include(reservation.token)
+    end
+
+    it 'reports asymmetric blocked incoming scopes for reserved queued-scope blockers' do
+      store.enqueue(
+        job: submission_job(
+          id: 'job-1',
+          created_at:,
+          uniqueness_key: 'billing:account-42',
+          uniqueness_scope: :queued
+        ),
+        now: created_at + 1
+      )
+      store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 30, now: created_at + 2)
+
+      snapshot = store.uniqueness_snapshot(now: created_at + 3)
+      blocker = snapshot[:uniqueness_keys].fetch('billing:account-42').first
+
+      expect(blocker).to include(
+        state: :reserved,
+        effective_state: :reserved,
+        uniqueness_scope: :queued,
+        blocked_incoming_scopes: %i[active until_terminal]
+      )
+    end
+  end
+end

--- a/docs/pages/reliability/uniqueness.md
+++ b/docs/pages/reliability/uniqueness.md
@@ -22,20 +22,53 @@ than hidden queue implementation logic.
 Teams need to see when work is suppressed, merged, or intentionally rejected by
 uniqueness rules.
 
+Karya's core v1 uniqueness behavior is reject-only. Duplicate job identities,
+idempotency keys, or active uniqueness windows reject fresh enqueue attempts
+instead of silently merging, replacing, or acknowledging them as success. Later
+bulk and operator recovery surfaces may add mutation workflows, but those are
+separate controls.
+
 ## Common Scenarios
 
 ### Preventing Duplicate Work
 
-Uniqueness should be visible when duplicate work is submitted:
+Uniqueness should be visible before or when duplicate work is submitted:
 
 ```text
 enqueue job billing-sync account=42
-result: duplicate-suppressed
-existing_job_id: billing-sync-42
+result: duplicate_uniqueness_key
+action: reject
+conflicting_job_id: billing-sync-42
 ```
 
 What matters is visibility into why new work was not accepted as a fresh
 execution.
+
+### Inspecting A Decision
+
+Operators and tooling can preflight a candidate job with a uniqueness decision.
+The decision reports whether Karya would accept or reject the job, which key
+caused the rejection, and the conflicting job id when one exists.
+
+```text
+uniqueness_decision job=billing-sync-43
+action: reject
+result: duplicate_idempotency_key
+key_type: idempotency_key
+conflicting_job_id: billing-sync-42
+```
+
+Decision inspection is read-only. It does not enqueue the candidate job, record
+the rejected attempt, recover expired leases, or promote retry-pending work.
+
+### Inspecting Current Blockers
+
+A uniqueness snapshot shows the keys currently influencing enqueue decisions:
+
+- idempotency keys remain blockers while the original job remains stored
+- uniqueness keys show effective blockers and the incoming scopes they block
+- due retry-pending work and expired in-flight leases are evaluated as their
+  effective uniqueness state for inspection without mutating runtime state
 
 ## Related Concepts
 


### PR DESCRIPTION
- Introduced `uniqueness_decision` method to evaluate job uniqueness before enqueueing.
- Added `uniqueness_snapshot` method to inspect current uniqueness keys and their states.
- Created `Decision`, `IdempotencyKeySnapshot`, and `UniquenessKeySnapshot` classes for structured decision results.
- Updated documentation to reflect new uniqueness behavior and inspection capabilities.
- Added tests to ensure correct functionality of uniqueness decision logic and snapshot reporting.

closes: #343 
