### PR TITLE
feat: add snapshot functionality for workflows

### DIFF
--- a/core/karya/lib/karya/queue_store/base.rb
+++ b/core/karya/lib/karya/queue_store/base.rb
@@ -81,6 +81,14 @@ module Karya
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 
+      # Inspect one workflow run by its batch id. Backends must derive
+      # workflow state from stored workflow metadata and current member jobs.
+      def workflow_snapshot(batch_id:, now:)
+        _batch_id = batch_id
+        _now = now
+        raise NotImplementedError, "#{self.class} must implement ##{__method__}"
+      end
+
       # Reserve must atomically move one durable queued job to reserved and
       # persist its lease token, worker id, reserved_at, and expires_at before
       # returning the reservation. A returned reservation is the only

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -258,8 +258,8 @@ module Karya
           def register_workflow(batch_id:, workflow_id:, step_job_ids:, dependency_job_ids_by_job_id:)
             workflow_registrations_by_batch_id[batch_id] = WorkflowRegistration.new(
               workflow_id,
-              step_job_ids,
-              dependency_job_ids_by_job_id
+              step_job_ids.dup.freeze,
+              dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }.freeze
             ).freeze
           end
 

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -36,7 +36,7 @@ module Karya
                       :workflow_registrations_by_batch_id
 
           # Immutable owner-local workflow registration metadata for one batch.
-          WorkflowRegistration = Struct.new(:workflow_id, :step_job_ids)
+          WorkflowRegistration = Struct.new(:workflow_id, :step_job_ids, :dependency_job_ids_by_job_id)
 
           def initialize(expired_tombstone_limit:)
             @batches_by_id = {}
@@ -232,21 +232,34 @@ module Karya
               @terminal_batch_ids_index.delete(batch_id)
               batch = batches_by_id.delete(batch_id)
               unless batch
-                @batch_id_by_job_id.delete_if { |_job_id, stored_batch_id| stored_batch_id == batch_id }
+                PrunedBatchCleanup.call(
+                  batch_id:,
+                  batch: nil,
+                  batch_id_by_job_id: @batch_id_by_job_id,
+                  workflow_dependency_job_ids_by_job_id:,
+                  workflow_registrations_by_batch_id:
+                )
                 next
               end
 
-              batch.job_ids.each { |job_id| @batch_id_by_job_id.delete(job_id) }
+              PrunedBatchCleanup.call(
+                batch_id:,
+                batch:,
+                batch_id_by_job_id: @batch_id_by_job_id,
+                workflow_dependency_job_ids_by_job_id:,
+                workflow_registrations_by_batch_id:
+              )
               pruned_batch_ids << batch_id
             end
 
             pruned_batch_ids
           end
 
-          def register_workflow(batch_id:, workflow_id:, step_job_ids:)
+          def register_workflow(batch_id:, workflow_id:, step_job_ids:, dependency_job_ids_by_job_id:)
             workflow_registrations_by_batch_id[batch_id] = WorkflowRegistration.new(
               workflow_id,
-              step_job_ids
+              step_job_ids,
+              dependency_job_ids_by_job_id
             ).freeze
           end
 
@@ -260,6 +273,46 @@ module Karya
               job&.terminal?
             end
           end
+
+          # Removes indexes owned by a pruned workflow or plain batch.
+          class PrunedBatchCleanup
+            def self.call(**)
+              new(**).call
+            end
+
+            def initialize(batch_id:, batch:, batch_id_by_job_id:, workflow_dependency_job_ids_by_job_id:, workflow_registrations_by_batch_id:)
+              @batch_id = batch_id
+              @batch = batch
+              @batch_id_by_job_id = batch_id_by_job_id
+              @workflow_dependency_job_ids_by_job_id = workflow_dependency_job_ids_by_job_id
+              @workflow_registrations_by_batch_id = workflow_registrations_by_batch_id
+            end
+
+            def call
+              pruned_job_ids ? cleanup_batch_jobs : cleanup_stale_batch_membership
+              workflow_registrations_by_batch_id.delete(batch_id)
+            end
+
+            private
+
+            attr_reader :batch, :batch_id, :batch_id_by_job_id, :workflow_dependency_job_ids_by_job_id, :workflow_registrations_by_batch_id
+
+            def pruned_job_ids
+              batch&.job_ids
+            end
+
+            def cleanup_batch_jobs
+              pruned_job_ids.each do |job_id|
+                batch_id_by_job_id.delete(job_id)
+                workflow_dependency_job_ids_by_job_id.delete(job_id)
+              end
+            end
+
+            def cleanup_stale_batch_membership
+              batch_id_by_job_id.delete_if { |_job_id, stored_batch_id| stored_batch_id == batch_id }
+            end
+          end
+          private_constant :PrunedBatchCleanup
 
           def trim_fair_queue_history
             last_reserved_queue_by_subscription.shift while last_reserved_queue_by_subscription.length > MAX_TRACKED_FAIR_QUEUE_LISTS

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -32,7 +32,11 @@ module Karya
                       :reservation_tokens_in_order,
                       :reservations_by_token,
                       :stuck_job_recoveries_by_id,
-                      :workflow_dependency_job_ids_by_job_id
+                      :workflow_dependency_job_ids_by_job_id,
+                      :workflow_registrations_by_batch_id
+
+          # Immutable owner-local workflow registration metadata for one batch.
+          WorkflowRegistration = Struct.new(:workflow_id, :step_job_ids)
 
           def initialize(expired_tombstone_limit:)
             @batches_by_id = {}
@@ -60,6 +64,7 @@ module Karya
             @terminal_batch_ids_index = {}
             @terminal_batch_ids_in_order = []
             @workflow_dependency_job_ids_by_job_id = {}
+            @workflow_registrations_by_batch_id = {}
           end
 
           def queue_job_ids_for(queue)
@@ -238,11 +243,14 @@ module Karya
             pruned_batch_ids
           end
 
-          def register_workflow_dependencies(dependency_job_ids_by_job_id)
-            dependency_job_ids_by_job_id.each do |job_id, dependency_job_ids|
-              workflow_dependency_job_ids_by_job_id[job_id] = dependency_job_ids
-            end
+          def register_workflow(batch_id:, workflow_id:, step_job_ids:)
+            workflow_registrations_by_batch_id[batch_id] = WorkflowRegistration.new(
+              workflow_id,
+              step_job_ids
+            ).freeze
           end
+
+          private_constant :WorkflowRegistration
 
           private
 

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -309,7 +309,14 @@ module Karya
             end
 
             def cleanup_stale_batch_membership
-              batch_id_by_job_id.delete_if { |_job_id, stored_batch_id| stored_batch_id == batch_id }
+              stale_job_ids = batch_id_by_job_id.each_with_object([]) do |(job_id, stored_batch_id), job_ids|
+                job_ids << job_id if stored_batch_id == batch_id
+              end
+
+              stale_job_ids.each do |job_id|
+                batch_id_by_job_id.delete(job_id)
+                workflow_dependency_job_ids_by_job_id.delete(job_id)
+              end
             end
           end
           private_constant :PrunedBatchCleanup

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -17,12 +17,18 @@ module Karya
             @mutex.synchronize do
               binding = Workflow.send(:build_execution_binding, definition:, jobs_by_step_id:, batch_id:)
               jobs = binding.jobs
-              batch = build_enqueue_batch(batch_id: binding.batch_id, jobs:, now: normalized_now)
+              workflow_batch_id = binding.batch_id
+              batch = build_enqueue_batch(batch_id: workflow_batch_id, jobs:, now: normalized_now)
               validate_bulk_enqueue_uniqueness(jobs, normalized_now)
               expire_reservations_locked(normalized_now)
               queued_jobs = jobs.map { |job| enqueue_validated_job(job, normalized_now) }
               store_batch(batch)
-              state.register_workflow_dependencies(binding.dependency_job_ids_by_job_id)
+              state.workflow_dependency_job_ids_by_job_id.merge!(binding.dependency_job_ids_by_job_id)
+              state.register_workflow(
+                batch_id: workflow_batch_id,
+                workflow_id: definition.id,
+                step_job_ids: StepJobIds.new(definition:, jobs:).to_h
+              )
               BulkMutationReport.new(
                 action: :enqueue_many,
                 performed_at: normalized_now,
@@ -33,7 +39,53 @@ module Karya
             end
           end
 
+          def workflow_snapshot(batch_id:, now:)
+            normalized_now = normalize_time(:now, now, error_class: Workflow::InvalidExecutionError)
+            normalized_batch_id = Workflow.send(:normalize_batch_identifier, :batch_id, batch_id)
+
+            @mutex.synchronize do
+              batch = fetch_batch(normalized_batch_id)
+              workflow_batch_id = batch.id
+              registration = fetch_workflow_registration(workflow_batch_id)
+              jobs = batch.job_ids.map { |job_id| state.jobs_by_id.fetch(job_id) }
+              Workflow::Snapshot.new(
+                workflow_id: registration.workflow_id,
+                batch_id: workflow_batch_id,
+                captured_at: normalized_now,
+                step_job_ids: registration.step_job_ids,
+                dependency_job_ids_by_job_id: state.workflow_dependency_job_ids_by_job_id,
+                jobs:
+              )
+            end
+          end
+
           private
+
+          # Builds step-to-job metadata in definition order.
+          class StepJobIds
+            def initialize(definition:, jobs:)
+              @definition = definition
+              @jobs = jobs
+            end
+
+            def to_h
+              definition.steps.each_with_object({}).with_index do |(workflow_step, step_jobs), index|
+                step_jobs[workflow_step.id] = jobs.fetch(index).id
+              end.freeze
+            end
+
+            private
+
+            attr_reader :definition, :jobs
+          end
+          private_constant :StepJobIds
+
+          def fetch_workflow_registration(batch_id)
+            registration = state.workflow_registrations_by_batch_id[batch_id]
+            return registration if registration
+
+            raise Workflow::InvalidExecutionError, "batch #{batch_id.inspect} is not a workflow batch"
+          end
 
           def workflow_dependencies_satisfied?(job)
             prerequisite_job_ids = state.workflow_dependency_job_ids_by_job_id[job.id]

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -72,8 +72,8 @@ module Karya
             end
 
             def to_h
-              definition.steps.each_with_object({}).with_index do |(workflow_step, step_jobs), index|
-                step_jobs[workflow_step.id] = jobs.fetch(index).id
+              definition.steps.each_with_object({}).with_index do |(workflow_step, step_job_ids), index|
+                step_job_ids[workflow_step.id] = jobs.fetch(index).id
               end.freeze
             end
 

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -22,12 +22,14 @@ module Karya
               validate_bulk_enqueue_uniqueness(jobs, normalized_now)
               expire_reservations_locked(normalized_now)
               queued_jobs = jobs.map { |job| enqueue_validated_job(job, normalized_now) }
+              dependency_job_ids_by_job_id = binding.dependency_job_ids_by_job_id
               store_batch(batch)
-              state.workflow_dependency_job_ids_by_job_id.merge!(binding.dependency_job_ids_by_job_id)
+              state.workflow_dependency_job_ids_by_job_id.merge!(dependency_job_ids_by_job_id)
               state.register_workflow(
                 batch_id: workflow_batch_id,
                 workflow_id: definition.id,
-                step_job_ids: StepJobIds.new(definition:, jobs:).to_h
+                step_job_ids: StepJobIds.new(definition:, jobs:).to_h,
+                dependency_job_ids_by_job_id:
               )
               BulkMutationReport.new(
                 action: :enqueue_many,
@@ -44,6 +46,7 @@ module Karya
             normalized_batch_id = Workflow.send(:normalize_batch_identifier, :batch_id, batch_id)
 
             @mutex.synchronize do
+              recover_in_flight_locked(normalized_now)
               batch = fetch_batch(normalized_batch_id)
               workflow_batch_id = batch.id
               registration = fetch_workflow_registration(workflow_batch_id)
@@ -53,7 +56,7 @@ module Karya
                 batch_id: workflow_batch_id,
                 captured_at: normalized_now,
                 step_job_ids: registration.step_job_ids,
-                dependency_job_ids_by_job_id: state.workflow_dependency_job_ids_by_job_id,
+                dependency_job_ids_by_job_id: registration.dependency_job_ids_by_job_id,
                 jobs:
               )
             end

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -50,7 +50,7 @@ module Karya
               batch = fetch_batch(normalized_batch_id)
               workflow_batch_id = batch.id
               registration = fetch_workflow_registration(workflow_batch_id)
-              jobs = batch.job_ids.map { |job_id| state.jobs_by_id.fetch(job_id) }
+              jobs = fetch_batch_jobs(batch)
               Workflow::Snapshot.new(
                 workflow_id: registration.workflow_id,
                 batch_id: workflow_batch_id,

--- a/core/karya/lib/karya/workflow.rb
+++ b/core/karya/lib/karya/workflow.rb
@@ -12,6 +12,7 @@ require_relative 'workflow/catalog'
 require_relative 'workflow/dependency'
 require_relative 'workflow/definition'
 require_relative 'workflow/execution_binding'
+require_relative 'workflow/snapshot'
 require_relative 'workflow/step'
 
 module Karya

--- a/core/karya/lib/karya/workflow/snapshot.rb
+++ b/core/karya/lib/karya/workflow/snapshot.rb
@@ -228,6 +228,7 @@ module Karya
           dependency_job_ids_by_job_id.each_with_object({}) do |(job_id, dependency_job_ids), normalized|
             normalized_job_id = Workflow.send(:normalize_execution_identifier, :job_id, job_id)
             raise InvalidExecutionError, 'dependency job ids must be an Array' unless dependency_job_ids.is_a?(Array)
+            raise InvalidExecutionError, "duplicate dependency job id #{normalized_job_id.inspect}" if normalized.key?(normalized_job_id)
 
             normalized[normalized_job_id] = DependencyJobIdList.new(dependency_job_ids).to_a
           end.freeze

--- a/core/karya/lib/karya/workflow/snapshot.rb
+++ b/core/karya/lib/karya/workflow/snapshot.rb
@@ -1,0 +1,399 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module Workflow
+    # Immutable inspection view for one workflow run at a point in time.
+    class Snapshot
+      FAILED_STATES = %i[failed dead_letter].freeze
+      COMPLETED_STATES = %i[succeeded cancelled].freeze
+      WAITING_STATES = %i[queued submission].freeze
+      REQUIRED_ATTRIBUTES = %i[
+        workflow_id
+        batch_id
+        captured_at
+        step_job_ids
+        dependency_job_ids_by_job_id
+        jobs
+      ].freeze
+
+      def initialize(**attributes)
+        attributes = Attributes.new(attributes)
+        @identity = attributes.identity
+        @membership = attributes.membership
+        @summary_data = SummaryData.new(membership)
+        freeze
+      end
+
+      def workflow_id
+        identity.workflow_id
+      end
+
+      def batch_id
+        identity.batch_id
+      end
+
+      def captured_at
+        identity.captured_at
+      end
+
+      def job_ids
+        membership.job_ids
+      end
+
+      def jobs
+        membership.jobs
+      end
+
+      def step_states
+        membership.step_states
+      end
+
+      def state_counts
+        summary_data.state_counts
+      end
+
+      def total_count
+        summary_data.total_count
+      end
+
+      def completed_count
+        summary_data.completed_count
+      end
+
+      def failed_count
+        summary_data.failed_count
+      end
+
+      def state
+        summary_data.state
+      end
+
+      # Validates and exposes snapshot construction attributes.
+      class Attributes
+        def initialize(attributes)
+          @attributes = attributes
+          validate_keys
+        end
+
+        def fetch(name)
+          attributes.fetch(name) { raise ArgumentError, "missing keyword: :#{name}" }
+        end
+
+        def identity
+          Identity.new(
+            workflow_id: Workflow.send(:normalize_identifier, :workflow_id, fetch(:workflow_id)),
+            batch_id: Workflow.send(:normalize_batch_identifier, :batch_id, fetch(:batch_id)),
+            captured_at: Timestamp.new(:captured_at, fetch(:captured_at)).to_time
+          )
+        end
+
+        def membership
+          Membership.new(
+            step_job_ids: StepJobIds.new(fetch(:step_job_ids)).to_h,
+            dependency_job_ids_by_job_id: DependencyJobIds.new(fetch(:dependency_job_ids_by_job_id)).to_h,
+            jobs: JobList.new(fetch(:jobs)).to_a
+          )
+        end
+
+        private
+
+        attr_reader :attributes
+
+        def validate_keys
+          unknown_keys = attributes.keys - REQUIRED_ATTRIBUTES
+          return if unknown_keys.empty?
+
+          raise ArgumentError, "unknown keyword: :#{unknown_keys.first}"
+        end
+      end
+
+      # Groups normalized snapshot identity fields.
+      class Identity
+        attr_reader :batch_id, :captured_at, :workflow_id
+
+        def initialize(workflow_id:, batch_id:, captured_at:)
+          @workflow_id = workflow_id
+          @batch_id = batch_id
+          @captured_at = captured_at
+          freeze
+        end
+      end
+
+      # Groups normalized workflow membership and derived step state fields.
+      class Membership
+        attr_reader :dependency_job_ids_by_job_id, :job_ids, :jobs, :step_job_ids, :step_states
+
+        def initialize(step_job_ids:, dependency_job_ids_by_job_id:, jobs:)
+          @step_job_ids = step_job_ids
+          @dependency_job_ids_by_job_id = dependency_job_ids_by_job_id
+          @jobs = jobs
+          validate_membership
+          @job_ids = jobs.map(&:id).freeze
+          @step_states = build_step_states
+          freeze
+        end
+
+        private
+
+        def validate_membership
+          snapshot_job_ids = jobs.map(&:id)
+          expected_job_ids = step_job_ids.values
+          return if snapshot_job_ids == expected_job_ids
+
+          raise InvalidExecutionError, 'step_job_ids must match jobs in order'
+        end
+
+        def build_step_states
+          jobs_by_id = jobs.to_h { |job| [job.id, job] }
+          step_job_ids.each_with_object({}) do |(step_id, job_id), states|
+            states[step_id] = jobs_by_id.fetch(job_id).state
+          end.freeze
+        end
+      end
+
+      # Groups snapshot state summary fields.
+      class SummaryData
+        attr_reader :completed_count, :failed_count, :state, :state_counts, :total_count
+
+        def initialize(membership)
+          jobs = membership.jobs
+          summary = Summary.new(jobs)
+          @state_counts = summary.state_counts
+          @total_count = jobs.length
+          @completed_count = summary.completed_count
+          @failed_count = summary.failed_count
+          @state = State.new(
+            jobs:,
+            dependency_job_ids_by_job_id: membership.dependency_job_ids_by_job_id
+          ).to_sym
+          freeze
+        end
+      end
+
+      # Normalizes timestamps into immutable values.
+      class Timestamp
+        def initialize(name, value)
+          @name = name
+          @value = value
+        end
+
+        def to_time
+          return value.dup.freeze if value.is_a?(Time)
+
+          raise InvalidExecutionError, "#{name} must be a Time"
+        end
+
+        private
+
+        attr_reader :name, :value
+      end
+
+      # Normalizes the ordered workflow step to job mapping.
+      class StepJobIds
+        def initialize(step_job_ids)
+          @step_job_ids = step_job_ids
+        end
+
+        def to_h
+          raise InvalidExecutionError, 'step_job_ids must be a Hash' unless step_job_ids.is_a?(Hash)
+          raise InvalidExecutionError, 'workflow snapshot must include at least one step' if step_job_ids.empty?
+
+          step_job_ids.each_with_object({}) do |(step_id, job_id), normalized|
+            normalized_step_id = Workflow.send(:normalize_execution_identifier, :step_id, step_id)
+            raise InvalidExecutionError, "duplicate workflow step #{normalized_step_id.inspect}" if normalized.key?(normalized_step_id)
+
+            normalized[normalized_step_id] = Workflow.send(:normalize_execution_identifier, :job_id, job_id)
+          end.freeze
+        end
+
+        private
+
+        attr_reader :step_job_ids
+      end
+
+      # Normalizes dependency metadata keyed by concrete job id.
+      class DependencyJobIds
+        def initialize(dependency_job_ids_by_job_id)
+          @dependency_job_ids_by_job_id = dependency_job_ids_by_job_id
+        end
+
+        def to_h
+          raise InvalidExecutionError, 'dependency_job_ids_by_job_id must be a Hash' unless dependency_job_ids_by_job_id.is_a?(Hash)
+
+          dependency_job_ids_by_job_id.each_with_object({}) do |(job_id, dependency_job_ids), normalized|
+            normalized_job_id = Workflow.send(:normalize_execution_identifier, :job_id, job_id)
+            raise InvalidExecutionError, 'dependency job ids must be an Array' unless dependency_job_ids.is_a?(Array)
+
+            normalized[normalized_job_id] = DependencyJobIdList.new(dependency_job_ids).to_a
+          end.freeze
+        end
+
+        private
+
+        attr_reader :dependency_job_ids_by_job_id
+      end
+
+      # Normalizes one prerequisite job id list.
+      class DependencyJobIdList
+        def initialize(dependency_job_ids)
+          @dependency_job_ids = dependency_job_ids
+        end
+
+        def to_a
+          dependency_job_ids.map do |dependency_job_id|
+            Workflow.send(:normalize_execution_identifier, :dependency_job_id, dependency_job_id)
+          end.freeze
+        end
+
+        private
+
+        attr_reader :dependency_job_ids
+      end
+
+      # Normalizes a snapshot job list while preserving current job objects.
+      class JobList
+        def initialize(jobs)
+          @jobs = jobs
+        end
+
+        def to_a
+          raise InvalidExecutionError, 'jobs must be an Array' unless jobs.is_a?(Array)
+          raise InvalidExecutionError, 'workflow snapshot must include at least one job' if jobs.empty?
+
+          jobs.each do |job|
+            raise InvalidExecutionError, 'jobs entries must be Karya::Job' unless job.is_a?(Job)
+          end
+          jobs.dup.freeze
+        end
+
+        private
+
+        attr_reader :jobs
+      end
+
+      # Summarizes current workflow job states.
+      class Summary
+        def initialize(jobs)
+          @jobs = jobs
+        end
+
+        def state_counts
+          @state_counts ||= jobs.each_with_object(Hash.new(0)) do |job, counts|
+            counts[job.state] += 1
+          end.freeze
+        end
+
+        def completed_count
+          jobs.count { |job| COMPLETED_STATES.include?(job.state) }
+        end
+
+        def failed_count
+          jobs.count { |job| FAILED_STATES.include?(job.state) }
+        end
+
+        private
+
+        attr_reader :jobs
+      end
+
+      # Wraps a job state query used by workflow state derivation.
+      class JobState
+        def initialize(job)
+          @job = job
+        end
+
+        def active?
+          !job.terminal? && !WAITING_STATES.include?(job.state)
+        end
+
+        private
+
+        attr_reader :job
+      end
+
+      # Derives workflow state from current job states and prerequisites.
+      class State
+        def initialize(jobs:, dependency_job_ids_by_job_id:)
+          @jobs = jobs
+          @dependency_job_ids_by_job_id = dependency_job_ids_by_job_id
+          @jobs_by_id = jobs.to_h { |job| [job.id, job] }
+        end
+
+        def to_sym
+          return :failed if failed?
+          return :succeeded if only_state?(:succeeded)
+          return :cancelled if only_state?(:cancelled)
+          return :failed if terminal_mixed?
+          return :running if running?
+          return :blocked if blocked?
+          return :running if progressed?
+
+          :pending
+        end
+
+        private
+
+        attr_reader :dependency_job_ids_by_job_id, :jobs, :jobs_by_id
+
+        def failed?
+          jobs.any? { |job| FAILED_STATES.include?(job.state) }
+        end
+
+        def only_state?(state)
+          jobs.all? { |job| job.state == state }
+        end
+
+        def terminal_mixed?
+          jobs.all?(&:terminal?)
+        end
+
+        def running?
+          jobs.any? { |job| JobState.new(job).active? }
+        end
+
+        def progressed?
+          jobs.any? { |job| !WAITING_STATES.include?(job.state) }
+        end
+
+        def blocked?
+          jobs.any? do |job|
+            WAITING_STATES.include?(job.state) && dependency_blocked?(job)
+          end
+        end
+
+        def dependency_blocked?(job)
+          dependency_job_ids_by_job_id.fetch(job.id, []).any? do |dependency_job_id|
+            dependency_job = jobs_by_id[dependency_job_id]
+            !dependency_job || dependency_job.state != :succeeded
+          end
+        end
+      end
+
+      private_constant :Attributes,
+                       :COMPLETED_STATES,
+                       :DependencyJobIdList,
+                       :DependencyJobIds,
+                       :FAILED_STATES,
+                       :Identity,
+                       :JobState,
+                       :JobList,
+                       :Membership,
+                       :REQUIRED_ATTRIBUTES,
+                       :State,
+                       :StepJobIds,
+                       :Summary,
+                       :SummaryData,
+                       :Timestamp,
+                       :WAITING_STATES
+
+      private
+
+      attr_reader :identity, :membership, :summary_data
+    end
+  end
+end

--- a/core/karya/sig/karya.rbs
+++ b/core/karya/sig/karya.rbs
@@ -25,6 +25,7 @@ module Karya
   type normalized_state_name = String
   type normalized_state_name_array = Array[normalized_state_name]
   type normalized_transition_map = Hash[normalized_state_name, normalized_state_name_array]
+  type workflow_snapshot_attribute_value = state_name | Time | Hash[state_name, state_name] | Hash[state_name, state_name_array] | Array[Job]
   type handler_parameter = [Symbol, Symbol?]
   type handler_parameters = Array[handler_parameter]
   type handler_dispatch_mode = :none | :positional_hash | :keywords
@@ -187,6 +188,7 @@ module Karya
   type queue_control_action = :pause_queue | :resume_queue
   type bulk_skip_reason = :not_found | :ineligible_state | :duplicate_request | :uniqueness_conflict
   type batch_aggregate_state = :failed | :running | :succeeded | :cancelled | :completed
+  type workflow_state = :pending | :running | :blocked | :succeeded | :failed | :cancelled
   type bulk_skipped_job = {
     job_id: String,
     reason: bulk_skip_reason,

--- a/core/karya/sig/karya/queue_store/base.rbs
+++ b/core/karya/sig/karya/queue_store/base.rbs
@@ -20,6 +20,8 @@ module Karya
         now: Time
       ) -> BulkMutationReport
 
+      def workflow_snapshot: (batch_id: Karya::state_name, now: Time) -> Karya::Workflow::Snapshot
+
       def reserve: (
         worker_id: String,
         lease_duration: Karya::lease_duration_value,

--- a/core/karya/sig/karya/queue_store/in_memory.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory.rbs
@@ -43,6 +43,7 @@ module Karya
         batch_id: Karya::state_name,
         now: Time
       ) -> BulkMutationReport
+      def workflow_snapshot: (batch_id: Karya::state_name, now: Time) -> Karya::Workflow::Snapshot
       def reserve: (
         worker_id: String,
         lease_duration: Karya::lease_duration_value,
@@ -146,6 +147,7 @@ module Karya
       ) -> Reservation
       def track_fairness_history?: (Array[String] queues) -> bool
       def raise_expired_reservation_error: (String reservation_token, String reservation_label) -> nil
+      def fetch_workflow_registration: (String batch_id) -> Internal::StoreState::WorkflowRegistration
       def workflow_dependencies_satisfied?: (Job job) -> bool
     end
   end

--- a/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
@@ -80,7 +80,12 @@ module Karya
           def reservation_token_in_use?: (String reservation_token) -> bool
           def register_batch: (Karya::Workflow::Batch batch) -> Karya::Workflow::Batch
           def prune_terminal_batches: (Integer retention_limit, ?changed_job: Job?) -> Array[String]
-          def register_workflow: (batch_id: String, workflow_id: String, step_job_ids: Hash[String, String]) -> WorkflowRegistration
+          def register_workflow: (
+            batch_id: String,
+            workflow_id: String,
+            step_job_ids: Hash[String, String],
+            dependency_job_ids_by_job_id: Hash[String, Array[String]]
+          ) -> WorkflowRegistration
 
           private
 
@@ -89,9 +94,47 @@ module Karya
           class WorkflowRegistration
             @workflow_id: String
             @step_job_ids: Hash[String, String]
+            @dependency_job_ids_by_job_id: Hash[String, Array[String]]
 
             attr_reader workflow_id: String
             attr_reader step_job_ids: Hash[String, String]
+            attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
+          end
+
+          class PrunedBatchCleanup
+            @batch_id: String
+            @batch: Karya::Workflow::Batch?
+            @batch_id_by_job_id: Hash[String, String]
+            @workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            @workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+
+            def self.call: (
+              batch_id: String,
+              batch: Karya::Workflow::Batch?,
+              batch_id_by_job_id: Hash[String, String],
+              workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]],
+              workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+            ) -> WorkflowRegistration?
+            def initialize: (
+              batch_id: String,
+              batch: Karya::Workflow::Batch?,
+              batch_id_by_job_id: Hash[String, String],
+              workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]],
+              workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+            ) -> void
+            def call: () -> WorkflowRegistration?
+
+            private
+
+            attr_reader batch: Karya::Workflow::Batch?
+            attr_reader batch_id: String
+            attr_reader batch_id_by_job_id: Hash[String, String]
+            attr_reader workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            attr_reader workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+
+            def pruned_job_ids: () -> Array[String]?
+            def cleanup_batch_jobs: () -> Array[String]?
+            def cleanup_stale_batch_membership: () -> Hash[String, String]
           end
 
           def trim_fair_queue_history: () -> void

--- a/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
@@ -30,6 +30,7 @@ module Karya
           @terminal_batch_ids_index: Hash[String, bool]
           @terminal_batch_ids_in_order: Array[String]
           @workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+          @workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
 
           attr_reader breaker_failures_by_scope: Hash[String, Array[Time]]
           attr_reader batches_by_id: Hash[String, Karya::Workflow::Batch]
@@ -51,6 +52,7 @@ module Karya
           attr_reader reservations_by_token: Hash[String, Reservation]
           attr_reader stuck_job_recoveries_by_id: Hash[String, Karya::stuck_job_recovery]
           attr_reader workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+          attr_reader workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
 
           def initialize: (expired_tombstone_limit: Integer) -> void
           def queue_job_ids_for: (String queue) -> Array[String]
@@ -78,11 +80,20 @@ module Karya
           def reservation_token_in_use?: (String reservation_token) -> bool
           def register_batch: (Karya::Workflow::Batch batch) -> Karya::Workflow::Batch
           def prune_terminal_batches: (Integer retention_limit, ?changed_job: Job?) -> Array[String]
-          def register_workflow_dependencies: (Hash[String, Array[String]] dependency_job_ids_by_job_id) -> Hash[String, Array[String]]
+          def register_workflow: (batch_id: String, workflow_id: String, step_job_ids: Hash[String, String]) -> WorkflowRegistration
 
           private
 
           def terminal_batch?: (Karya::Workflow::Batch batch) -> bool
+
+          class WorkflowRegistration
+            @workflow_id: String
+            @step_job_ids: Hash[String, String]
+
+            attr_reader workflow_id: String
+            attr_reader step_job_ids: Hash[String, String]
+          end
+
           def trim_fair_queue_history: () -> void
           def prune_expired_reservation_tokens: () -> bool?
         end

--- a/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
@@ -96,6 +96,12 @@ module Karya
             @step_job_ids: Hash[String, String]
             @dependency_job_ids_by_job_id: Hash[String, Array[String]]
 
+            def initialize: (
+              String workflow_id,
+              Hash[String, String] step_job_ids,
+              Hash[String, Array[String]] dependency_job_ids_by_job_id
+            ) -> void
+
             attr_reader workflow_id: String
             attr_reader step_job_ids: Hash[String, String]
             attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]

--- a/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
@@ -134,7 +134,7 @@ module Karya
 
             def pruned_job_ids: () -> Array[String]?
             def cleanup_batch_jobs: () -> Array[String]?
-            def cleanup_stale_batch_membership: () -> Hash[String, String]
+            def cleanup_stale_batch_membership: () -> Array[String]
           end
 
           def trim_fair_queue_history: () -> void

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -9,9 +9,24 @@ module Karya
             batch_id: Karya::state_name,
             now: Time
           ) -> BulkMutationReport
+          def workflow_snapshot: (batch_id: Karya::state_name, now: Time) -> Karya::Workflow::Snapshot
 
           private
 
+          class StepJobIds
+            @definition: Karya::Workflow::Definition
+            @jobs: Array[Job]
+
+            def initialize: (definition: Karya::Workflow::Definition, jobs: Array[Job]) -> void
+            def to_h: () -> Hash[String, String]
+
+          private
+
+            attr_reader definition: Karya::Workflow::Definition
+            attr_reader jobs: Array[Job]
+          end
+
+          def fetch_workflow_registration: (String batch_id) -> InMemory::Internal::StoreState::WorkflowRegistration
           def workflow_dependencies_satisfied?: (Job job) -> bool
         end
       end

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -168,6 +168,210 @@ module Karya
       def validate_membership: () -> void
     end
 
+    class Snapshot
+      @identity: Identity
+      @membership: Membership
+      @summary_data: SummaryData
+
+      def initialize: (
+        workflow_id: state_name,
+        batch_id: state_name,
+        captured_at: Time,
+        step_job_ids: Hash[state_name, state_name],
+        dependency_job_ids_by_job_id: Hash[state_name, Array[state_name]],
+        jobs: Array[Job]
+      ) -> void
+
+      def workflow_id: () -> String
+      def batch_id: () -> String
+      def captured_at: () -> Time
+      def job_ids: () -> Array[String]
+      def jobs: () -> Array[Job]
+      def step_states: () -> Hash[String, state_name]
+      def state_counts: () -> Hash[state_name, Integer]
+      def total_count: () -> Integer
+      def completed_count: () -> Integer
+      def failed_count: () -> Integer
+      def state: () -> Karya::workflow_state
+
+    private
+
+      attr_reader identity: Identity
+      attr_reader membership: Membership
+      attr_reader summary_data: SummaryData
+
+      class Attributes
+        @attributes: Hash[Symbol, workflow_snapshot_attribute_value]
+
+        def initialize: (Hash[Symbol, workflow_snapshot_attribute_value] attributes) -> void
+        def fetch: (Symbol name) -> workflow_snapshot_attribute_value
+        def identity: () -> Identity
+        def membership: () -> Membership
+
+      private
+
+        attr_reader attributes: Hash[Symbol, workflow_snapshot_attribute_value]
+        def validate_keys: () -> void
+      end
+
+      class Identity
+        @workflow_id: String
+        @batch_id: String
+        @captured_at: Time
+
+        attr_reader workflow_id: String
+        attr_reader batch_id: String
+        attr_reader captured_at: Time
+
+        def initialize: (workflow_id: String, batch_id: String, captured_at: Time) -> void
+      end
+
+      class Membership
+        @step_job_ids: Hash[String, String]
+        @dependency_job_ids_by_job_id: Hash[String, Array[String]]
+        @jobs: Array[Job]
+        @job_ids: Array[String]
+        @step_states: Hash[String, state_name]
+
+        attr_reader step_job_ids: Hash[String, String]
+        attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
+        attr_reader jobs: Array[Job]
+        attr_reader job_ids: Array[String]
+        attr_reader step_states: Hash[String, state_name]
+
+        def initialize: (
+          step_job_ids: Hash[String, String],
+          dependency_job_ids_by_job_id: Hash[String, Array[String]],
+          jobs: Array[Job]
+        ) -> void
+
+      private
+
+        def validate_membership: () -> void
+        def build_step_states: () -> Hash[String, state_name]
+      end
+
+      class SummaryData
+        @state_counts: Hash[state_name, Integer]
+        @total_count: Integer
+        @completed_count: Integer
+        @failed_count: Integer
+        @state: Karya::workflow_state
+
+        attr_reader state_counts: Hash[state_name, Integer]
+        attr_reader total_count: Integer
+        attr_reader completed_count: Integer
+        attr_reader failed_count: Integer
+        attr_reader state: Karya::workflow_state
+
+        def initialize: (Membership membership) -> void
+      end
+
+      class Timestamp
+        @name: Symbol
+        @value: Time
+
+        def initialize: (Symbol name, Time value) -> void
+        def to_time: () -> Time
+
+      private
+
+        attr_reader name: Symbol
+        attr_reader value: Time
+      end
+
+      class StepJobIds
+        @step_job_ids: Hash[state_name, state_name]
+
+        def initialize: (Hash[state_name, state_name] step_job_ids) -> void
+        def to_h: () -> Hash[String, String]
+
+      private
+
+        attr_reader step_job_ids: Hash[state_name, state_name]
+      end
+
+      class DependencyJobIds
+        @dependency_job_ids_by_job_id: Hash[state_name, Array[state_name]]
+
+        def initialize: (Hash[state_name, Array[state_name]] dependency_job_ids_by_job_id) -> void
+        def to_h: () -> Hash[String, Array[String]]
+
+      private
+
+        attr_reader dependency_job_ids_by_job_id: Hash[state_name, Array[state_name]]
+      end
+
+      class DependencyJobIdList
+        @dependency_job_ids: Array[state_name]
+
+        def initialize: (Array[state_name] dependency_job_ids) -> void
+        def to_a: () -> Array[String]
+
+      private
+
+        attr_reader dependency_job_ids: Array[state_name]
+      end
+
+      class JobList
+        @jobs: Array[Job]
+
+        def initialize: (Array[Job] jobs) -> void
+        def to_a: () -> Array[Job]
+
+      private
+
+        attr_reader jobs: Array[Job]
+      end
+
+      class Summary
+        @jobs: Array[Job]
+        @state_counts: Hash[state_name, Integer]?
+
+        def initialize: (Array[Job] jobs) -> void
+        def state_counts: () -> Hash[state_name, Integer]
+        def completed_count: () -> Integer
+        def failed_count: () -> Integer
+
+      private
+
+        attr_reader jobs: Array[Job]
+      end
+
+      class JobState
+        @job: Job
+
+        def initialize: (Job job) -> void
+        def active?: () -> bool
+
+      private
+
+        attr_reader job: Job
+      end
+
+      class State
+        @jobs: Array[Job]
+        @dependency_job_ids_by_job_id: Hash[String, Array[String]]
+        @jobs_by_id: Hash[String, Job]
+
+        def initialize: (jobs: Array[Job], dependency_job_ids_by_job_id: Hash[String, Array[String]]) -> void
+        def to_sym: () -> Karya::workflow_state
+
+      private
+
+        attr_reader jobs: Array[Job]
+        attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
+        attr_reader jobs_by_id: Hash[String, Job]
+        def failed?: () -> bool
+        def only_state?: (state_name state) -> bool
+        def terminal_mixed?: () -> bool
+        def running?: () -> bool
+        def progressed?: () -> bool
+        def blocked?: () -> bool
+        def dependency_blocked?: (Job job) -> bool
+      end
+    end
+
     class Dependency
       @step_id: String
       @depends_on_step_id: String

--- a/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
@@ -145,16 +145,26 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
   end
 
   it 'stores workflow registrations by batch id' do
+    step_job_ids = { 'root' => 'job-root' }
+    dependency_job_ids = []
+    dependency_job_ids_by_job_id = { 'job-root' => dependency_job_ids }
+
     registration = store_state.register_workflow(
       batch_id: 'batch-1',
       workflow_id: 'invoice_closeout',
-      step_job_ids: { 'root' => 'job-root' },
-      dependency_job_ids_by_job_id: { 'job-root' => [] }
+      step_job_ids:,
+      dependency_job_ids_by_job_id:
     )
+    step_job_ids['root'] = 'mutated'
+    dependency_job_ids << 'mutated'
+    dependency_job_ids_by_job_id['job-root'] = ['mutated']
 
     expect(registration.workflow_id).to eq('invoice_closeout')
     expect(registration.step_job_ids).to eq('root' => 'job-root')
     expect(registration.dependency_job_ids_by_job_id).to eq('job-root' => [])
+    expect(registration.step_job_ids).to be_frozen
+    expect(registration.dependency_job_ids_by_job_id).to be_frozen
+    expect(registration.dependency_job_ids_by_job_id.fetch('job-root')).to be_frozen
     expect(registration).to be_frozen
     expect(store_state.workflow_registrations_by_batch_id['batch-1']).to eq(registration)
     expect(store_state.workflow_registrations_by_batch_id['missing']).to be_nil

--- a/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
@@ -88,11 +88,18 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
   it 'removes stale job batch membership when pruning a missing batch entry' do
     store_state.jobs_by_id['job-1'] = succeeded_job('job-1')
     store_state.register_batch(batch('batch-1', ['job-1']))
+    store_state.register_workflow(
+      batch_id: 'batch-1',
+      workflow_id: 'invoice_closeout',
+      step_job_ids: { 'root' => 'job-1' },
+      dependency_job_ids_by_job_id: { 'job-1' => [] }
+    )
     store_state.batches_by_id.delete('batch-1')
 
     store_state.prune_terminal_batches(0)
 
     expect(store_state.instance_variable_get(:@batch_id_by_job_id)).to eq({})
+    expect(store_state.workflow_registrations_by_batch_id).to eq({})
   end
 
   it 'leaves stale changed-job batch membership for explicit pruning cleanup' do
@@ -137,13 +144,37 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
     registration = store_state.register_workflow(
       batch_id: 'batch-1',
       workflow_id: 'invoice_closeout',
-      step_job_ids: { 'root' => 'job-root' }
+      step_job_ids: { 'root' => 'job-root' },
+      dependency_job_ids_by_job_id: { 'job-root' => [] }
     )
 
     expect(registration.workflow_id).to eq('invoice_closeout')
     expect(registration.step_job_ids).to eq('root' => 'job-root')
+    expect(registration.dependency_job_ids_by_job_id).to eq('job-root' => [])
     expect(registration).to be_frozen
     expect(store_state.workflow_registrations_by_batch_id['batch-1']).to eq(registration)
     expect(store_state.workflow_registrations_by_batch_id['missing']).to be_nil
+  end
+
+  it 'removes workflow metadata when pruning terminal batches' do
+    store_state.jobs_by_id['job-root'] = succeeded_job('job-root')
+    store_state.jobs_by_id['job-child'] = succeeded_job('job-child')
+    store_state.register_batch(batch('batch-1', %w[job-root job-child]))
+    store_state.workflow_dependency_job_ids_by_job_id['job-root'] = []
+    store_state.workflow_dependency_job_ids_by_job_id['job-child'] = ['job-root']
+    store_state.register_workflow(
+      batch_id: 'batch-1',
+      workflow_id: 'invoice_closeout',
+      step_job_ids: { 'root' => 'job-root', 'child' => 'job-child' },
+      dependency_job_ids_by_job_id: {
+        'job-root' => [],
+        'job-child' => ['job-root']
+      }
+    )
+
+    expect(store_state.prune_terminal_batches(0)).to eq(['batch-1'])
+
+    expect(store_state.workflow_registrations_by_batch_id).to eq({})
+    expect(store_state.workflow_dependency_job_ids_by_job_id).to eq({})
   end
 end

--- a/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
@@ -133,13 +133,17 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
     expect(store_state.batches_by_id.keys).to eq(['batch-1'])
   end
 
-  it 'stores workflow dependency metadata by job id' do
-    dependencies = { 'job-1' => [], 'job-2' => ['job-1'] }
+  it 'stores workflow registrations by batch id' do
+    registration = store_state.register_workflow(
+      batch_id: 'batch-1',
+      workflow_id: 'invoice_closeout',
+      step_job_ids: { 'root' => 'job-root' }
+    )
 
-    store_state.register_workflow_dependencies(dependencies)
-
-    expect(store_state.workflow_dependency_job_ids_by_job_id['job-1']).to eq([])
-    expect(store_state.workflow_dependency_job_ids_by_job_id['job-2']).to eq(['job-1'])
-    expect(store_state.workflow_dependency_job_ids_by_job_id['missing']).to be_nil
+    expect(registration.workflow_id).to eq('invoice_closeout')
+    expect(registration.step_job_ids).to eq('root' => 'job-root')
+    expect(registration).to be_frozen
+    expect(store_state.workflow_registrations_by_batch_id['batch-1']).to eq(registration)
+    expect(store_state.workflow_registrations_by_batch_id['missing']).to be_nil
   end
 end

--- a/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
@@ -88,18 +88,22 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
   it 'removes stale job batch membership when pruning a missing batch entry' do
     store_state.jobs_by_id['job-1'] = succeeded_job('job-1')
     store_state.register_batch(batch('batch-1', ['job-1']))
+    store_state.register_batch(batch('batch-2', ['job-2']))
     store_state.register_workflow(
       batch_id: 'batch-1',
       workflow_id: 'invoice_closeout',
       step_job_ids: { 'root' => 'job-1' },
       dependency_job_ids_by_job_id: { 'job-1' => [] }
     )
+    store_state.workflow_dependency_job_ids_by_job_id['job-1'] = []
+    store_state.workflow_dependency_job_ids_by_job_id['job-2'] = []
     store_state.batches_by_id.delete('batch-1')
 
     store_state.prune_terminal_batches(0)
 
-    expect(store_state.instance_variable_get(:@batch_id_by_job_id)).to eq({})
+    expect(store_state.instance_variable_get(:@batch_id_by_job_id)).to eq('job-2' => 'batch-2')
     expect(store_state.workflow_registrations_by_batch_id).to eq({})
+    expect(store_state.workflow_dependency_job_ids_by_job_id).to eq('job-2' => [])
   end
 
   it 'leaves stale changed-job batch membership for explicit pruning cleanup' do

--- a/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
   it 'treats non-workflow jobs and root workflow jobs as ready' do
     plain_job = job(id: 'job-1', state: :queued)
     root_job = job(id: 'job-2', state: :queued)
-    store.send(:state).register_workflow_dependencies('job-2' => [])
+    store.send(:state).workflow_dependency_job_ids_by_job_id['job-2'] = []
 
     expect(store.send(:workflow_dependencies_satisfied?, plain_job)).to be(true)
     expect(store.send(:workflow_dependencies_satisfied?, root_job)).to be(true)
@@ -29,7 +29,7 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
     queued = job(id: 'job-2', state: :queued)
     store.send(:state).jobs_by_id['job-1'] = succeeded
     store.send(:state).jobs_by_id['job-2'] = queued
-    store.send(:state).register_workflow_dependencies('job-3' => %w[job-1 job-2])
+    store.send(:state).workflow_dependency_job_ids_by_job_id['job-3'] = %w[job-1 job-2]
 
     expect(store.send(:workflow_dependencies_satisfied?, dependent)).to be(false)
 
@@ -42,8 +42,32 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
 
   it 'treats missing prerequisite jobs as blocked' do
     dependent = job(id: 'job-2', state: :queued)
-    store.send(:state).register_workflow_dependencies('job-2' => ['missing'])
+    store.send(:state).workflow_dependency_job_ids_by_job_id['job-2'] = ['missing']
 
     expect(store.send(:workflow_dependencies_satisfied?, dependent)).to be(false)
+  end
+
+  it 'builds step-to-job metadata in workflow definition order' do
+    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
+    workflow_support = internal.const_get(:WorkflowSupport, false)
+    helper = workflow_support.const_get(:StepJobIds, false)
+    definition = Karya::Workflow.define(:ordered) do
+      step :first, handler: :sync_billing
+      step :second, handler: :sync_billing
+    end
+
+    result = helper.new(
+      definition:,
+      jobs: [job(id: 'job-1', state: :submission), job(id: 'job-2', state: :submission)]
+    ).to_h
+
+    expect(result).to eq('first' => 'job-1', 'second' => 'job-2')
+    expect(result).to be_frozen
+  end
+
+  it 'raises workflow-domain errors for non-workflow batches' do
+    expect do
+      store.send(:fetch_workflow_registration, 'batch-1')
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'batch "batch-1" is not a workflow batch')
   end
 end

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -275,6 +275,43 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect(ready.state).to eq(:running)
     end
 
+    it 'runs in-flight maintenance before building workflow snapshots' do
+      definition = Karya::Workflow.define(:snapshot_recovery) do
+        step :root, handler: :root
+        step :child, handler: :child, depends_on: :root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root), child: workflow_job(:child) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      reserve(2)
+
+      snapshot = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 63)
+
+      expect(snapshot.step_states).to eq('root' => :queued, 'child' => :queued)
+      expect(snapshot.state).to eq(:blocked)
+    end
+
+    it 'limits workflow snapshot dependency metadata to the workflow batch' do
+      definition = Karya::Workflow.define(:snapshot_scope) do
+        step :root, handler: :root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      store.send(:state).workflow_dependency_job_ids_by_job_id['outside-job'] = 'invalid'
+
+      snapshot = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 2)
+
+      expect(snapshot.job_ids).to eq(['job-root'])
+      expect(snapshot.state).to eq(:pending)
+    end
+
     it 'snapshots fan-out and fan-in states' do
       definition = Karya::Workflow.define(:snapshot_fan_in) do
         step :capture, handler: :capture

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -245,6 +245,99 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect(reserve(6, handler_names: ['child']).job_id).to eq('job-child')
     end
 
+    it 'registers workflow metadata and snapshots chain progress' do
+      definition = Karya::Workflow.define(:snapshot_chain) do
+        step :root, handler: :root
+        step :child, handler: :child, depends_on: :root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root), child: workflow_job(:child) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+
+      blocked = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 2)
+      expect(blocked).to have_attributes(
+        workflow_id: 'snapshot_chain',
+        batch_id: 'batch_one',
+        job_ids: %w[job-root job-child],
+        step_states: { 'root' => :queued, 'child' => :queued },
+        state: :blocked
+      )
+
+      root = reserve(3)
+      expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 4).state).to eq(:running)
+      run_successfully(root, start_offset: 5, complete_offset: 6)
+
+      ready = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 7)
+      expect(ready.step_states).to eq('root' => :succeeded, 'child' => :queued)
+      expect(ready.state).to eq(:running)
+    end
+
+    it 'snapshots fan-out and fan-in states' do
+      definition = Karya::Workflow.define(:snapshot_fan_in) do
+        step :capture, handler: :capture
+        step :pack, handler: :pack
+        step :notify, handler: :notify, depends_on: %i[capture pack]
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: {
+          capture: workflow_job(:capture),
+          pack: workflow_job(:pack),
+          notify: workflow_job(:notify)
+        },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      capture = reserve(2)
+      pack = reserve(3)
+
+      expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 4).state).to eq(:running)
+      run_successfully(capture, start_offset: 5, complete_offset: 6)
+      expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 7).state).to eq(:running)
+      run_successfully(pack, start_offset: 8, complete_offset: 9)
+
+      expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 10).state).to eq(:running)
+    end
+
+    it 'moves failed workflows out of failed when prerequisite jobs are retried' do
+      definition = Karya::Workflow.define(:snapshot_retry) do
+        step :root, handler: :root
+        step :child, handler: :child, depends_on: :root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root), child: workflow_job(:child) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      root = reserve(2)
+      store.start_execution(reservation_token: root.token, now: created_at + 3)
+      store.fail_execution(reservation_token: root.token, now: created_at + 4, failure_classification: :error)
+      expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 5).state).to eq(:failed)
+
+      store.retry_jobs(job_ids: ['job-root'], now: created_at + 6)
+      expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 7).state).to eq(:blocked)
+      retried_root = reserve(8)
+      run_successfully(retried_root, start_offset: 9, complete_offset: 10)
+
+      expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 11).state).to eq(:running)
+    end
+
+    it 'reports workflow snapshot errors for unknown and non-workflow batches' do
+      expect do
+        store.workflow_snapshot(batch_id: :missing, now: created_at + 1)
+      end.to raise_error(Karya::Workflow::UnknownBatchError, 'batch "missing" is not registered')
+
+      store.enqueue_many(jobs: [workflow_job(:root)], batch_id: :plain_batch, now: created_at + 2)
+
+      expect do
+        store.workflow_snapshot(batch_id: :plain_batch, now: created_at + 3)
+      end.to raise_error(Karya::Workflow::InvalidExecutionError, 'batch "plain_batch" is not a workflow batch')
+    end
+
     it 'rejects invalid workflow bindings without partial writes' do
       definition = Karya::Workflow.define(:invalid_binding) do
         step :root, handler: :root
@@ -260,6 +353,8 @@ RSpec.describe Karya::QueueStore::InMemory do
       end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow step "root" job handler must match workflow step handler')
 
       expect { store.batch_snapshot(batch_id: :batch_one, now: created_at + 2) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one" is not registered')
+      expect { store.workflow_snapshot(batch_id: :batch_one, now: created_at + 2) }
         .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one" is not registered')
       expect(reserve(3)).to be_nil
     end

--- a/core/karya/spec/karya/queue_store_base_spec.rb
+++ b/core/karya/spec/karya/queue_store_base_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe Karya::QueueStore do
     end.to raise_error(NotImplementedError, /implement #enqueue_workflow/)
   end
 
+  it 'requires workflow_snapshot to be implemented' do
+    expect do
+      store.workflow_snapshot(batch_id: 'batch-1', now: Time.utc(2026, 3, 27, 12, 0, 0))
+    end.to raise_error(NotImplementedError, /implement #workflow_snapshot/)
+  end
+
   it 'requires reserve to be implemented' do
     expect do
       store.reserve(

--- a/core/karya/spec/karya/workflow/snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/snapshot_spec.rb
@@ -166,6 +166,10 @@ RSpec.describe Karya::Workflow::Snapshot do
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'dependency job ids must be an Array')
 
     expect do
+      snapshot(jobs:, dependencies: { 'job_root' => [], ' job_root ' => [] })
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'duplicate dependency job id "job_root"')
+
+    expect do
       snapshot(jobs:, step_job_ids: { root: 'job_other' })
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'step_job_ids must match jobs in order')
   end

--- a/core/karya/spec/karya/workflow/snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/snapshot_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+RSpec.describe Karya::Workflow::Snapshot do
+  let(:captured_at) { Time.utc(2026, 4, 24, 12, 0, 0) }
+
+  around do |example|
+    Karya::JobLifecycle.send(:clear_extensions!)
+    example.run
+    Karya::JobLifecycle.send(:clear_extensions!)
+  end
+
+  def job(id:, state:)
+    Karya::Job.new(id:, queue: :billing, handler: :sync_billing, state:, created_at: captured_at)
+  end
+
+  def snapshot(jobs:, step_job_ids: nil, dependencies: {})
+    described_class.new(
+      workflow_id: ' invoice_closeout ',
+      batch_id: ' batch_1 ',
+      captured_at:,
+      step_job_ids: step_job_ids || jobs.to_h { |workflow_job| [workflow_job.id.delete_prefix('job_'), workflow_job.id] },
+      dependency_job_ids_by_job_id: dependencies,
+      jobs:
+    )
+  end
+
+  it 'builds an immutable workflow snapshot' do
+    jobs = [job(id: 'job_root', state: :succeeded), job(id: 'job_child', state: :queued)]
+
+    result = snapshot(jobs:, step_job_ids: { root: 'job_root', child: 'job_child' }, dependencies: { 'job_child' => ['job_root'] })
+
+    expect(result).to have_attributes(
+      workflow_id: 'invoice_closeout',
+      batch_id: 'batch_1',
+      captured_at:,
+      job_ids: %w[job_root job_child],
+      step_states: { 'root' => :succeeded, 'child' => :queued },
+      state_counts: { succeeded: 1, queued: 1 },
+      total_count: 2,
+      completed_count: 1,
+      failed_count: 0,
+      state: :running
+    )
+    expect(result).to be_frozen
+    expect(result.jobs).to be_frozen
+    expect(result.step_states).to be_frozen
+    expect(result.state_counts).to be_frozen
+  end
+
+  it 'rejects invalid identifiers and timestamps' do
+    jobs = [job(id: 'job_root', state: :queued)]
+
+    expect do
+      described_class.new(
+        workflow_id: nil,
+        batch_id: :batch,
+        captured_at:,
+        step_job_ids: { root: 'job_root' },
+        dependency_job_ids_by_job_id: {},
+        jobs:
+      )
+    end.to raise_error(Karya::Workflow::InvalidDefinitionError, 'workflow_id must be present')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: nil,
+        captured_at:,
+        step_job_ids: { root: 'job_root' },
+        dependency_job_ids_by_job_id: {},
+        jobs:
+      )
+    end.to raise_error(Karya::Workflow::InvalidBatchError, 'batch_id must be present')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        captured_at: 'now',
+        step_job_ids: { root: 'job_root' },
+        dependency_job_ids_by_job_id: {},
+        jobs:
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'captured_at must be a Time')
+  end
+
+  it 'validates step mappings and job lists' do
+    jobs = [job(id: 'job_root', state: :queued)]
+
+    expect do
+      snapshot(jobs:, step_job_ids: 'root')
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'step_job_ids must be a Hash')
+
+    expect do
+      snapshot(jobs:, step_job_ids: {})
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow snapshot must include at least one step')
+
+    expect do
+      snapshot(jobs:, step_job_ids: { root: 'job_root', ' root ' => 'job_root' })
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'duplicate workflow step "root"')
+
+    expect do
+      snapshot(jobs:, step_job_ids: { root: nil })
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'job_id must be present')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        captured_at:,
+        step_job_ids: { root: 'job_root' },
+        dependency_job_ids_by_job_id: {},
+        jobs: 'job_root'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'jobs must be an Array')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        captured_at:,
+        step_job_ids: { root: 'job_root' },
+        dependency_job_ids_by_job_id: {},
+        jobs: []
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow snapshot must include at least one job')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        captured_at:,
+        step_job_ids: { root: 'job_root' },
+        dependency_job_ids_by_job_id: {},
+        jobs: ['job_root']
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'jobs entries must be Karya::Job')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        captured_at:,
+        step_job_ids: { root: 'job_root' },
+        dependency_job_ids_by_job_id: {},
+        jobs:,
+        unexpected: true
+      )
+    end.to raise_error(ArgumentError, 'unknown keyword: :unexpected')
+  end
+
+  it 'validates dependency mappings and membership' do
+    jobs = [job(id: 'job_root', state: :queued)]
+
+    expect do
+      snapshot(jobs:, dependencies: 'job_root')
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'dependency_job_ids_by_job_id must be a Hash')
+
+    expect do
+      snapshot(jobs:, dependencies: { 'job_root' => 'missing' })
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'dependency job ids must be an Array')
+
+    expect do
+      snapshot(jobs:, step_job_ids: { root: 'job_other' })
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'step_job_ids must match jobs in order')
+  end
+
+  it 'derives workflow states' do
+    expect(snapshot(jobs: [job(id: 'job_root', state: :queued)]).state).to eq(:pending)
+    expect(snapshot(jobs: [job(id: 'job_root', state: :reserved)]).state).to eq(:running)
+    expect(snapshot(jobs: [job(id: 'job_root', state: :running)]).state).to eq(:running)
+    expect(snapshot(jobs: [job(id: 'job_root', state: :retry_pending)]).state).to eq(:running)
+    expect(snapshot(jobs: [job(id: 'job_root', state: :succeeded)]).state).to eq(:succeeded)
+    expect(snapshot(jobs: [job(id: 'job_root', state: :cancelled)]).state).to eq(:cancelled)
+    expect(snapshot(jobs: [job(id: 'job_root', state: :failed)]).state).to eq(:failed)
+    expect(snapshot(jobs: [job(id: 'job_root', state: :dead_letter)]).state).to eq(:failed)
+  end
+
+  it 'treats completed progress with ready queued work as running' do
+    result = snapshot(
+      jobs: [job(id: 'job_root', state: :succeeded), job(id: 'job_child', state: :queued)],
+      step_job_ids: { root: 'job_root', child: 'job_child' },
+      dependencies: { 'job_child' => ['job_root'] }
+    )
+
+    expect(result.state).to eq(:running)
+  end
+
+  it 'derives blocked and terminal mixed workflow states' do
+    root = job(id: 'job_root', state: :queued)
+    child = job(id: 'job_child', state: :queued)
+
+    blocked = snapshot(
+      jobs: [root, child],
+      step_job_ids: { root: 'job_root', child: 'job_child' },
+      dependencies: { 'job_child' => ['job_root'] }
+    )
+    expect(blocked.state).to eq(:blocked)
+
+    missing_dependency = snapshot(
+      jobs: [child],
+      step_job_ids: { child: 'job_child' },
+      dependencies: { 'job_child' => ['missing'] }
+    )
+    expect(missing_dependency.state).to eq(:blocked)
+
+    terminal_mixed = snapshot(
+      jobs: [job(id: 'job_root', state: :succeeded), job(id: 'job_child', state: :cancelled)],
+      step_job_ids: { root: 'job_root', child: 'job_child' }
+    )
+    expect(terminal_mixed.state).to eq(:failed)
+  end
+
+  it 'treats custom nonterminal lifecycle states as running' do
+    Karya::JobLifecycle.register_state(:awaiting_review)
+
+    expect(snapshot(jobs: [job(id: 'job_root', state: :awaiting_review)]).state).to eq(:running)
+  end
+end

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -70,6 +70,8 @@ operator search and governance layers choose targets:
   immutable, and aggregate batch state is inspected from current member jobs
 - workflow enqueue stores all step jobs in one immutable batch and gates
   reservation of dependent steps until prerequisite jobs have succeeded
+- workflow snapshots derive workflow state from stored workflow metadata and
+  current member job states without mutating the batch membership
 - bulk retry returns failed or `retry_pending` jobs to normal queued execution
   when they are still eligible and uniqueness-safe
 - bulk cancellation can stop queued, retry-pending, reserved, or running jobs;

--- a/docs/pages/workflows/basics.md
+++ b/docs/pages/workflows/basics.md
@@ -51,6 +51,18 @@ queued prerequisite jobs do not unblock dependent steps. Retry can still move a
 failed prerequisite back through normal execution; once that prerequisite
 succeeds, dependent queued work becomes eligible.
 
+Workflow snapshots expose the current workflow state separately from the batch
+aggregate state:
+
+- `pending` when steps are queued and ready but not yet active
+- `running` while at least one step is active, or workflow progress has made
+  queued follow-up work eligible
+- `blocked` when queued dependent steps are waiting on prerequisites
+- `succeeded` when every step succeeded
+- `cancelled` when every step was cancelled
+- `failed` when a step failed, was dead-lettered, or terminal mixed outcomes
+  prevent workflow success
+
 ### Batch Identity And Aggregate State
 
 Workflow batches give related runtime jobs one stable identity. Batch creation


### PR DESCRIPTION
- Introduced a new `Snapshot` class to provide an immutable view of a workflow's state at a specific point in time.
- The snapshot includes attributes such as `workflow_id`, `batch_id`, `captured_at`, `step_job_ids`, and `jobs`.
- Added methods to derive the current state of the workflow based on the states of its jobs, including states like `pending`, `running`, `blocked`, `succeeded`, `cancelled`, and `failed`.
- Updated the workflow definition to support snapshot creation and retrieval.
- Enhanced the queue store to manage workflow registrations and snapshots effectively.
- Added comprehensive tests to ensure the correctness of the snapshot functionality and its integration with existing workflow processes.
- Updated documentation to reflect the new snapshot capabilities and their implications for workflow state management.

closes: #85