### PR TITLE
feat: implement workflow rollback functionality

### DIFF
--- a/core/karya/lib/karya/queue_store/base.rb
+++ b/core/karya/lib/karya/queue_store/base.rb
@@ -73,11 +73,12 @@ module Karya
       # Enqueue one complete workflow run atomically. Concrete jobs remain the
       # canonical executable units; workflow metadata only gates reservation
       # until prerequisite jobs have succeeded.
-      def enqueue_workflow(definition:, jobs_by_step_id:, batch_id:, now:)
+      def enqueue_workflow(definition:, jobs_by_step_id:, batch_id:, now:, compensation_jobs_by_step_id: {})
         _definition = definition
         _jobs_by_step_id = jobs_by_step_id
         _batch_id = batch_id
         _now = now
+        _compensation_jobs_by_step_id = compensation_jobs_by_step_id
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 
@@ -86,6 +87,14 @@ module Karya
       def workflow_snapshot(batch_id:, now:)
         _batch_id = batch_id
         _now = now
+        raise NotImplementedError, "#{self.class} must implement ##{__method__}"
+      end
+
+      # Trigger explicit saga rollback for one failed workflow batch.
+      def rollback_workflow(batch_id:, now:, reason:)
+        _batch_id = batch_id
+        _now = now
+        _reason = reason
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 

--- a/core/karya/lib/karya/queue_store/bulk_mutation_report.rb
+++ b/core/karya/lib/karya/queue_store/bulk_mutation_report.rb
@@ -17,6 +17,7 @@ module Karya
         replay_dead_letter_jobs
         retry_dead_letter_jobs
         discard_dead_letter_jobs
+        rollback_workflow
       ].freeze
       SKIPPED_JOB_REASONS = %i[not_found ineligible_state duplicate_request uniqueness_conflict].freeze
 
@@ -122,7 +123,7 @@ module Karya
 
       def action_error_message
         'action must be one of :enqueue_many, :retry_jobs, :cancel_jobs, :dead_letter_jobs, ' \
-          ':replay_dead_letter_jobs, :retry_dead_letter_jobs, or :discard_dead_letter_jobs'
+          ':replay_dead_letter_jobs, :retry_dead_letter_jobs, :discard_dead_letter_jobs, or :rollback_workflow'
       end
 
       private_constant :ACTIONS, :JobIdList, :JobList, :SKIPPED_JOB_REASONS

--- a/core/karya/lib/karya/queue_store/in_memory/internal/batch_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/batch_support.rb
@@ -49,7 +49,9 @@ module Karya
               max_size: max_batch_size
             )
             batch_id = batch.id
-            raise Workflow::DuplicateBatchError, "batch #{batch_id.inspect} already exists" if state.batches_by_id.key?(batch_id)
+            if state.batches_by_id.key?(batch_id) || workflow_rollback_batch_id?(batch_id)
+              raise Workflow::DuplicateBatchError, "batch #{batch_id.inspect} already exists"
+            end
 
             batch
           end
@@ -67,6 +69,12 @@ module Karya
             state.register_batch(batch)
             state.prune_terminal_batches(completed_batch_retention_limit)
             batch
+          end
+
+          def workflow_rollback_batch_id?(batch_id)
+            state.workflow_rollbacks_by_batch_id.any? do |_workflow_batch_id, rollback|
+              rollback.rollback_batch_id == batch_id
+            end
           end
 
           def fetch_batch(batch_id)

--- a/core/karya/lib/karya/queue_store/in_memory/internal/batch_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/batch_support.rb
@@ -72,9 +72,7 @@ module Karya
           end
 
           def workflow_rollback_batch_id?(batch_id)
-            state.workflow_rollbacks_by_batch_id.any? do |_workflow_batch_id, rollback|
-              rollback.rollback_batch_id == batch_id
-            end
+            state.workflow_rollback_batch_ids.key?(batch_id)
           end
 
           def fetch_batch(batch_id)

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -33,6 +33,7 @@ module Karya
                       :reservations_by_token,
                       :stuck_job_recoveries_by_id,
                       :workflow_dependency_job_ids_by_job_id,
+                      :workflow_rollback_batch_ids,
                       :workflow_registrations_by_batch_id,
                       :workflow_rollbacks_by_batch_id
 
@@ -53,6 +54,7 @@ module Karya
             end
 
             def register_workflow_rollback(batch_id:, rollback_batch_id:, reason:, requested_at:, compensation_job_ids:)
+              workflow_rollback_batch_ids[rollback_batch_id] = true
               workflow_rollbacks_by_batch_id[batch_id] = WorkflowRollback.new(
                 batch_id,
                 rollback_batch_id,
@@ -93,6 +95,7 @@ module Karya
             @terminal_batch_ids_index = {}
             @terminal_batch_ids_in_order = []
             @workflow_dependency_job_ids_by_job_id = {}
+            @workflow_rollback_batch_ids = {}
             @workflow_registrations_by_batch_id = {}
             @workflow_rollbacks_by_batch_id = {}
           end
@@ -265,9 +268,15 @@ module Karya
                 PrunedBatchCleanup.call(
                   batch_id:,
                   batch: nil,
-                  batch_id_by_job_id: @batch_id_by_job_id,
-                  workflow_dependency_job_ids_by_job_id:,
-                  workflow_registrations_by_batch_id:
+                  job_indexes: {
+                    batch_id_by_job_id: @batch_id_by_job_id,
+                    workflow_dependency_job_ids_by_job_id:
+                  },
+                  workflow_indexes: {
+                    workflow_rollback_batch_ids:,
+                    workflow_registrations_by_batch_id:,
+                    workflow_rollbacks_by_batch_id:
+                  }
                 )
                 next
               end
@@ -275,9 +284,15 @@ module Karya
               PrunedBatchCleanup.call(
                 batch_id:,
                 batch:,
-                batch_id_by_job_id: @batch_id_by_job_id,
-                workflow_dependency_job_ids_by_job_id:,
-                workflow_registrations_by_batch_id:
+                job_indexes: {
+                  batch_id_by_job_id: @batch_id_by_job_id,
+                  workflow_dependency_job_ids_by_job_id:
+                },
+                workflow_indexes: {
+                  workflow_rollback_batch_ids:,
+                  workflow_registrations_by_batch_id:,
+                  workflow_rollbacks_by_batch_id:
+                }
               )
               pruned_batch_ids << batch_id
             end
@@ -300,22 +315,29 @@ module Karya
               new(**).call
             end
 
-            def initialize(batch_id:, batch:, batch_id_by_job_id:, workflow_dependency_job_ids_by_job_id:, workflow_registrations_by_batch_id:)
+            def initialize(
+              batch_id:,
+              batch:,
+              job_indexes:,
+              workflow_indexes:
+            )
               @batch_id = batch_id
               @batch = batch
-              @batch_id_by_job_id = batch_id_by_job_id
-              @workflow_dependency_job_ids_by_job_id = workflow_dependency_job_ids_by_job_id
-              @workflow_registrations_by_batch_id = workflow_registrations_by_batch_id
+              @job_indexes = job_indexes
+              @workflow_indexes = workflow_indexes
             end
 
             def call
               pruned_job_ids ? cleanup_batch_jobs : cleanup_stale_batch_membership
-              workflow_registrations_by_batch_id.delete(batch_id)
+              cleanup_workflow_registration
             end
 
             private
 
-            attr_reader :batch, :batch_id, :batch_id_by_job_id, :workflow_dependency_job_ids_by_job_id, :workflow_registrations_by_batch_id
+            attr_reader :batch,
+                        :batch_id,
+                        :job_indexes,
+                        :workflow_indexes
 
             def pruned_job_ids
               batch&.job_ids
@@ -337,6 +359,34 @@ module Karya
                 batch_id_by_job_id.delete(job_id)
                 workflow_dependency_job_ids_by_job_id.delete(job_id)
               end
+            end
+
+            def cleanup_workflow_registration
+              registration = workflow_registrations_by_batch_id.delete(batch_id)
+              rollback = workflow_rollbacks_by_batch_id.delete(batch_id)
+              workflow_rollback_batch_ids.delete(batch_id)
+              workflow_rollback_batch_ids.delete(rollback.rollback_batch_id) if rollback
+              registration
+            end
+
+            def batch_id_by_job_id
+              job_indexes.fetch(:batch_id_by_job_id)
+            end
+
+            def workflow_dependency_job_ids_by_job_id
+              job_indexes.fetch(:workflow_dependency_job_ids_by_job_id)
+            end
+
+            def workflow_rollback_batch_ids
+              workflow_indexes.fetch(:workflow_rollback_batch_ids)
+            end
+
+            def workflow_registrations_by_batch_id
+              workflow_indexes.fetch(:workflow_registrations_by_batch_id)
+            end
+
+            def workflow_rollbacks_by_batch_id
+              workflow_indexes.fetch(:workflow_rollbacks_by_batch_id)
             end
           end
           private_constant :PrunedBatchCleanup

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -364,7 +364,6 @@ module Karya
             def cleanup_workflow_registration
               registration = workflow_registrations_by_batch_id.delete(batch_id)
               rollback = workflow_rollbacks_by_batch_id.delete(batch_id)
-              workflow_rollback_batch_ids.delete(batch_id)
               workflow_rollback_batch_ids.delete(rollback.rollback_batch_id) if rollback
               registration
             end

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -33,10 +33,13 @@ module Karya
                       :reservations_by_token,
                       :stuck_job_recoveries_by_id,
                       :workflow_dependency_job_ids_by_job_id,
-                      :workflow_registrations_by_batch_id
+                      :workflow_registrations_by_batch_id,
+                      :workflow_rollbacks_by_batch_id
 
           # Immutable owner-local workflow registration metadata for one batch.
-          WorkflowRegistration = Struct.new(:workflow_id, :step_job_ids, :dependency_job_ids_by_job_id)
+          WorkflowRegistration = Struct.new(:workflow_id, :step_job_ids, :dependency_job_ids_by_job_id, :compensation_jobs_by_step_id)
+          # Immutable owner-local rollback metadata for one workflow batch.
+          WorkflowRollback = Struct.new(:batch_id, :rollback_batch_id, :reason, :requested_at, :compensation_job_ids)
 
           def initialize(expired_tombstone_limit:)
             @batches_by_id = {}
@@ -65,6 +68,7 @@ module Karya
             @terminal_batch_ids_in_order = []
             @workflow_dependency_job_ids_by_job_id = {}
             @workflow_registrations_by_batch_id = {}
+            @workflow_rollbacks_by_batch_id = {}
           end
 
           def queue_job_ids_for(queue)
@@ -255,15 +259,36 @@ module Karya
             pruned_batch_ids
           end
 
-          def register_workflow(batch_id:, workflow_id:, step_job_ids:, dependency_job_ids_by_job_id:)
+          def register_workflow_dependencies(dependency_job_ids_by_job_id)
+            workflow_dependency_job_ids_by_job_id.merge!(
+              dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }
+            )
+          end
+
+          def workflow_dependency_job_ids_for(job_id)
+            workflow_dependency_job_ids_by_job_id[job_id]
+          end
+
+          def register_workflow(batch_id:, workflow_id:, step_job_ids:, dependency_job_ids_by_job_id:, compensation_jobs_by_step_id:)
             workflow_registrations_by_batch_id[batch_id] = WorkflowRegistration.new(
               workflow_id,
               step_job_ids.dup.freeze,
-              dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }.freeze
+              dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }.freeze,
+              compensation_jobs_by_step_id.dup.freeze
             ).freeze
           end
 
-          private_constant :WorkflowRegistration
+          def register_workflow_rollback(batch_id:, rollback_batch_id:, reason:, requested_at:, compensation_job_ids:)
+            workflow_rollbacks_by_batch_id[batch_id] = WorkflowRollback.new(
+              batch_id,
+              rollback_batch_id,
+              reason,
+              requested_at,
+              compensation_job_ids.dup.freeze
+            ).freeze
+          end
+
+          private_constant :WorkflowRegistration, :WorkflowRollback
 
           private
 

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -41,6 +41,32 @@ module Karya
           # Immutable owner-local rollback metadata for one workflow batch.
           WorkflowRollback = Struct.new(:batch_id, :rollback_batch_id, :reason, :requested_at, :compensation_job_ids)
 
+          # Workflow registration writers kept separate from generic store state.
+          module WorkflowMetadata
+            def register_workflow(batch_id:, workflow_id:, step_job_ids:, dependency_job_ids_by_job_id:, compensation_jobs_by_step_id:)
+              workflow_registrations_by_batch_id[batch_id] = WorkflowRegistration.new(
+                workflow_id,
+                step_job_ids.dup.freeze,
+                dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }.freeze,
+                compensation_jobs_by_step_id.dup.freeze
+              ).freeze
+            end
+
+            def register_workflow_rollback(batch_id:, rollback_batch_id:, reason:, requested_at:, compensation_job_ids:)
+              workflow_rollbacks_by_batch_id[batch_id] = WorkflowRollback.new(
+                batch_id,
+                rollback_batch_id,
+                reason,
+                requested_at,
+                compensation_job_ids.dup.freeze
+              ).freeze
+            end
+          end
+
+          include WorkflowMetadata
+
+          private_constant :WorkflowMetadata, :WorkflowRegistration, :WorkflowRollback
+
           def initialize(expired_tombstone_limit:)
             @batches_by_id = {}
             @batch_id_by_job_id = {}
@@ -258,37 +284,6 @@ module Karya
 
             pruned_batch_ids
           end
-
-          def register_workflow_dependencies(dependency_job_ids_by_job_id)
-            workflow_dependency_job_ids_by_job_id.merge!(
-              dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }
-            )
-          end
-
-          def workflow_dependency_job_ids_for(job_id)
-            workflow_dependency_job_ids_by_job_id[job_id]
-          end
-
-          def register_workflow(batch_id:, workflow_id:, step_job_ids:, dependency_job_ids_by_job_id:, compensation_jobs_by_step_id:)
-            workflow_registrations_by_batch_id[batch_id] = WorkflowRegistration.new(
-              workflow_id,
-              step_job_ids.dup.freeze,
-              dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }.freeze,
-              compensation_jobs_by_step_id.dup.freeze
-            ).freeze
-          end
-
-          def register_workflow_rollback(batch_id:, rollback_batch_id:, reason:, requested_at:, compensation_job_ids:)
-            workflow_rollbacks_by_batch_id[batch_id] = WorkflowRollback.new(
-              batch_id,
-              rollback_batch_id,
-              reason,
-              requested_at,
-              compensation_job_ids.dup.freeze
-            ).freeze
-          end
-
-          private_constant :WorkflowRegistration, :WorkflowRollback
 
           private
 

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -166,7 +166,7 @@ module Karya
               previous_job_id = nil
               jobs.each_with_object({}) do |job, dependencies|
                 job_id = job.id
-                dependencies[job_id] = previous_job_id ? [previous_job_id].freeze : []
+                dependencies[job_id] = previous_job_id ? [previous_job_id].freeze : [].freeze
                 previous_job_id = job_id
               end.freeze
             end

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -117,7 +117,7 @@ module Karya
             end
 
             def to_s
-              "#{batch_id}.rollback"
+              "#{batch_id}.rollback".freeze
             end
 
             private
@@ -209,7 +209,7 @@ module Karya
             raise_duplicate_rollback(workflow_batch_id)
             jobs = fetch_batch_jobs(batch)
             snapshot = WorkflowSnapshotBuilder.new(batch:, registration:, jobs:, now:).to_snapshot
-            RollbackState.new(snapshot).validate
+            RollbackState.new(snapshot, registration.dependency_job_ids_by_job_id).validate
             plan = RollbackPlan.new(registration:, jobs:).to_plan
             rollback_batch_id = RollbackBatchId.new(workflow_batch_id).to_s
             rollback_batch = build_rollback_batch(batch_id: rollback_batch_id, jobs: plan.jobs, now:)
@@ -265,9 +265,12 @@ module Karya
           # Validates rollback state eligibility.
           class RollbackState
             ACTIVE_JOB_STATES = %i[reserved running].freeze
+            WAITING_JOB_STATES = %i[queued submission].freeze
 
-            def initialize(snapshot)
+            def initialize(snapshot, dependency_job_ids_by_job_id)
               @snapshot = snapshot
+              @dependency_job_ids_by_job_id = dependency_job_ids_by_job_id
+              @jobs_by_id = snapshot.jobs.to_h { |job| [job.id, job] }
             end
 
             def validate
@@ -278,14 +281,29 @@ module Karya
 
             private
 
-            attr_reader :snapshot
+            attr_reader :dependency_job_ids_by_job_id, :jobs_by_id, :snapshot
 
             def failed_snapshot?
               snapshot.state == :failed
             end
 
             def active_jobs?
-              snapshot.jobs.any? { |job| ACTIVE_JOB_STATES.include?(job.state) }
+              snapshot.jobs.any? { |job| active_job?(job) }
+            end
+
+            def active_job?(job)
+              ACTIVE_JOB_STATES.include?(job.state) || runnable_waiting_job?(job)
+            end
+
+            def runnable_waiting_job?(job)
+              WAITING_JOB_STATES.include?(job.state) && dependencies_satisfied?(job)
+            end
+
+            def dependencies_satisfied?(job)
+              dependency_job_ids_by_job_id.fetch(job.id, []).all? do |dependency_job_id|
+                dependency_job = jobs_by_id[dependency_job_id]
+                dependency_job && dependency_job.state == :succeeded
+              end
             end
 
             def validation_error_message

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -102,9 +102,16 @@ module Karya
           private
 
           def normalize_rollback_reason(reason)
-            Karya::Internal::DeadLetterReason.normalize(reason, error_class: Workflow::InvalidExecutionError)
-          rescue Workflow::InvalidExecutionError => e
-            raise Workflow::InvalidExecutionError, e.message.gsub('dead_letter_reason', 'reason'), cause: e
+            max_length = Karya::Internal::DeadLetterReason::MAX_LENGTH
+            too_long_message = "reason must be at most #{max_length} characters"
+
+            raise Workflow::InvalidExecutionError, 'reason must be a String' unless reason.is_a?(String)
+
+            normalized_reason = reason.strip
+            raise Workflow::InvalidExecutionError, 'reason must be present' if normalized_reason.empty?
+            raise Workflow::InvalidExecutionError, too_long_message if normalized_reason.length > max_length
+
+            normalized_reason.freeze
           end
 
           # Groups the validated rollback batch and enqueue plan.

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -52,7 +52,7 @@ module Karya
 
           def rollback_workflow(batch_id:, now:, reason:)
             normalized_now = normalize_time(:now, now, error_class: Workflow::InvalidExecutionError)
-            normalized_reason = Karya::Internal::DeadLetterReason.normalize(reason, error_class: Workflow::InvalidExecutionError)
+            normalized_reason = normalize_rollback_reason(reason)
             normalized_batch_id = Workflow.send(:normalize_batch_identifier, :batch_id, batch_id)
 
             @mutex.synchronize do
@@ -100,6 +100,12 @@ module Karya
           end
 
           private
+
+          def normalize_rollback_reason(reason)
+            Karya::Internal::DeadLetterReason.normalize(reason, error_class: Workflow::InvalidExecutionError)
+          rescue Workflow::InvalidExecutionError => e
+            raise Workflow::InvalidExecutionError, e.message.gsub('dead_letter_reason', 'reason'), cause: e
+          end
 
           # Groups the validated rollback batch and enqueue plan.
           Rollback = Struct.new(:workflow_batch_id, :rollback_batch_id, :batch, :plan)

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -264,7 +264,7 @@ module Karya
 
           # Validates rollback state eligibility.
           class RollbackState
-            ACTIVE_JOB_STATES = %i[reserved running].freeze
+            ACTIVE_JOB_STATES = %i[reserved running retry_pending].freeze
             WAITING_JOB_STATES = %i[queued submission].freeze
 
             def initialize(snapshot, dependency_job_ids_by_job_id)

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -30,7 +30,9 @@ module Karya
               queued_jobs = jobs.map { |job| enqueue_validated_job(job, normalized_now) }
               dependency_job_ids_by_job_id = binding.dependency_job_ids_by_job_id
               store_batch(batch)
-              state.register_workflow_dependencies(dependency_job_ids_by_job_id)
+              state.workflow_dependency_job_ids_by_job_id.merge!(
+                dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }
+              )
               state.register_workflow(
                 batch_id: workflow_batch_id,
                 workflow_id: definition.id,
@@ -63,7 +65,9 @@ module Karya
               queued_jobs = rollback_jobs.map { |job| enqueue_validated_job(job, normalized_now) }
               queued_job_ids = queued_jobs.map(&:id)
               store_batch(rollback_batch) if rollback_batch
-              state.register_workflow_dependencies(rollback_plan.dependency_job_ids_by_job_id)
+              state.workflow_dependency_job_ids_by_job_id.merge!(
+                rollback_plan.dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }
+              )
               state.register_workflow_rollback(
                 batch_id: rollback.workflow_batch_id,
                 rollback_batch_id: rollback.rollback_batch_id,
@@ -91,7 +95,7 @@ module Karya
               workflow_batch_id = batch.id
               registration = fetch_workflow_registration(workflow_batch_id)
               jobs = fetch_batch_jobs(batch)
-              workflow_snapshot_for(batch:, registration:, jobs:, now: normalized_now)
+              WorkflowSnapshotBuilder.new(batch:, registration:, jobs:, now: normalized_now).to_snapshot
             end
           end
 
@@ -198,7 +202,7 @@ module Karya
             registration = fetch_workflow_registration(workflow_batch_id)
             raise_duplicate_rollback(workflow_batch_id)
             jobs = fetch_batch_jobs(batch)
-            snapshot = workflow_snapshot_for(batch:, registration:, jobs:, now:)
+            snapshot = WorkflowSnapshotBuilder.new(batch:, registration:, jobs:, now:).to_snapshot
             RollbackState.new(snapshot).validate
             plan = RollbackPlan.new(registration:, jobs:).to_plan
             rollback_batch_id = RollbackBatchId.new(workflow_batch_id).to_s
@@ -221,16 +225,6 @@ module Karya
             raise Workflow::DuplicateBatchError, "batch #{batch_id.inspect} already exists"
           end
 
-          def workflow_snapshot_for(batch:, registration:, jobs:, now:)
-            WorkflowSnapshotBuilder.new(
-              batch:,
-              registration:,
-              jobs:,
-              now:,
-              dependency_job_ids_by_job_id: registration.dependency_job_ids_by_job_id
-            ).to_snapshot
-          end
-
           def raise_duplicate_rollback(batch_id)
             return unless state.workflow_rollbacks_by_batch_id[batch_id]
 
@@ -239,12 +233,11 @@ module Karya
 
           # Builds workflow snapshots from stored workflow metadata.
           class WorkflowSnapshotBuilder
-            def initialize(batch:, registration:, jobs:, now:, dependency_job_ids_by_job_id:)
+            def initialize(batch:, registration:, jobs:, now:)
               @batch = batch
               @registration = registration
               @jobs = jobs
               @now = now
-              @dependency_job_ids_by_job_id = dependency_job_ids_by_job_id
             end
 
             def to_snapshot
@@ -253,14 +246,14 @@ module Karya
                 batch_id: batch.id,
                 captured_at: now,
                 step_job_ids: registration.step_job_ids,
-                dependency_job_ids_by_job_id:,
+                dependency_job_ids_by_job_id: registration.dependency_job_ids_by_job_id,
                 jobs:
               )
             end
 
             private
 
-            attr_reader :batch, :dependency_job_ids_by_job_id, :jobs, :now, :registration
+            attr_reader :batch, :jobs, :now, :registration
           end
 
           # Validates rollback state eligibility.

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -56,12 +56,12 @@ module Karya
             normalized_batch_id = Workflow.send(:normalize_batch_identifier, :batch_id, batch_id)
 
             @mutex.synchronize do
+              expire_reservations_locked(normalized_now)
               rollback = prepare_rollback(normalized_batch_id, normalized_now)
               rollback_plan = rollback.plan
               rollback_jobs = rollback_plan.jobs
               rollback_batch = rollback.batch
               validate_bulk_enqueue_uniqueness(rollback_jobs, normalized_now)
-              expire_reservations_locked(normalized_now)
               queued_jobs = rollback_jobs.map { |job| enqueue_validated_job(job, normalized_now) }
               queued_job_ids = queued_jobs.map(&:id)
               store_batch(rollback_batch) if rollback_batch

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -112,12 +112,15 @@ module Karya
 
           # Builds a deterministic rollback batch id for one workflow batch.
           class RollbackBatchId
+            PREFIX = '__karya_workflow_rollback_v1__'
+            private_constant :PREFIX
+
             def initialize(batch_id)
               @batch_id = batch_id
             end
 
             def to_s
-              "#{batch_id}.rollback".freeze
+              "#{PREFIX}#{batch_id.unpack1('H*')}".freeze
             end
 
             private

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -264,19 +264,36 @@ module Karya
 
           # Validates rollback state eligibility.
           class RollbackState
+            ACTIVE_JOB_STATES = %i[reserved running].freeze
+
             def initialize(snapshot)
               @snapshot = snapshot
             end
 
             def validate
-              return if snapshot.state == :failed
+              return if failed_snapshot? && !active_jobs?
 
-              raise Workflow::InvalidExecutionError, "workflow batch #{snapshot.batch_id.inspect} must be failed before rollback"
+              raise Workflow::InvalidExecutionError, validation_error_message
             end
 
             private
 
             attr_reader :snapshot
+
+            def failed_snapshot?
+              snapshot.state == :failed
+            end
+
+            def active_jobs?
+              snapshot.jobs.any? { |job| ACTIVE_JOB_STATES.include?(job.state) }
+            end
+
+            def validation_error_message
+              batch_id = snapshot.batch_id.inspect
+              return "workflow batch #{batch_id} must be failed before rollback" unless failed_snapshot?
+
+              "workflow batch #{batch_id} has active jobs and cannot be rolled back"
+            end
           end
           private_constant :RollbackState, :WorkflowSnapshotBuilder
 

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -11,11 +11,17 @@ module Karya
       module Internal
         # Owner-local workflow enqueue and prerequisite readiness support.
         module WorkflowSupport
-          def enqueue_workflow(definition:, jobs_by_step_id:, batch_id:, now:)
+          def enqueue_workflow(definition:, jobs_by_step_id:, batch_id:, now:, compensation_jobs_by_step_id: {})
             normalized_now = normalize_time(:now, now, error_class: Workflow::InvalidExecutionError)
 
             @mutex.synchronize do
-              binding = Workflow.send(:build_execution_binding, definition:, jobs_by_step_id:, batch_id:)
+              binding = Workflow.send(
+                :build_compensated_execution_binding,
+                definition:,
+                jobs_by_step_id:,
+                batch_id:,
+                compensation_jobs_by_step_id:
+              )
               jobs = binding.jobs
               workflow_batch_id = binding.batch_id
               batch = build_enqueue_batch(batch_id: workflow_batch_id, jobs:, now: normalized_now)
@@ -24,17 +30,51 @@ module Karya
               queued_jobs = jobs.map { |job| enqueue_validated_job(job, normalized_now) }
               dependency_job_ids_by_job_id = binding.dependency_job_ids_by_job_id
               store_batch(batch)
-              state.workflow_dependency_job_ids_by_job_id.merge!(dependency_job_ids_by_job_id)
+              state.register_workflow_dependencies(dependency_job_ids_by_job_id)
               state.register_workflow(
                 batch_id: workflow_batch_id,
                 workflow_id: definition.id,
                 step_job_ids: StepJobIds.new(definition:, jobs:).to_h,
-                dependency_job_ids_by_job_id:
+                dependency_job_ids_by_job_id:,
+                compensation_jobs_by_step_id: binding.compensation_jobs_by_step_id
               )
               BulkMutationReport.new(
                 action: :enqueue_many,
                 performed_at: normalized_now,
                 requested_job_ids: jobs.map(&:id),
+                changed_jobs: queued_jobs,
+                skipped_jobs: []
+              )
+            end
+          end
+
+          def rollback_workflow(batch_id:, now:, reason:)
+            normalized_now = normalize_time(:now, now, error_class: Workflow::InvalidExecutionError)
+            normalized_reason = Karya::Internal::DeadLetterReason.normalize(reason, error_class: Workflow::InvalidExecutionError)
+            normalized_batch_id = Workflow.send(:normalize_batch_identifier, :batch_id, batch_id)
+
+            @mutex.synchronize do
+              rollback = prepare_rollback(normalized_batch_id, normalized_now)
+              rollback_plan = rollback.plan
+              rollback_jobs = rollback_plan.jobs
+              rollback_batch = rollback.batch
+              validate_bulk_enqueue_uniqueness(rollback_jobs, normalized_now)
+              expire_reservations_locked(normalized_now)
+              queued_jobs = rollback_jobs.map { |job| enqueue_validated_job(job, normalized_now) }
+              queued_job_ids = queued_jobs.map(&:id)
+              store_batch(rollback_batch) if rollback_batch
+              state.register_workflow_dependencies(rollback_plan.dependency_job_ids_by_job_id)
+              state.register_workflow_rollback(
+                batch_id: rollback.workflow_batch_id,
+                rollback_batch_id: rollback.rollback_batch_id,
+                reason: normalized_reason,
+                requested_at: normalized_now,
+                compensation_job_ids: queued_job_ids
+              )
+              BulkMutationReport.new(
+                action: :rollback_workflow,
+                performed_at: normalized_now,
+                requested_job_ids: queued_job_ids,
                 changed_jobs: queued_jobs,
                 skipped_jobs: []
               )
@@ -51,18 +91,80 @@ module Karya
               workflow_batch_id = batch.id
               registration = fetch_workflow_registration(workflow_batch_id)
               jobs = fetch_batch_jobs(batch)
-              Workflow::Snapshot.new(
-                workflow_id: registration.workflow_id,
-                batch_id: workflow_batch_id,
-                captured_at: normalized_now,
-                step_job_ids: registration.step_job_ids,
-                dependency_job_ids_by_job_id: registration.dependency_job_ids_by_job_id,
-                jobs:
-              )
+              workflow_snapshot_for(batch:, registration:, jobs:, now: normalized_now)
             end
           end
 
           private
+
+          # Groups the validated rollback batch and enqueue plan.
+          Rollback = Struct.new(:workflow_batch_id, :rollback_batch_id, :batch, :plan)
+
+          # Builds a deterministic rollback batch id for one workflow batch.
+          class RollbackBatchId
+            def initialize(batch_id)
+              @batch_id = batch_id
+            end
+
+            def to_s
+              "#{batch_id}.rollback"
+            end
+
+            private
+
+            attr_reader :batch_id
+          end
+
+          # Immutable rollback enqueue plan.
+          class RollbackPlan
+            # Immutable compensation jobs and dependency metadata.
+            Plan = Struct.new(:jobs, :dependency_job_ids_by_job_id)
+            private_constant :Plan
+
+            def initialize(registration:, jobs:)
+              @registration = registration
+              @jobs_by_id = jobs.to_h { |job| [job.id, job] }
+            end
+
+            def to_plan
+              compensation_jobs = ordered_compensation_jobs
+              Plan.new(compensation_jobs.freeze, RollbackDependencies.new(compensation_jobs).to_h).freeze
+            end
+
+            private
+
+            attr_reader :jobs_by_id, :registration
+
+            def ordered_compensation_jobs
+              step_job_ids = registration.step_job_ids
+              step_job_ids.keys.reverse.filter_map do |step_id|
+                primary_job = jobs_by_id.fetch(step_job_ids.fetch(step_id))
+                next unless primary_job.state == :succeeded
+
+                registration.compensation_jobs_by_step_id[step_id]
+              end
+            end
+          end
+
+          # Builds serial dependency metadata for rollback compensation jobs.
+          class RollbackDependencies
+            def initialize(jobs)
+              @jobs = jobs
+            end
+
+            def to_h
+              previous_job_id = nil
+              jobs.each_with_object({}) do |job, dependencies|
+                job_id = job.id
+                dependencies[job_id] = previous_job_id ? [previous_job_id].freeze : []
+                previous_job_id = job_id
+              end.freeze
+            end
+
+            private
+
+            attr_reader :jobs
+          end
 
           # Builds step-to-job metadata in definition order.
           class StepJobIds
@@ -81,7 +183,7 @@ module Karya
 
             attr_reader :definition, :jobs
           end
-          private_constant :StepJobIds
+          private_constant :Rollback, :RollbackBatchId, :RollbackDependencies, :RollbackPlan, :StepJobIds
 
           def fetch_workflow_registration(batch_id)
             registration = state.workflow_registrations_by_batch_id[batch_id]
@@ -89,6 +191,95 @@ module Karya
 
             raise Workflow::InvalidExecutionError, "batch #{batch_id.inspect} is not a workflow batch"
           end
+
+          def prepare_rollback(batch_id, now)
+            batch = fetch_batch(batch_id)
+            workflow_batch_id = batch.id
+            registration = fetch_workflow_registration(workflow_batch_id)
+            raise_duplicate_rollback(workflow_batch_id)
+            jobs = fetch_batch_jobs(batch)
+            snapshot = workflow_snapshot_for(batch:, registration:, jobs:, now:)
+            RollbackState.new(snapshot).validate
+            plan = RollbackPlan.new(registration:, jobs:).to_plan
+            rollback_batch_id = RollbackBatchId.new(workflow_batch_id).to_s
+            rollback_batch = build_rollback_batch(batch_id: rollback_batch_id, jobs: plan.jobs, now:)
+            Rollback.new(workflow_batch_id, rollback_batch_id, rollback_batch, plan).freeze
+          end
+
+          def build_rollback_batch(batch_id:, jobs:, now:)
+            if jobs.empty?
+              raise_duplicate_batch(batch_id)
+              return nil
+            end
+
+            build_enqueue_batch(batch_id:, jobs:, now:)
+          end
+
+          def raise_duplicate_batch(batch_id)
+            return unless state.batches_by_id.key?(batch_id) || workflow_rollback_batch_id?(batch_id)
+
+            raise Workflow::DuplicateBatchError, "batch #{batch_id.inspect} already exists"
+          end
+
+          def workflow_snapshot_for(batch:, registration:, jobs:, now:)
+            WorkflowSnapshotBuilder.new(
+              batch:,
+              registration:,
+              jobs:,
+              now:,
+              dependency_job_ids_by_job_id: registration.dependency_job_ids_by_job_id
+            ).to_snapshot
+          end
+
+          def raise_duplicate_rollback(batch_id)
+            return unless state.workflow_rollbacks_by_batch_id[batch_id]
+
+            raise Workflow::InvalidExecutionError, "workflow batch #{batch_id.inspect} has already been rolled back"
+          end
+
+          # Builds workflow snapshots from stored workflow metadata.
+          class WorkflowSnapshotBuilder
+            def initialize(batch:, registration:, jobs:, now:, dependency_job_ids_by_job_id:)
+              @batch = batch
+              @registration = registration
+              @jobs = jobs
+              @now = now
+              @dependency_job_ids_by_job_id = dependency_job_ids_by_job_id
+            end
+
+            def to_snapshot
+              Workflow::Snapshot.new(
+                workflow_id: registration.workflow_id,
+                batch_id: batch.id,
+                captured_at: now,
+                step_job_ids: registration.step_job_ids,
+                dependency_job_ids_by_job_id:,
+                jobs:
+              )
+            end
+
+            private
+
+            attr_reader :batch, :dependency_job_ids_by_job_id, :jobs, :now, :registration
+          end
+
+          # Validates rollback state eligibility.
+          class RollbackState
+            def initialize(snapshot)
+              @snapshot = snapshot
+            end
+
+            def validate
+              return if snapshot.state == :failed
+
+              raise Workflow::InvalidExecutionError, "workflow batch #{snapshot.batch_id.inspect} must be failed before rollback"
+            end
+
+            private
+
+            attr_reader :snapshot
+          end
+          private_constant :RollbackState, :WorkflowSnapshotBuilder
 
           def workflow_dependencies_satisfied?(job)
             prerequisite_job_ids = state.workflow_dependency_job_ids_by_job_id[job.id]

--- a/core/karya/lib/karya/workflow.rb
+++ b/core/karya/lib/karya/workflow.rb
@@ -61,6 +61,11 @@ module Karya
     end
     module_function :build_execution_binding
 
+    def build_compensated_execution_binding(definition:, jobs_by_step_id:, batch_id:, compensation_jobs_by_step_id:)
+      ExecutionBinding.new(definition:, jobs_by_step_id:, batch_id:, compensation_jobs_by_step_id:)
+    end
+    module_function :build_compensated_execution_binding
+
     # Owner-local DSL builder for workflow definition.
     class Builder
       def initialize(id)
@@ -68,8 +73,8 @@ module Karya
         @steps = []
       end
 
-      def step(id, handler:, arguments: {}, depends_on: nil)
-        steps << Step.new(id:, handler:, arguments:, depends_on:)
+      def step(id, handler:, arguments: {}, depends_on: nil, compensate_with: nil, compensation_arguments: {})
+        steps << Step.new(id:, handler:, arguments:, depends_on:, compensate_with:, compensation_arguments:)
         nil
       end
 
@@ -87,5 +92,6 @@ module Karya
     private_class_method :normalize_batch_identifier
     private_class_method :normalize_execution_identifier
     private_class_method :build_execution_binding
+    private_class_method :build_compensated_execution_binding
   end
 end

--- a/core/karya/lib/karya/workflow/execution_binding.rb
+++ b/core/karya/lib/karya/workflow/execution_binding.rb
@@ -9,15 +9,16 @@ module Karya
   module Workflow
     # Normalized binding from workflow definition steps to concrete submission jobs.
     class ExecutionBinding
-      attr_reader :batch_id, :dependency_job_ids_by_job_id, :jobs
+      attr_reader :batch_id, :compensation_jobs_by_step_id, :dependency_job_ids_by_job_id, :jobs
 
-      def initialize(definition:, jobs_by_step_id:, batch_id:)
+      def initialize(definition:, jobs_by_step_id:, batch_id:, compensation_jobs_by_step_id: {})
         @definition = validate_definition(definition)
         @batch_id = Workflow.send(:normalize_batch_identifier, :batch_id, batch_id)
         normalized_jobs = JobMap.new(jobs_by_step_id).to_h
         validate_step_coverage(normalized_jobs)
         @jobs_by_step_id = normalized_jobs
         validate_jobs
+        @compensation_jobs_by_step_id = CompensationJobMap.new(definition:, jobs_by_step_id: compensation_jobs_by_step_id).to_h
         @jobs = definition.steps.map { |workflow_step| normalized_jobs.fetch(workflow_step.id) }.freeze
         @dependency_job_ids_by_job_id = DependencyJobIds.new(definition:, jobs_by_step_id: normalized_jobs).to_h
         freeze
@@ -97,6 +98,68 @@ module Karya
         end
       end
 
+      # Normalizes and validates compensation job specs by workflow step id.
+      class CompensationJobMap
+        def initialize(definition:, jobs_by_step_id:)
+          @definition = definition
+          @jobs_by_step_id = jobs_by_step_id
+        end
+
+        def to_h
+          normalized_jobs = JobMap.new(jobs_by_step_id).to_h
+          validate_step_coverage(normalized_jobs)
+          validate_jobs(normalized_jobs)
+          normalized_jobs.freeze
+        end
+
+        private
+
+        attr_reader :definition, :jobs_by_step_id
+
+        def validate_step_coverage(normalized_jobs)
+          expected_step_ids = definition.steps.select(&:compensable?).map(&:id)
+          actual_step_ids = normalized_jobs.keys
+          missing_step_ids = expected_step_ids - actual_step_ids
+          unknown_step_ids = actual_step_ids - expected_step_ids
+
+          raise InvalidExecutionError, "missing workflow compensation job #{missing_step_ids.first.inspect}" unless missing_step_ids.empty?
+          raise InvalidExecutionError, "unknown workflow compensation job #{unknown_step_ids.first.inspect}" unless unknown_step_ids.empty?
+        end
+
+        def validate_jobs(normalized_jobs)
+          definition.steps.select(&:compensable?).each do |workflow_step|
+            CompensationJob.new(workflow_step, normalized_jobs.fetch(workflow_step.id)).validate
+          end
+        end
+      end
+
+      # Validates one compensation job against its workflow step contract.
+      class CompensationJob
+        def initialize(workflow_step, job)
+          @workflow_step = workflow_step
+          @job = job
+        end
+
+        def validate
+          raise InvalidExecutionError, "workflow compensation #{step_label} job must be a Karya::Job" unless job.is_a?(Job)
+          raise InvalidExecutionError, "workflow compensation #{step_label} job must be in :submission state" unless job.state == :submission
+          unless job.handler == workflow_step.compensate_with
+            raise InvalidExecutionError, "workflow compensation #{step_label} job handler must match workflow compensation handler"
+          end
+          return if job.arguments == workflow_step.compensation_arguments
+
+          raise InvalidExecutionError, "workflow compensation #{step_label} job arguments must match workflow compensation arguments"
+        end
+
+        private
+
+        attr_reader :job, :workflow_step
+
+        def step_label
+          workflow_step.id.inspect
+        end
+      end
+
       # Maps each concrete workflow job id to its prerequisite concrete job ids.
       class DependencyJobIds
         def initialize(definition:, jobs_by_step_id:)
@@ -122,7 +185,11 @@ module Karya
         end
       end
 
-      private_constant :DependencyJobIds, :JobMap, :StepJob
+      private_constant :CompensationJob,
+                       :CompensationJobMap,
+                       :DependencyJobIds,
+                       :JobMap,
+                       :StepJob
     end
   end
 end

--- a/core/karya/lib/karya/workflow/execution_binding.rb
+++ b/core/karya/lib/karya/workflow/execution_binding.rb
@@ -107,6 +107,8 @@ module Karya
         end
 
         def to_h
+          raise InvalidExecutionError, 'compensation_jobs_by_step_id must be a Hash' unless jobs_by_step_id.is_a?(Hash)
+
           normalized_jobs = JobMap.new(jobs_by_step_id, label: 'workflow compensation job').to_h
           validate_step_coverage(normalized_jobs)
           validate_jobs(normalized_jobs)

--- a/core/karya/lib/karya/workflow/execution_binding.rb
+++ b/core/karya/lib/karya/workflow/execution_binding.rb
@@ -53,8 +53,9 @@ module Karya
 
       # Normalizes caller-supplied step ids without interning request input.
       class JobMap
-        def initialize(jobs_by_step_id)
+        def initialize(jobs_by_step_id, label: 'workflow step job')
           @jobs_by_step_id = jobs_by_step_id
+          @label = label
         end
 
         def to_h
@@ -62,7 +63,7 @@ module Karya
 
           jobs_by_step_id.each_with_object({}) do |(step_id, job), normalized|
             normalized_step_id = Workflow.send(:normalize_execution_identifier, :step_id, step_id)
-            raise InvalidExecutionError, "duplicate workflow step job #{normalized_step_id.inspect}" if normalized.key?(normalized_step_id)
+            raise InvalidExecutionError, "duplicate #{label} #{normalized_step_id.inspect}" if normalized.key?(normalized_step_id)
 
             normalized[normalized_step_id] = job
           end.freeze
@@ -70,7 +71,7 @@ module Karya
 
         private
 
-        attr_reader :jobs_by_step_id
+        attr_reader :jobs_by_step_id, :label
       end
 
       # Validates one concrete job against its workflow step contract.
@@ -106,7 +107,7 @@ module Karya
         end
 
         def to_h
-          normalized_jobs = JobMap.new(jobs_by_step_id).to_h
+          normalized_jobs = JobMap.new(jobs_by_step_id, label: 'workflow compensation job').to_h
           validate_step_coverage(normalized_jobs)
           validate_jobs(normalized_jobs)
           normalized_jobs.freeze

--- a/core/karya/lib/karya/workflow/execution_binding.rb
+++ b/core/karya/lib/karya/workflow/execution_binding.rb
@@ -18,9 +18,12 @@ module Karya
         validate_step_coverage(normalized_jobs)
         @jobs_by_step_id = normalized_jobs
         validate_jobs
-        @compensation_jobs_by_step_id = CompensationJobMap.new(definition:, jobs_by_step_id: compensation_jobs_by_step_id).to_h
-        @jobs = definition.steps.map { |workflow_step| normalized_jobs.fetch(workflow_step.id) }.freeze
-        @dependency_job_ids_by_job_id = DependencyJobIds.new(definition:, jobs_by_step_id: normalized_jobs).to_h
+        @compensation_jobs_by_step_id = CompensationJobMap.new(
+          definition: @definition,
+          jobs_by_step_id: compensation_jobs_by_step_id
+        ).to_h
+        @jobs = @definition.steps.map { |workflow_step| normalized_jobs.fetch(workflow_step.id) }.freeze
+        @dependency_job_ids_by_job_id = DependencyJobIds.new(definition: @definition, jobs_by_step_id: normalized_jobs).to_h
         freeze
       end
 

--- a/core/karya/lib/karya/workflow/step.rb
+++ b/core/karya/lib/karya/workflow/step.rb
@@ -21,12 +21,12 @@ module Karya
       def initialize(id:, handler:, **options)
         @id = Workflow.send(:normalize_identifier, :step_id, id)
         @handler = Workflow.send(:normalize_identifier, :handler, handler)
-        @options = Options.new(options)
-        @arguments = Arguments.new(@options.arguments, step_id: @id, handler: @handler).normalize
-        @depends_on = Dependencies.new(@options.depends_on).normalize
-        @compensate_with = CompensationHandler.new(@options.compensate_with).normalize
+        normalized_options = Options.new(options)
+        @arguments = Arguments.new(normalized_options.arguments, step_id: @id, handler: @handler).normalize
+        @depends_on = Dependencies.new(normalized_options.depends_on).normalize
+        @compensate_with = CompensationHandler.new(normalized_options.compensate_with).normalize
         @compensation_arguments = Arguments.new(
-          @options.compensation_arguments,
+          normalized_options.compensation_arguments,
           step_id: @id,
           handler: compensation_handler_label
         ).normalize

--- a/core/karya/lib/karya/workflow/step.rb
+++ b/core/karya/lib/karya/workflow/step.rb
@@ -30,6 +30,7 @@ module Karya
           step_id: @id,
           handler: compensation_handler_label
         ).normalize
+        validate_compensation_configuration
         freeze
       end
 
@@ -37,7 +38,7 @@ module Karya
         !!compensate_with
       end
 
-      # Normalizes optional constructor fields without growing the public API.
+      # Centralizes optional constructor field defaults and key validation.
       class Options
         ALLOWED_KEYS = %i[arguments depends_on compensate_with compensation_arguments].freeze
 
@@ -146,6 +147,12 @@ module Karya
       private_constant :Arguments, :CompensationHandler, :Dependencies, :Options
 
       private
+
+      def validate_compensation_configuration
+        return if compensate_with || compensation_arguments.empty?
+
+        raise InvalidDefinitionError, "workflow step #{id.inspect} cannot define compensation_arguments without compensate_with"
+      end
 
       def compensation_handler_label
         compensate_with || 'compensation'

--- a/core/karya/lib/karya/workflow/step.rb
+++ b/core/karya/lib/karya/workflow/step.rb
@@ -68,10 +68,21 @@ module Karya
         attr_reader :options
 
         def validate_keys
-          unexpected_keys = options.keys - ALLOWED_KEYS
           return if unexpected_keys.empty?
 
-          raise ArgumentError, "unknown keyword: :#{unexpected_keys.first}"
+          raise ArgumentError, "#{unknown_keyword_label}: #{formatted_unexpected_keys}"
+        end
+
+        def unexpected_keys
+          options.keys - ALLOWED_KEYS
+        end
+
+        def unknown_keyword_label
+          unexpected_keys.length == 1 ? 'unknown keyword' : 'unknown keywords'
+        end
+
+        def formatted_unexpected_keys
+          unexpected_keys.map { |key| ":#{key}" }.join(', ')
         end
       end
 

--- a/core/karya/lib/karya/workflow/step.rb
+++ b/core/karya/lib/karya/workflow/step.rb
@@ -11,14 +11,67 @@ module Karya
   module Workflow
     # Immutable one-step workflow composition unit.
     class Step
-      attr_reader :arguments, :depends_on, :handler, :id
+      attr_reader :arguments,
+                  :compensate_with,
+                  :compensation_arguments,
+                  :depends_on,
+                  :handler,
+                  :id
 
-      def initialize(id:, handler:, arguments: {}, depends_on: nil)
+      def initialize(id:, handler:, **options)
         @id = Workflow.send(:normalize_identifier, :step_id, id)
         @handler = Workflow.send(:normalize_identifier, :handler, handler)
-        @arguments = Arguments.new(arguments, step_id: @id, handler: @handler).normalize
-        @depends_on = Dependencies.new(depends_on).normalize
+        @options = Options.new(options)
+        @arguments = Arguments.new(@options.arguments, step_id: @id, handler: @handler).normalize
+        @depends_on = Dependencies.new(@options.depends_on).normalize
+        @compensate_with = CompensationHandler.new(@options.compensate_with).normalize
+        @compensation_arguments = Arguments.new(
+          @options.compensation_arguments,
+          step_id: @id,
+          handler: compensation_handler_label
+        ).normalize
         freeze
+      end
+
+      def compensable?
+        !!compensate_with
+      end
+
+      # Normalizes optional constructor fields without growing the public API.
+      class Options
+        ALLOWED_KEYS = %i[arguments depends_on compensate_with compensation_arguments].freeze
+
+        def initialize(options)
+          @options = options
+          validate_keys
+        end
+
+        def arguments
+          options.fetch(:arguments, {})
+        end
+
+        def depends_on
+          options.fetch(:depends_on, nil)
+        end
+
+        def compensate_with
+          options.fetch(:compensate_with, nil)
+        end
+
+        def compensation_arguments
+          options.fetch(:compensation_arguments, {})
+        end
+
+        private
+
+        attr_reader :options
+
+        def validate_keys
+          unexpected_keys = options.keys - ALLOWED_KEYS
+          return if unexpected_keys.empty?
+
+          raise ArgumentError, "unknown keyword: :#{unexpected_keys.first}"
+        end
       end
 
       # Normalizes workflow step arguments into the same immutable scalar graph
@@ -70,7 +123,33 @@ module Karya
         end
       end
 
-      private_constant :Arguments, :Dependencies
+      # Normalizes an optional compensation handler.
+      class CompensationHandler
+        def initialize(value)
+          @value = value
+        end
+
+        def normalize
+          case value
+          when NilClass
+            nil
+          else
+            Workflow.send(:normalize_identifier, :compensate_with, value)
+          end
+        end
+
+        private
+
+        attr_reader :value
+      end
+
+      private_constant :Arguments, :CompensationHandler, :Dependencies, :Options
+
+      private
+
+      def compensation_handler_label
+        compensate_with || 'compensation'
+      end
     end
   end
 end

--- a/core/karya/sig/karya.rbs
+++ b/core/karya/sig/karya.rbs
@@ -184,7 +184,8 @@ module Karya
     :dead_letter_jobs |
     :replay_dead_letter_jobs |
     :retry_dead_letter_jobs |
-    :discard_dead_letter_jobs
+    :discard_dead_letter_jobs |
+    :rollback_workflow
   type queue_control_action = :pause_queue | :resume_queue
   type bulk_skip_reason = :not_found | :ineligible_state | :duplicate_request | :uniqueness_conflict
   type batch_aggregate_state = :failed | :running | :succeeded | :cancelled | :completed

--- a/core/karya/sig/karya/queue_store/base.rbs
+++ b/core/karya/sig/karya/queue_store/base.rbs
@@ -17,10 +17,13 @@ module Karya
         definition: Karya::Workflow::Definition,
         jobs_by_step_id: Hash[Karya::state_name, Job],
         batch_id: Karya::state_name,
-        now: Time
+        now: Time,
+        ?compensation_jobs_by_step_id: Hash[Karya::state_name, Job]
       ) -> BulkMutationReport
 
       def workflow_snapshot: (batch_id: Karya::state_name, now: Time) -> Karya::Workflow::Snapshot
+
+      def rollback_workflow: (batch_id: Karya::state_name, now: Time, reason: String) -> BulkMutationReport
 
       def reserve: (
         worker_id: String,

--- a/core/karya/sig/karya/queue_store/in_memory.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory.rbs
@@ -41,9 +41,11 @@ module Karya
         definition: Karya::Workflow::Definition,
         jobs_by_step_id: Hash[Karya::state_name, Job],
         batch_id: Karya::state_name,
-        now: Time
+        now: Time,
+        ?compensation_jobs_by_step_id: Hash[Karya::state_name, Job]
       ) -> BulkMutationReport
       def workflow_snapshot: (batch_id: Karya::state_name, now: Time) -> Karya::Workflow::Snapshot
+      def rollback_workflow: (batch_id: Karya::state_name, now: Time, reason: String) -> BulkMutationReport
       def reserve: (
         worker_id: String,
         lease_duration: Karya::lease_duration_value,

--- a/core/karya/sig/karya/queue_store/in_memory/internal/batch_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/batch_support.rbs
@@ -11,6 +11,7 @@ module Karya
           def build_enqueue_batch: (batch_id: Karya::state_name, jobs: Array[Job], now: Time) -> Karya::Workflow::Batch
           def store_optional_batch: (Karya::Workflow::Batch? batch) -> Karya::Workflow::Batch?
           def store_batch: (Karya::Workflow::Batch batch) -> Karya::Workflow::Batch
+          def workflow_rollback_batch_id?: (String batch_id) -> bool
           def fetch_batch: (String batch_id) -> Karya::Workflow::Batch
           def fetch_batch_jobs: (Karya::Workflow::Batch batch) -> Array[Job]
         end

--- a/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
@@ -82,8 +82,6 @@ module Karya
           def reservation_token_in_use?: (String reservation_token) -> bool
           def register_batch: (Karya::Workflow::Batch batch) -> Karya::Workflow::Batch
           def prune_terminal_batches: (Integer retention_limit, ?changed_job: Job?) -> Array[String]
-          def register_workflow_dependencies: (Hash[String, Array[String]] dependency_job_ids_by_job_id) -> Hash[String, Array[String]]
-          def workflow_dependency_job_ids_for: (String job_id) -> Array[String]?
           def register_workflow: (
             batch_id: String,
             workflow_id: String,

--- a/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
@@ -31,6 +31,7 @@ module Karya
           @terminal_batch_ids_in_order: Array[String]
           @workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
           @workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+          @workflow_rollbacks_by_batch_id: Hash[String, WorkflowRollback]
 
           attr_reader breaker_failures_by_scope: Hash[String, Array[Time]]
           attr_reader batches_by_id: Hash[String, Karya::Workflow::Batch]
@@ -53,6 +54,7 @@ module Karya
           attr_reader stuck_job_recoveries_by_id: Hash[String, Karya::stuck_job_recovery]
           attr_reader workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
           attr_reader workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+          attr_reader workflow_rollbacks_by_batch_id: Hash[String, WorkflowRollback]
 
           def initialize: (expired_tombstone_limit: Integer) -> void
           def queue_job_ids_for: (String queue) -> Array[String]
@@ -80,12 +82,22 @@ module Karya
           def reservation_token_in_use?: (String reservation_token) -> bool
           def register_batch: (Karya::Workflow::Batch batch) -> Karya::Workflow::Batch
           def prune_terminal_batches: (Integer retention_limit, ?changed_job: Job?) -> Array[String]
+          def register_workflow_dependencies: (Hash[String, Array[String]] dependency_job_ids_by_job_id) -> Hash[String, Array[String]]
+          def workflow_dependency_job_ids_for: (String job_id) -> Array[String]?
           def register_workflow: (
             batch_id: String,
             workflow_id: String,
             step_job_ids: Hash[String, String],
-            dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            dependency_job_ids_by_job_id: Hash[String, Array[String]],
+            compensation_jobs_by_step_id: Hash[String, Job]
           ) -> WorkflowRegistration
+          def register_workflow_rollback: (
+            batch_id: String,
+            rollback_batch_id: String,
+            reason: String,
+            requested_at: Time,
+            compensation_job_ids: Array[String]
+          ) -> WorkflowRollback
 
           private
 
@@ -95,16 +107,19 @@ module Karya
             @workflow_id: String
             @step_job_ids: Hash[String, String]
             @dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            @compensation_jobs_by_step_id: Hash[String, Job]
 
             def initialize: (
               String workflow_id,
               Hash[String, String] step_job_ids,
-              Hash[String, Array[String]] dependency_job_ids_by_job_id
+              Hash[String, Array[String]] dependency_job_ids_by_job_id,
+              Hash[String, Job] compensation_jobs_by_step_id
             ) -> void
 
             attr_reader workflow_id: String
             attr_reader step_job_ids: Hash[String, String]
             attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            attr_reader compensation_jobs_by_step_id: Hash[String, Job]
           end
 
           class PrunedBatchCleanup
@@ -141,6 +156,28 @@ module Karya
             def pruned_job_ids: () -> Array[String]?
             def cleanup_batch_jobs: () -> Array[String]?
             def cleanup_stale_batch_membership: () -> Array[String]
+          end
+
+          class WorkflowRollback
+            @batch_id: String
+            @rollback_batch_id: String
+            @reason: String
+            @requested_at: Time
+            @compensation_job_ids: Array[String]
+
+            def initialize: (
+              String batch_id,
+              String rollback_batch_id,
+              String reason,
+              Time requested_at,
+              Array[String] compensation_job_ids
+            ) -> void
+
+            attr_reader batch_id: String
+            attr_reader rollback_batch_id: String
+            attr_reader reason: String
+            attr_reader requested_at: Time
+            attr_reader compensation_job_ids: Array[String]
           end
 
           def trim_fair_queue_history: () -> void

--- a/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
@@ -30,6 +30,7 @@ module Karya
           @terminal_batch_ids_index: Hash[String, bool]
           @terminal_batch_ids_in_order: Array[String]
           @workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+          @workflow_rollback_batch_ids: Hash[String, bool]
           @workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
           @workflow_rollbacks_by_batch_id: Hash[String, WorkflowRollback]
 
@@ -53,6 +54,7 @@ module Karya
           attr_reader reservations_by_token: Hash[String, Reservation]
           attr_reader stuck_job_recoveries_by_id: Hash[String, Karya::stuck_job_recovery]
           attr_reader workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+          attr_reader workflow_rollback_batch_ids: Hash[String, bool]
           attr_reader workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
           attr_reader workflow_rollbacks_by_batch_id: Hash[String, WorkflowRollback]
 
@@ -123,23 +125,41 @@ module Karya
           class PrunedBatchCleanup
             @batch_id: String
             @batch: Karya::Workflow::Batch?
-            @batch_id_by_job_id: Hash[String, String]
-            @workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
-            @workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+            @job_indexes: {
+              batch_id_by_job_id: Hash[String, String],
+              workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            }
+            @workflow_indexes: {
+              workflow_rollback_batch_ids: Hash[String, bool],
+              workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration],
+              workflow_rollbacks_by_batch_id: Hash[String, WorkflowRollback]
+            }
 
             def self.call: (
               batch_id: String,
               batch: Karya::Workflow::Batch?,
-              batch_id_by_job_id: Hash[String, String],
-              workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]],
-              workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+              job_indexes: {
+                batch_id_by_job_id: Hash[String, String],
+                workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+              },
+              workflow_indexes: {
+                workflow_rollback_batch_ids: Hash[String, bool],
+                workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration],
+                workflow_rollbacks_by_batch_id: Hash[String, WorkflowRollback]
+              }
             ) -> WorkflowRegistration?
             def initialize: (
               batch_id: String,
               batch: Karya::Workflow::Batch?,
-              batch_id_by_job_id: Hash[String, String],
-              workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]],
-              workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+              job_indexes: {
+                batch_id_by_job_id: Hash[String, String],
+                workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+              },
+              workflow_indexes: {
+                workflow_rollback_batch_ids: Hash[String, bool],
+                workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration],
+                workflow_rollbacks_by_batch_id: Hash[String, WorkflowRollback]
+              }
             ) -> void
             def call: () -> WorkflowRegistration?
 
@@ -147,13 +167,24 @@ module Karya
 
             attr_reader batch: Karya::Workflow::Batch?
             attr_reader batch_id: String
-            attr_reader batch_id_by_job_id: Hash[String, String]
-            attr_reader workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
-            attr_reader workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration]
+            attr_reader job_indexes: {
+              batch_id_by_job_id: Hash[String, String],
+              workflow_dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            }
+            attr_reader workflow_indexes: {
+              workflow_rollback_batch_ids: Hash[String, bool],
+              workflow_registrations_by_batch_id: Hash[String, WorkflowRegistration],
+              workflow_rollbacks_by_batch_id: Hash[String, WorkflowRollback]
+            }
 
             def pruned_job_ids: () -> Array[String]?
             def cleanup_batch_jobs: () -> Array[String]?
             def cleanup_stale_batch_membership: () -> Array[String]
+            def batch_id_by_job_id: () -> Hash[String, String]
+            def workflow_dependency_job_ids_by_job_id: () -> Hash[String, Array[String]]
+            def workflow_rollback_batch_ids: () -> Hash[String, bool]
+            def workflow_registrations_by_batch_id: () -> Hash[String, WorkflowRegistration]
+            def workflow_rollbacks_by_batch_id: () -> Hash[String, WorkflowRollback]
           end
 
           class WorkflowRollback

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -7,11 +7,69 @@ module Karya
             definition: Karya::Workflow::Definition,
             jobs_by_step_id: Hash[Karya::state_name, Job],
             batch_id: Karya::state_name,
-            now: Time
+            now: Time,
+            ?compensation_jobs_by_step_id: Hash[Karya::state_name, Job]
           ) -> BulkMutationReport
           def workflow_snapshot: (batch_id: Karya::state_name, now: Time) -> Karya::Workflow::Snapshot
+          def rollback_workflow: (batch_id: Karya::state_name, now: Time, reason: String) -> BulkMutationReport
 
           private
+
+          class Rollback
+            @workflow_batch_id: String
+            @rollback_batch_id: String
+            @batch: Karya::Workflow::Batch?
+            @plan: RollbackPlan::Plan
+
+            attr_reader workflow_batch_id: String
+            attr_reader rollback_batch_id: String
+            attr_reader batch: Karya::Workflow::Batch?
+            attr_reader plan: RollbackPlan::Plan
+          end
+
+          class RollbackBatchId
+            @batch_id: String
+
+            def initialize: (String batch_id) -> void
+            def to_s: () -> String
+
+          private
+
+            attr_reader batch_id: String
+          end
+
+          class RollbackPlan
+            @registration: InMemory::Internal::StoreState::WorkflowRegistration
+            @jobs_by_id: Hash[String, Job]
+
+            def initialize: (registration: InMemory::Internal::StoreState::WorkflowRegistration, jobs: Array[Job]) -> void
+            def to_plan: () -> RollbackPlan::Plan
+
+          private
+
+            attr_reader registration: InMemory::Internal::StoreState::WorkflowRegistration
+            attr_reader jobs_by_id: Hash[String, Job]
+            def ordered_compensation_jobs: () -> Array[Job]
+
+            class Plan
+              @jobs: Array[Job]
+              @dependency_job_ids_by_job_id: Hash[String, Array[String]]
+
+              attr_reader jobs: Array[Job]
+              attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            end
+          end
+
+          class RollbackDependencies
+            @jobs: Array[Job]
+
+            def initialize: (Array[Job] jobs) -> void
+            def to_h: () -> Hash[String, Array[String]]
+
+          private
+
+            attr_reader jobs: Array[Job]
+          end
 
           class StepJobIds
             @definition: Karya::Workflow::Definition
@@ -27,7 +85,53 @@ module Karya
           end
 
           def fetch_workflow_registration: (String batch_id) -> InMemory::Internal::StoreState::WorkflowRegistration
+          def prepare_rollback: (String batch_id, Time now) -> Rollback
+          def build_rollback_batch: (batch_id: String, jobs: Array[Job], now: Time) -> Karya::Workflow::Batch?
+          def raise_duplicate_batch: (String batch_id) -> nil
+          def workflow_snapshot_for: (
+            batch: Karya::Workflow::Batch,
+            registration: InMemory::Internal::StoreState::WorkflowRegistration,
+            jobs: Array[Job],
+            now: Time
+          ) -> Karya::Workflow::Snapshot
+          def raise_duplicate_rollback: (String batch_id) -> nil
           def workflow_dependencies_satisfied?: (Job job) -> bool
+
+          class WorkflowSnapshotBuilder
+            @batch: Karya::Workflow::Batch
+            @registration: InMemory::Internal::StoreState::WorkflowRegistration
+            @jobs: Array[Job]
+            @now: Time
+            @dependency_job_ids_by_job_id: Hash[String, Array[String]]
+
+            def initialize: (
+              batch: Karya::Workflow::Batch,
+              registration: InMemory::Internal::StoreState::WorkflowRegistration,
+              jobs: Array[Job],
+              now: Time,
+              dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            ) -> void
+            def to_snapshot: () -> Karya::Workflow::Snapshot
+
+          private
+
+            attr_reader batch: Karya::Workflow::Batch
+            attr_reader registration: InMemory::Internal::StoreState::WorkflowRegistration
+            attr_reader jobs: Array[Job]
+            attr_reader now: Time
+            attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
+          end
+
+          class RollbackState
+            @snapshot: Karya::Workflow::Snapshot
+
+            def initialize: (Karya::Workflow::Snapshot snapshot) -> void
+            def validate: () -> nil
+
+          private
+
+            attr_reader snapshot: Karya::Workflow::Snapshot
+          end
         end
       end
     end

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -85,6 +85,7 @@ module Karya
           end
 
           def fetch_workflow_registration: (String batch_id) -> InMemory::Internal::StoreState::WorkflowRegistration
+          def normalize_rollback_reason: (untyped reason) -> String
           def prepare_rollback: (String batch_id, Time now) -> Rollback
           def build_rollback_batch: (batch_id: String, jobs: Array[Job], now: Time) -> Karya::Workflow::Batch?
           def raise_duplicate_batch: (String batch_id) -> nil

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -126,6 +126,7 @@ module Karya
 
           private
 
+            ACTIVE_JOB_STATES: Array[Symbol]
             WAITING_JOB_STATES: Array[Symbol]
             attr_reader snapshot: Karya::Workflow::Snapshot
             attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -21,6 +21,7 @@ module Karya
             @batch: Karya::Workflow::Batch?
             @plan: RollbackPlan::Plan
 
+            def initialize: (String workflow_batch_id, String rollback_batch_id, Karya::Workflow::Batch? batch, RollbackPlan::Plan plan) -> void
             attr_reader workflow_batch_id: String
             attr_reader rollback_batch_id: String
             attr_reader batch: Karya::Workflow::Batch?
@@ -55,6 +56,7 @@ module Karya
               @jobs: Array[Job]
               @dependency_job_ids_by_job_id: Hash[String, Array[String]]
 
+              def initialize: (Array[Job] jobs, Hash[String, Array[String]] dependency_job_ids_by_job_id) -> void
               attr_reader jobs: Array[Job]
               attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
             end

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -118,15 +118,23 @@ module Karya
 
           class RollbackState
             @snapshot: Karya::Workflow::Snapshot
+            @dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            @jobs_by_id: Hash[String, Job]
 
-            def initialize: (Karya::Workflow::Snapshot snapshot) -> void
+            def initialize: (Karya::Workflow::Snapshot snapshot, Hash[String, Array[String]] dependency_job_ids_by_job_id) -> void
             def validate: () -> nil
 
           private
 
+            WAITING_JOB_STATES: Array[Symbol]
             attr_reader snapshot: Karya::Workflow::Snapshot
+            attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            attr_reader jobs_by_id: Hash[String, Job]
             def failed_snapshot?: () -> bool
             def active_jobs?: () -> bool
+            def active_job?: (Job job) -> bool
+            def runnable_waiting_job?: (Job job) -> bool
+            def dependencies_satisfied?: (Job job) -> bool
             def validation_error_message: () -> String
           end
         end

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -85,7 +85,7 @@ module Karya
           end
 
           def fetch_workflow_registration: (String batch_id) -> InMemory::Internal::StoreState::WorkflowRegistration
-          def normalize_rollback_reason: (untyped reason) -> String
+          def normalize_rollback_reason: (String reason) -> String
           def prepare_rollback: (String batch_id, Time now) -> Rollback
           def build_rollback_batch: (batch_id: String, jobs: Array[Job], now: Time) -> Karya::Workflow::Batch?
           def raise_duplicate_batch: (String batch_id) -> nil

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -125,6 +125,9 @@ module Karya
           private
 
             attr_reader snapshot: Karya::Workflow::Snapshot
+            def failed_snapshot?: () -> bool
+            def active_jobs?: () -> bool
+            def validation_error_message: () -> String
           end
         end
       end

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -88,12 +88,6 @@ module Karya
           def prepare_rollback: (String batch_id, Time now) -> Rollback
           def build_rollback_batch: (batch_id: String, jobs: Array[Job], now: Time) -> Karya::Workflow::Batch?
           def raise_duplicate_batch: (String batch_id) -> nil
-          def workflow_snapshot_for: (
-            batch: Karya::Workflow::Batch,
-            registration: InMemory::Internal::StoreState::WorkflowRegistration,
-            jobs: Array[Job],
-            now: Time
-          ) -> Karya::Workflow::Snapshot
           def raise_duplicate_rollback: (String batch_id) -> nil
           def workflow_dependencies_satisfied?: (Job job) -> bool
 
@@ -102,14 +96,12 @@ module Karya
             @registration: InMemory::Internal::StoreState::WorkflowRegistration
             @jobs: Array[Job]
             @now: Time
-            @dependency_job_ids_by_job_id: Hash[String, Array[String]]
 
             def initialize: (
               batch: Karya::Workflow::Batch,
               registration: InMemory::Internal::StoreState::WorkflowRegistration,
               jobs: Array[Job],
-              now: Time,
-              dependency_job_ids_by_job_id: Hash[String, Array[String]]
+              now: Time
             ) -> void
             def to_snapshot: () -> Karya::Workflow::Snapshot
 
@@ -119,7 +111,6 @@ module Karya
             attr_reader registration: InMemory::Internal::StoreState::WorkflowRegistration
             attr_reader jobs: Array[Job]
             attr_reader now: Time
-            attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
           end
 
           class RollbackState

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -611,13 +611,15 @@ module Karya
 
       class JobMap
         @jobs_by_step_id: Hash[state_name, Job]
+        @label: String
 
-        def initialize: (Hash[state_name, Job] jobs_by_step_id) -> void
+        def initialize: (Hash[state_name, Job] jobs_by_step_id, ?label: String) -> void
         def to_h: () -> Hash[String, Job]
 
       private
 
         attr_reader jobs_by_step_id: Hash[state_name, Job]
+        attr_reader label: String
       end
 
       class StepJob

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -387,18 +387,26 @@ module Karya
       @handler: String
       @arguments: Hash[String, job_argument]
       @depends_on: Array[String]
+      @compensate_with: String?
+      @compensation_arguments: Hash[String, job_argument]
+      @options: Options
 
       attr_reader id: String
       attr_reader handler: String
       attr_reader arguments: Hash[String, job_argument]
       attr_reader depends_on: Array[String]
+      attr_reader compensate_with: String?
+      attr_reader compensation_arguments: Hash[String, job_argument]
 
       def initialize: (
         id: state_name,
         handler: state_name,
         ?arguments: Hash[state_name, job_argument],
-        ?depends_on: (state_name | Array[state_name] | nil)
+        ?depends_on: (state_name | Array[state_name] | nil),
+        ?compensate_with: state_name?,
+        ?compensation_arguments: Hash[state_name, job_argument]
       ) -> void
+      def compensable?: () -> bool
 
     private
 
@@ -422,6 +430,23 @@ module Karya
         def context_message: () -> String
       end
 
+      class Options
+        ALLOWED_KEYS: Array[Symbol]
+
+        @options: Hash[Symbol, Hash[state_name, job_argument] | (state_name | Array[state_name] | nil)]
+
+        def initialize: (Hash[Symbol, Hash[state_name, job_argument] | (state_name | Array[state_name] | nil)] options) -> void
+        def arguments: () -> Hash[state_name, job_argument]
+        def depends_on: () -> (state_name | Array[state_name] | nil)
+        def compensate_with: () -> state_name?
+        def compensation_arguments: () -> Hash[state_name, job_argument]
+
+      private
+
+        attr_reader options: Hash[Symbol, Hash[state_name, job_argument] | (state_name | Array[state_name] | nil)]
+        def validate_keys: () -> void
+      end
+
       class Dependencies
         @value: (state_name | Array[state_name] | nil)
 
@@ -433,6 +458,19 @@ module Karya
         attr_reader value: (state_name | Array[state_name] | nil)
         def raw_dependencies: () -> Array[state_name]
       end
+
+      class CompensationHandler
+        @value: state_name?
+
+        def initialize: (state_name? value) -> void
+        def normalize: () -> String?
+
+      private
+
+        attr_reader value: state_name?
+      end
+
+      def compensation_handler_label: () -> String
     end
 
     class Definition
@@ -515,13 +553,26 @@ module Karya
       jobs_by_step_id: Hash[state_name, Job],
       batch_id: state_name
     ) -> ExecutionBinding
+    def self.build_compensated_execution_binding: (
+      definition: Definition,
+      jobs_by_step_id: Hash[state_name, Job],
+      batch_id: state_name,
+      compensation_jobs_by_step_id: Hash[state_name, Job]
+    ) -> ExecutionBinding
 
     class Builder
       @id: state_name
       @steps: Array[Step]
 
       def initialize: (state_name id) -> void
-      def step: (state_name id, handler: state_name, ?arguments: Hash[state_name, job_argument], ?depends_on: (state_name | Array[state_name] | nil)) -> nil
+      def step: (
+        state_name id,
+        handler: state_name,
+        ?arguments: Hash[state_name, job_argument],
+        ?depends_on: (state_name | Array[state_name] | nil),
+        ?compensate_with: state_name?,
+        ?compensation_arguments: Hash[state_name, job_argument]
+      ) -> nil
       def to_definition: () -> Definition
 
     private
@@ -534,17 +585,20 @@ module Karya
       @definition: Definition
       @batch_id: String
       @jobs_by_step_id: Hash[String, Job]
+      @compensation_jobs_by_step_id: Hash[String, Job]
       @jobs: Array[Job]
       @dependency_job_ids_by_job_id: Hash[String, Array[String]]
 
       attr_reader batch_id: String
       attr_reader jobs: Array[Job]
+      attr_reader compensation_jobs_by_step_id: Hash[String, Job]
       attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
 
       def initialize: (
         definition: Definition,
         jobs_by_step_id: Hash[state_name, Job],
-        batch_id: state_name
+        batch_id: state_name,
+        ?compensation_jobs_by_step_id: Hash[state_name, Job]
       ) -> void
 
     private
@@ -568,6 +622,35 @@ module Karya
       end
 
       class StepJob
+        @workflow_step: Step
+        @job: Job
+
+        def initialize: (Step workflow_step, Job job) -> void
+        def validate: () -> void
+
+      private
+
+        attr_reader job: Job
+        attr_reader workflow_step: Step
+        def step_label: () -> String
+      end
+
+      class CompensationJobMap
+        @definition: Definition
+        @jobs_by_step_id: Hash[state_name, Job]
+
+        def initialize: (definition: Definition, jobs_by_step_id: Hash[state_name, Job]) -> void
+        def to_h: () -> Hash[String, Job]
+
+      private
+
+        attr_reader definition: Definition
+        attr_reader jobs_by_step_id: Hash[state_name, Job]
+        def validate_step_coverage: (Hash[String, Job] normalized_jobs) -> void
+        def validate_jobs: (Hash[String, Job] normalized_jobs) -> void
+      end
+
+      class CompensationJob
         @workflow_step: Step
         @job: Job
 

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -389,7 +389,6 @@ module Karya
       @depends_on: Array[String]
       @compensate_with: String?
       @compensation_arguments: Hash[String, job_argument]
-      @options: Options
 
       attr_reader id: String
       attr_reader handler: String

--- a/core/karya/spec/karya/queue_store/in_memory/internal/batch_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/batch_support_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::BatchSupport' do
     end.to raise_error(Karya::Workflow::UnknownBatchError, 'batch "missing" is not registered')
   end
 
+  it 'rejects batch ids reserved for workflow rollback batches' do
+    store.send(:state).register_workflow_rollback(
+      batch_id: 'batch_1',
+      rollback_batch_id: 'batch_1.rollback',
+      reason: 'operator rollback',
+      requested_at: created_at,
+      compensation_job_ids: []
+    )
+
+    expect do
+      store.send(:build_enqueue_batch, batch_id: 'batch_1.rollback', jobs: [submission_job('job_1')], now: created_at)
+    end.to raise_error(Karya::Workflow::DuplicateBatchError, 'batch "batch_1.rollback" already exists')
+  end
+
   it 'raises workflow-domain errors for batches with missing member jobs' do
     batch = Karya::Workflow::Batch.new(id: 'batch_1', job_ids: ['missing_job'], created_at:)
     store.send(:store_batch, batch)

--- a/core/karya/spec/karya/queue_store/in_memory/internal/batch_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/batch_support_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::BatchSupport' do
     Karya::Job.new(id:, queue: :billing, handler: :sync_billing, state: :submission, created_at:)
   end
 
+  def rollback_batch_id(batch_id)
+    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
+    workflow_support = internal.const_get(:WorkflowSupport, false)
+    workflow_support.const_get(:RollbackBatchId, false).new(batch_id).to_s
+  end
+
   it 'builds and stores owner-local batch state' do
     jobs = [submission_job('job_1'), submission_job('job_2')]
 
@@ -41,15 +47,15 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::BatchSupport' do
   it 'rejects batch ids reserved for workflow rollback batches' do
     store.send(:state).register_workflow_rollback(
       batch_id: 'batch_1',
-      rollback_batch_id: 'batch_1.rollback',
+      rollback_batch_id: rollback_batch_id('batch_1'),
       reason: 'operator rollback',
       requested_at: created_at,
       compensation_job_ids: []
     )
 
     expect do
-      store.send(:build_enqueue_batch, batch_id: 'batch_1.rollback', jobs: [submission_job('job_1')], now: created_at)
-    end.to raise_error(Karya::Workflow::DuplicateBatchError, 'batch "batch_1.rollback" already exists')
+      store.send(:build_enqueue_batch, batch_id: rollback_batch_id('batch_1'), jobs: [submission_job('job_1')], now: created_at)
+    end.to raise_error(Karya::Workflow::DuplicateBatchError, "batch #{rollback_batch_id('batch_1').inspect} already exists")
   end
 
   it 'raises workflow-domain errors for batches with missing member jobs' do

--- a/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
@@ -199,6 +199,31 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
     expect(store_state.workflow_dependency_job_ids_by_job_id).to eq({})
   end
 
+  it 'removes workflow rollback metadata when pruning terminal batches' do
+    store_state.jobs_by_id['job-root'] = succeeded_job('job-root')
+    store_state.register_batch(batch('batch-1', ['job-root']))
+    store_state.register_workflow(
+      batch_id: 'batch-1',
+      workflow_id: 'invoice_closeout',
+      step_job_ids: { 'root' => 'job-root' },
+      dependency_job_ids_by_job_id: { 'job-root' => [] },
+      compensation_jobs_by_step_id: {}
+    )
+    store_state.register_workflow_rollback(
+      batch_id: 'batch-1',
+      rollback_batch_id: 'batch-1.rollback',
+      reason: 'operator rollback',
+      requested_at: Time.utc(2026, 4, 24, 12, 0, 0),
+      compensation_job_ids: []
+    )
+
+    expect(store_state.prune_terminal_batches(0)).to eq(['batch-1'])
+
+    expect(store_state.workflow_registrations_by_batch_id).to eq({})
+    expect(store_state.workflow_rollbacks_by_batch_id).to eq({})
+    expect(store_state.workflow_rollback_batch_ids).to eq({})
+  end
+
   it 'stores workflow rollback metadata by workflow batch id' do
     compensation_job_ids = ['rollback-job-1']
 
@@ -215,6 +240,7 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
     expect(rollback.compensation_job_ids).to eq(['rollback-job-1'])
     expect(rollback.compensation_job_ids).to be_frozen
     expect(rollback).to be_frozen
+    expect(store_state.workflow_rollback_batch_ids).to eq('batch-1.rollback' => true)
     expect(store_state.workflow_rollbacks_by_batch_id.fetch('batch-1')).to eq(rollback)
     expect(store_state.workflow_rollbacks_by_batch_id['missing']).to be_nil
   end

--- a/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
       batch_id: 'batch-1',
       workflow_id: 'invoice_closeout',
       step_job_ids: { 'root' => 'job-1' },
-      dependency_job_ids_by_job_id: { 'job-1' => [] }
+      dependency_job_ids_by_job_id: { 'job-1' => [] },
+      compensation_jobs_by_step_id: {}
     )
     store_state.workflow_dependency_job_ids_by_job_id['job-1'] = []
     store_state.workflow_dependency_job_ids_by_job_id['job-2'] = []

--- a/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
@@ -148,25 +148,30 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
     step_job_ids = { 'root' => 'job-root' }
     dependency_job_ids = []
     dependency_job_ids_by_job_id = { 'job-root' => dependency_job_ids }
+    compensation_jobs_by_step_id = { 'root' => instance_double(Karya::Job) }
 
     registration = store_state.register_workflow(
       batch_id: 'batch-1',
       workflow_id: 'invoice_closeout',
       step_job_ids:,
-      dependency_job_ids_by_job_id:
+      dependency_job_ids_by_job_id:,
+      compensation_jobs_by_step_id:
     )
     step_job_ids['root'] = 'mutated'
     dependency_job_ids << 'mutated'
     dependency_job_ids_by_job_id['job-root'] = ['mutated']
+    compensation_jobs_by_step_id['root'] = instance_double(Karya::Job)
 
     expect(registration.workflow_id).to eq('invoice_closeout')
     expect(registration.step_job_ids).to eq('root' => 'job-root')
     expect(registration.dependency_job_ids_by_job_id).to eq('job-root' => [])
+    expect(registration.compensation_jobs_by_step_id.keys).to eq(['root'])
     expect(registration.step_job_ids).to be_frozen
     expect(registration.dependency_job_ids_by_job_id).to be_frozen
     expect(registration.dependency_job_ids_by_job_id.fetch('job-root')).to be_frozen
+    expect(registration.compensation_jobs_by_step_id).to be_frozen
     expect(registration).to be_frozen
-    expect(store_state.workflow_registrations_by_batch_id['batch-1']).to eq(registration)
+    expect(store_state.workflow_registrations_by_batch_id.fetch('batch-1')).to eq(registration)
     expect(store_state.workflow_registrations_by_batch_id['missing']).to be_nil
   end
 
@@ -183,12 +188,33 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
       dependency_job_ids_by_job_id: {
         'job-root' => [],
         'job-child' => ['job-root']
-      }
+      },
+      compensation_jobs_by_step_id: {}
     )
 
     expect(store_state.prune_terminal_batches(0)).to eq(['batch-1'])
 
     expect(store_state.workflow_registrations_by_batch_id).to eq({})
     expect(store_state.workflow_dependency_job_ids_by_job_id).to eq({})
+  end
+
+  it 'stores workflow rollback metadata by workflow batch id' do
+    compensation_job_ids = ['rollback-job-1']
+
+    rollback = store_state.register_workflow_rollback(
+      batch_id: 'batch-1',
+      rollback_batch_id: 'batch-1.rollback',
+      reason: 'operator rollback',
+      requested_at: Time.utc(2026, 4, 24, 12, 0, 0),
+      compensation_job_ids:
+    )
+    compensation_job_ids << 'mutated'
+
+    expect(rollback.rollback_batch_id).to eq('batch-1.rollback')
+    expect(rollback.compensation_job_ids).to eq(['rollback-job-1'])
+    expect(rollback.compensation_job_ids).to be_frozen
+    expect(rollback).to be_frozen
+    expect(store_state.workflow_rollbacks_by_batch_id.fetch('batch-1')).to eq(rollback)
+    expect(store_state.workflow_rollbacks_by_batch_id['missing']).to be_nil
   end
 end

--- a/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/store_state_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
     Karya::Job.new(id:, queue: 'billing', handler: 'billing_sync', state: :queued, created_at:)
   end
 
+  def rollback_batch_id(batch_id)
+    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
+    workflow_support = internal.const_get(:WorkflowSupport, false)
+    workflow_support.const_get(:RollbackBatchId, false).new(batch_id).to_s
+  end
+
   it 'ignores execution tokens that are not present' do
     store_state.execution_tokens_in_order << 'lease-1'
 
@@ -211,7 +217,7 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
     )
     store_state.register_workflow_rollback(
       batch_id: 'batch-1',
-      rollback_batch_id: 'batch-1.rollback',
+      rollback_batch_id: rollback_batch_id('batch-1'),
       reason: 'operator rollback',
       requested_at: Time.utc(2026, 4, 24, 12, 0, 0),
       compensation_job_ids: []
@@ -229,18 +235,18 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::StoreState' do
 
     rollback = store_state.register_workflow_rollback(
       batch_id: 'batch-1',
-      rollback_batch_id: 'batch-1.rollback',
+      rollback_batch_id: rollback_batch_id('batch-1'),
       reason: 'operator rollback',
       requested_at: Time.utc(2026, 4, 24, 12, 0, 0),
       compensation_job_ids:
     )
     compensation_job_ids << 'mutated'
 
-    expect(rollback.rollback_batch_id).to eq('batch-1.rollback')
+    expect(rollback.rollback_batch_id).to eq(rollback_batch_id('batch-1'))
     expect(rollback.compensation_job_ids).to eq(['rollback-job-1'])
     expect(rollback.compensation_job_ids).to be_frozen
     expect(rollback).to be_frozen
-    expect(store_state.workflow_rollback_batch_ids).to eq('batch-1.rollback' => true)
+    expect(store_state.workflow_rollback_batch_ids).to eq(rollback_batch_id('batch-1') => true)
     expect(store_state.workflow_rollbacks_by_batch_id.fetch('batch-1')).to eq(rollback)
     expect(store_state.workflow_rollbacks_by_batch_id['missing']).to be_nil
   end

--- a/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'reason must be present')
   end
 
+  it 'builds frozen rollback batch ids' do
+    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
+    workflow_support = internal.const_get(:WorkflowSupport, false)
+    helper = workflow_support.const_get(:RollbackBatchId, false)
+
+    rollback_batch_id = helper.new('batch-1').to_s
+
+    expect(rollback_batch_id).to eq('batch-1.rollback')
+    expect(rollback_batch_id).to be_frozen
+  end
+
   it 'builds rollback jobs in reverse definition order with serial dependencies' do
     internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
     workflow_support = internal.const_get(:WorkflowSupport, false)

--- a/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
     Karya::Job.new(id:, queue: :rollback, handler: :undo, state: :submission, created_at:)
   end
 
+  def rollback_batch_id(batch_id)
+    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
+    workflow_support = internal.const_get(:WorkflowSupport, false)
+    workflow_support.const_get(:RollbackBatchId, false).new(batch_id).to_s
+  end
+
   it 'treats non-workflow jobs and root workflow jobs as ready' do
     plain_job = job(id: 'job-1', state: :queued)
     root_job = job(id: 'job-2', state: :queued)
@@ -82,14 +88,12 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
   end
 
   it 'builds frozen rollback batch ids' do
-    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
-    workflow_support = internal.const_get(:WorkflowSupport, false)
-    helper = workflow_support.const_get(:RollbackBatchId, false)
+    expect(rollback_batch_id('batch-1')).to eq('__karya_workflow_rollback_v1__62617463682d31')
+    expect(rollback_batch_id('batch-1')).to be_frozen
+  end
 
-    rollback_batch_id = helper.new('batch-1').to_s
-
-    expect(rollback_batch_id).to eq('batch-1.rollback')
-    expect(rollback_batch_id).to be_frozen
+  it 'builds distinct rollback batch ids for suffixed workflow batch ids' do
+    expect(rollback_batch_id('batch-1')).not_to eq(rollback_batch_id('batch-1.rollback'))
   end
 
   it 'builds rollback jobs in reverse definition order with serial dependencies' do

--- a/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
@@ -87,6 +87,18 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'reason must be present')
   end
 
+  it 'rejects non-string rollback reasons with workflow terminology' do
+    expect do
+      store.send(:normalize_rollback_reason, :operator_rollback)
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'reason must be a String')
+  end
+
+  it 'rejects overlong rollback reasons with workflow terminology' do
+    expect do
+      store.send(:normalize_rollback_reason, 'a' * 1025)
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'reason must be at most 1024 characters')
+  end
+
   it 'builds frozen rollback batch ids' do
     expect(rollback_batch_id('batch-1')).to eq('__karya_workflow_rollback_v1__62617463682d31')
     expect(rollback_batch_id('batch-1')).to be_frozen

--- a/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'batch "batch-1" is not a workflow batch')
   end
 
+  it 'rewrites rollback reason validation errors into workflow terminology' do
+    expect do
+      store.send(:normalize_rollback_reason, " \t ")
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'reason must be present')
+  end
+
   it 'builds rollback jobs in reverse definition order with serial dependencies' do
     internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
     workflow_support = internal.const_get(:WorkflowSupport, false)

--- a/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
       'rollback-job-3' => [],
       'rollback-job-1' => ['rollback-job-3']
     )
+    expect(result.dependency_job_ids_by_job_id.fetch('rollback-job-3')).to be_frozen
   end
 
   it 'builds empty rollback plans when every compensation step is skipped' do

--- a/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
       batch_id: 'batch-1',
       workflow_id: 'invoice_closeout',
       step_job_ids: { 'first' => 'job-1', 'second' => 'job-2', 'third' => 'job-3' },
+      dependency_job_ids_by_job_id: {},
       compensation_jobs_by_step_id: {
         'first' => rollback_job('rollback-job-1'),
         'second' => rollback_job('rollback-job-2'),
@@ -110,6 +111,7 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
       batch_id: 'batch-1',
       workflow_id: 'invoice_closeout',
       step_job_ids: { 'first' => 'job-1' },
+      dependency_job_ids_by_job_id: {},
       compensation_jobs_by_step_id: { 'first' => rollback_job('rollback-job-1') }
     )
 

--- a/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory/internal/workflow_support_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
     Karya::Job.new(id:, queue: :billing, handler: :sync_billing, state:, created_at:)
   end
 
+  def rollback_job(id)
+    Karya::Job.new(id:, queue: :rollback, handler: :undo, state: :submission, created_at:)
+  end
+
   it 'treats non-workflow jobs and root workflow jobs as ready' do
     plain_job = job(id: 'job-1', state: :queued)
     root_job = job(id: 'job-2', state: :queued)
@@ -69,5 +73,49 @@ RSpec.describe 'Karya::QueueStore::InMemory::Internal::WorkflowSupport' do
     expect do
       store.send(:fetch_workflow_registration, 'batch-1')
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'batch "batch-1" is not a workflow batch')
+  end
+
+  it 'builds rollback jobs in reverse definition order with serial dependencies' do
+    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
+    workflow_support = internal.const_get(:WorkflowSupport, false)
+    helper = workflow_support.const_get(:RollbackPlan, false)
+    registration = store.send(:state).register_workflow(
+      batch_id: 'batch-1',
+      workflow_id: 'invoice_closeout',
+      step_job_ids: { 'first' => 'job-1', 'second' => 'job-2', 'third' => 'job-3' },
+      compensation_jobs_by_step_id: {
+        'first' => rollback_job('rollback-job-1'),
+        'second' => rollback_job('rollback-job-2'),
+        'third' => rollback_job('rollback-job-3')
+      }
+    )
+
+    result = helper.new(
+      registration:,
+      jobs: [job(id: 'job-1', state: :succeeded), job(id: 'job-2', state: :failed), job(id: 'job-3', state: :succeeded)]
+    ).to_plan
+
+    expect(result.jobs.map(&:id)).to eq(%w[rollback-job-3 rollback-job-1])
+    expect(result.dependency_job_ids_by_job_id).to eq(
+      'rollback-job-3' => [],
+      'rollback-job-1' => ['rollback-job-3']
+    )
+  end
+
+  it 'builds empty rollback plans when every compensation step is skipped' do
+    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
+    workflow_support = internal.const_get(:WorkflowSupport, false)
+    helper = workflow_support.const_get(:RollbackPlan, false)
+    registration = store.send(:state).register_workflow(
+      batch_id: 'batch-1',
+      workflow_id: 'invoice_closeout',
+      step_job_ids: { 'first' => 'job-1' },
+      compensation_jobs_by_step_id: { 'first' => rollback_job('rollback-job-1') }
+    )
+
+    result = helper.new(registration:, jobs: [job(id: 'job-1', state: :failed)]).to_plan
+
+    expect(result.jobs).to eq([])
+    expect(result.dependency_job_ids_by_job_id).to eq({})
   end
 end

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -12,13 +12,29 @@ RSpec.describe Karya::QueueStore::InMemory do
   let(:token_generator) { -> { token_sequence.next } }
   let(:created_at) { Time.utc(2026, 4, 24, 12, 0, 0) }
 
-  def workflow_job(step_id, handler: step_id, arguments: {}, priority: 0)
+  def workflow_job(step_id, handler: step_id, arguments: {}, priority: 0, uniqueness_key: nil, uniqueness_scope: nil)
     Karya::Job.new(
       id: "job-#{step_id}",
       queue: :billing,
       handler:,
       arguments:,
       priority:,
+      uniqueness_key:,
+      uniqueness_scope:,
+      state: :submission,
+      created_at:
+    )
+  end
+
+  def compensation_job(step_id, handler: :"undo_#{step_id}", arguments: {}, priority: 0, uniqueness_key: nil, uniqueness_scope: nil)
+    Karya::Job.new(
+      id: "rollback-job-#{step_id}",
+      queue: :billing,
+      handler:,
+      arguments:,
+      priority:,
+      uniqueness_key:,
+      uniqueness_scope:,
       state: :submission,
       created_at:
     )
@@ -266,7 +282,7 @@ RSpec.describe Karya::QueueStore::InMemory do
         state: :blocked
       )
 
-      root = reserve(3)
+      root = reserve(3, handler_names: ['root'])
       expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 4).state).to eq(:running)
       run_successfully(root, start_offset: 5, complete_offset: 6)
 
@@ -373,6 +389,210 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect do
         store.workflow_snapshot(batch_id: :plain_batch, now: created_at + 3)
       end.to raise_error(Karya::Workflow::InvalidExecutionError, 'batch "plain_batch" is not a workflow batch')
+    end
+
+    it 'rolls back succeeded compensable steps in reverse definition order' do
+      definition = Karya::Workflow.define(:rollback_chain) do
+        step :first, handler: :first, compensate_with: :undo_first
+        step :second, handler: :second, depends_on: :first, compensate_with: :undo_second
+        step :third, handler: :third, depends_on: :second, compensate_with: :undo_third
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: {
+          first: workflow_job(:first),
+          second: workflow_job(:second),
+          third: workflow_job(:third)
+        },
+        compensation_jobs_by_step_id: {
+          first: compensation_job(:first),
+          second: compensation_job(:second),
+          third: compensation_job(:third)
+        },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      first = reserve(2)
+      run_successfully(first, start_offset: 3, complete_offset: 4)
+      second = reserve(5)
+      run_successfully(second, start_offset: 6, complete_offset: 7)
+      third = reserve(8)
+      store.start_execution(reservation_token: third.token, now: created_at + 9)
+      store.fail_execution(reservation_token: third.token, now: created_at + 10, failure_classification: :error)
+
+      report = store.rollback_workflow(batch_id: :batch_one, now: created_at + 11, reason: 'operator rollback')
+
+      expect(report.action).to eq(:rollback_workflow)
+      expect(report.changed_jobs.map(&:id)).to eq(%w[rollback-job-second rollback-job-first])
+      expect(store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 12).job_ids)
+        .to eq(%w[rollback-job-second rollback-job-first])
+      expect(reserve(13).job_id).to eq('rollback-job-second')
+      expect(reserve(14)).to be_nil
+    end
+
+    it 'serializes rollback compensation through dependency gating' do
+      definition = Karya::Workflow.define(:rollback_order) do
+        step :first, handler: :first, compensate_with: :undo_first
+        step :second, handler: :second, compensate_with: :undo_second
+        step :third, handler: :third
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: {
+          first: workflow_job(:first),
+          second: workflow_job(:second),
+          third: workflow_job(:third)
+        },
+        compensation_jobs_by_step_id: {
+          first: compensation_job(:first),
+          second: compensation_job(:second)
+        },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      first = reserve(2)
+      second = reserve(3)
+      third = reserve(4)
+      run_successfully(first, start_offset: 5, complete_offset: 6)
+      run_successfully(second, start_offset: 7, complete_offset: 8)
+      store.start_execution(reservation_token: third.token, now: created_at + 9)
+      store.fail_execution(reservation_token: third.token, now: created_at + 10, failure_classification: :error)
+      store.rollback_workflow(batch_id: :batch_one, now: created_at + 11, reason: 'operator rollback')
+
+      second_rollback = reserve(12)
+      expect(second_rollback.job_id).to eq('rollback-job-second')
+      expect(reserve(13, handler_names: ['undo_first'])).to be_nil
+      run_successfully(second_rollback, start_offset: 14, complete_offset: 15)
+      expect(reserve(16, handler_names: ['undo_first']).job_id).to eq('rollback-job-first')
+    end
+
+    it 'rejects invalid rollback requests without partial rollback writes' do
+      definition = Karya::Workflow.define(:rollback_reject) do
+        step :root, handler: :root, compensate_with: :undo_root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root) },
+        compensation_jobs_by_step_id: { root: compensation_job(:root) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 2, reason: 'operator rollback')
+      end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow batch "batch_one" must be failed before rollback')
+      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 3) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+    end
+
+    it 'records no-op rollback when every compensation step is skipped' do
+      definition = Karya::Workflow.define(:rollback_noop) do
+        step :root, handler: :root
+        step :child, handler: :child, depends_on: :root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root), child: workflow_job(:child) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      root = reserve(2)
+      run_successfully(root, start_offset: 3, complete_offset: 4)
+      child = reserve(5)
+      store.start_execution(reservation_token: child.token, now: created_at + 6)
+      store.fail_execution(reservation_token: child.token, now: created_at + 7, failure_classification: :error)
+
+      report = store.rollback_workflow(batch_id: :batch_one, now: created_at + 8, reason: 'operator rollback')
+
+      expect(report.action).to eq(:rollback_workflow)
+      expect(report.requested_job_ids).to eq([])
+      expect(report.changed_jobs).to eq([])
+      expect(reserve(9)).to be_nil
+      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 10) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+      expect do
+        store.enqueue_many(jobs: [workflow_job(:other)], batch_id: 'batch_one.rollback', now: created_at + 11)
+      end.to raise_error(Karya::Workflow::DuplicateBatchError, 'batch "batch_one.rollback" already exists')
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 12, reason: 'operator rollback')
+      end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow batch "batch_one" has already been rolled back')
+    end
+
+    it 'rejects no-op rollback when the deterministic rollback batch id already exists' do
+      definition = Karya::Workflow.define(:rollback_noop_conflict) do
+        step :root, handler: :root
+        step :child, handler: :child, depends_on: :root
+      end
+      store.enqueue_many(jobs: [workflow_job(:other)], batch_id: 'batch_one.rollback', now: created_at + 1)
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root), child: workflow_job(:child) },
+        batch_id: :batch_one,
+        now: created_at + 2
+      )
+      root = reserve(3, handler_names: ['root'])
+      run_successfully(root, start_offset: 4, complete_offset: 5)
+      child = reserve(6, handler_names: ['child'])
+      store.start_execution(reservation_token: child.token, now: created_at + 7)
+      store.fail_execution(reservation_token: child.token, now: created_at + 8, failure_classification: :error)
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 9, reason: 'operator rollback')
+      end.to raise_error(Karya::Workflow::DuplicateBatchError, 'batch "batch_one.rollback" already exists')
+      store.cancel_jobs(job_ids: ['job-other'], now: created_at + 10)
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 11, reason: 'operator rollback')
+      end.to raise_error(Karya::Workflow::DuplicateBatchError, 'batch "batch_one.rollback" already exists')
+    end
+
+    it 'rejects duplicate rollback requests' do
+      definition = Karya::Workflow.define(:rollback_duplicate) do
+        step :root, handler: :root, compensate_with: :undo_root
+        step :child, handler: :child, depends_on: :root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root), child: workflow_job(:child) },
+        compensation_jobs_by_step_id: { root: compensation_job(:root) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      root = reserve(2)
+      run_successfully(root, start_offset: 3, complete_offset: 4)
+      child = reserve(5)
+      store.start_execution(reservation_token: child.token, now: created_at + 6)
+      store.fail_execution(reservation_token: child.token, now: created_at + 7, failure_classification: :error)
+      store.rollback_workflow(batch_id: :batch_one, now: created_at + 8, reason: 'operator rollback')
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 9, reason: 'operator rollback')
+      end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow batch "batch_one" has already been rolled back')
+    end
+
+    it 'rejects rollback uniqueness conflicts without partial writes' do
+      definition = Karya::Workflow.define(:rollback_conflict) do
+        step :root, handler: :root, compensate_with: :undo_root
+        step :child, handler: :child, depends_on: :root
+      end
+      store.enqueue(job: workflow_job(:other, uniqueness_key: 'rollback-key', uniqueness_scope: :queued), now: created_at + 1)
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root), child: workflow_job(:child) },
+        compensation_jobs_by_step_id: { root: compensation_job(:root, uniqueness_key: 'rollback-key', uniqueness_scope: :queued) },
+        batch_id: :batch_one,
+        now: created_at + 2
+      )
+      root = reserve(3, handler_names: ['root'])
+      run_successfully(root, start_offset: 4, complete_offset: 5)
+      child = reserve(6, handler_names: ['child'])
+      store.start_execution(reservation_token: child.token, now: created_at + 7)
+      store.fail_execution(reservation_token: child.token, now: created_at + 8, failure_classification: :error)
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 9, reason: 'operator rollback')
+      end.to raise_error(Karya::DuplicateUniquenessKeyError)
+      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 10) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
     end
 
     it 'rejects invalid workflow bindings without partial writes' do

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe Karya::QueueStore::InMemory do
     )
   end
 
+  def rollback_batch_id(batch_id)
+    internal = Karya::QueueStore::InMemory.const_get(:Internal, false)
+    workflow_support = internal.const_get(:WorkflowSupport, false)
+    workflow_support.const_get(:RollbackBatchId, false).new(batch_id).to_s
+  end
+
   def run_successfully(reservation, start_offset:, complete_offset:)
     store.start_execution(reservation_token: reservation.token, now: created_at + start_offset)
     store.complete_execution(reservation_token: reservation.token, now: created_at + complete_offset)
@@ -424,7 +430,7 @@ RSpec.describe Karya::QueueStore::InMemory do
 
       expect(report.action).to eq(:rollback_workflow)
       expect(report.changed_jobs.map(&:id)).to eq(%w[rollback-job-second rollback-job-first])
-      expect(store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 12).job_ids)
+      expect(store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 12).job_ids)
         .to eq(%w[rollback-job-second rollback-job-first])
       expect(reserve(13, queue: 'rollback').job_id).to eq('rollback-job-second')
       expect(reserve(14, queue: 'rollback')).to be_nil
@@ -481,8 +487,8 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect do
         store.rollback_workflow(batch_id: :batch_one, now: created_at + 2, reason: 'operator rollback')
       end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow batch "batch_one" must be failed before rollback')
-      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 3) }
-        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+      expect { store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 3) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, "batch #{rollback_batch_id('batch_one').inspect} is not registered")
     end
 
     it 'rejects rollback while failed workflows still have active jobs' do
@@ -519,8 +525,8 @@ RSpec.describe Karya::QueueStore::InMemory do
         Karya::Workflow::InvalidExecutionError,
         'workflow batch "batch_one" has active jobs and cannot be rolled back'
       )
-      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 11) }
-        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+      expect { store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 11) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, "batch #{rollback_batch_id('batch_one').inspect} is not registered")
     end
 
     it 'rejects rollback while failed workflows still have runnable waiting jobs' do
@@ -555,8 +561,8 @@ RSpec.describe Karya::QueueStore::InMemory do
         Karya::Workflow::InvalidExecutionError,
         'workflow batch "batch_one" has active jobs and cannot be rolled back'
       )
-      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 9) }
-        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+      expect { store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 9) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, "batch #{rollback_batch_id('batch_one').inspect} is not registered")
     end
 
     it 'rejects rollback while failed workflows still have retry-pending jobs' do
@@ -600,8 +606,8 @@ RSpec.describe Karya::QueueStore::InMemory do
         Karya::Workflow::InvalidExecutionError,
         'workflow batch "batch_one" has active jobs and cannot be rolled back'
       )
-      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 12) }
-        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+      expect { store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 12) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, "batch #{rollback_batch_id('batch_one').inspect} is not registered")
     end
 
     it 'recovers expired in-flight work before deciding rollback eligibility' do
@@ -666,11 +672,11 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect(report.requested_job_ids).to eq([])
       expect(report.changed_jobs).to eq([])
       expect(reserve(9)).to be_nil
-      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 10) }
-        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+      expect { store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 10) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, "batch #{rollback_batch_id('batch_one').inspect} is not registered")
       expect do
-        store.enqueue_many(jobs: [workflow_job(:other)], batch_id: 'batch_one.rollback', now: created_at + 11)
-      end.to raise_error(Karya::Workflow::DuplicateBatchError, 'batch "batch_one.rollback" already exists')
+        store.enqueue_many(jobs: [workflow_job(:other)], batch_id: rollback_batch_id('batch_one'), now: created_at + 11)
+      end.to raise_error(Karya::Workflow::DuplicateBatchError, "batch #{rollback_batch_id('batch_one').inspect} already exists")
       expect do
         store.rollback_workflow(batch_id: :batch_one, now: created_at + 12, reason: 'operator rollback')
       end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow batch "batch_one" has already been rolled back')
@@ -681,7 +687,7 @@ RSpec.describe Karya::QueueStore::InMemory do
         step :root, handler: :root
         step :child, handler: :child, depends_on: :root
       end
-      store.enqueue_many(jobs: [workflow_job(:other)], batch_id: 'batch_one.rollback', now: created_at + 1)
+      store.enqueue_many(jobs: [workflow_job(:other)], batch_id: rollback_batch_id('batch_one'), now: created_at + 1)
       store.enqueue_workflow(
         definition:,
         jobs_by_step_id: { root: workflow_job(:root), child: workflow_job(:child) },
@@ -696,11 +702,11 @@ RSpec.describe Karya::QueueStore::InMemory do
 
       expect do
         store.rollback_workflow(batch_id: :batch_one, now: created_at + 9, reason: 'operator rollback')
-      end.to raise_error(Karya::Workflow::DuplicateBatchError, 'batch "batch_one.rollback" already exists')
+      end.to raise_error(Karya::Workflow::DuplicateBatchError, "batch #{rollback_batch_id('batch_one').inspect} already exists")
       store.cancel_jobs(job_ids: ['job-other'], now: created_at + 10)
       expect do
         store.rollback_workflow(batch_id: :batch_one, now: created_at + 11, reason: 'operator rollback')
-      end.to raise_error(Karya::Workflow::DuplicateBatchError, 'batch "batch_one.rollback" already exists')
+      end.to raise_error(Karya::Workflow::DuplicateBatchError, "batch #{rollback_batch_id('batch_one').inspect} already exists")
     end
 
     it 'rejects duplicate rollback requests' do
@@ -749,8 +755,8 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect do
         store.rollback_workflow(batch_id: :batch_one, now: created_at + 9, reason: 'operator rollback')
       end.to raise_error(Karya::DuplicateUniquenessKeyError)
-      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 10) }
-        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+      expect { store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 10) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, "batch #{rollback_batch_id('batch_one').inspect} is not registered")
     end
 
     it 'rejects invalid workflow bindings without partial writes' do

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -485,6 +485,23 @@ RSpec.describe Karya::QueueStore::InMemory do
         .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
     end
 
+    it 'rejects invalid rollback reasons with rollback-domain errors' do
+      definition = Karya::Workflow.define(:rollback_invalid_reason) do
+        step :root, handler: :root, compensate_with: :undo_root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root) },
+        compensation_jobs_by_step_id: { root: compensation_job(:root) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 2, reason: " \t ")
+      end.to raise_error(Karya::Workflow::InvalidExecutionError, 'reason must be present')
+    end
+
     it 'records no-op rollback when every compensation step is skipped' do
       definition = Karya::Workflow.define(:rollback_noop) do
         step :root, handler: :root

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Karya::QueueStore::InMemory do
   def compensation_job(step_id, handler: :"undo_#{step_id}", arguments: {}, priority: 0, uniqueness_key: nil, uniqueness_scope: nil)
     Karya::Job.new(
       id: "rollback-job-#{step_id}",
-      queue: :billing,
+      queue: :rollback,
       handler:,
       arguments:,
       priority:,
@@ -40,9 +40,9 @@ RSpec.describe Karya::QueueStore::InMemory do
     )
   end
 
-  def reserve(now_offset, handler_names: nil)
+  def reserve(now_offset, handler_names: nil, queue: 'billing')
     store.reserve(
-      queue: 'billing',
+      queue:,
       handler_names:,
       worker_id: "worker-#{now_offset}",
       lease_duration: 60,
@@ -426,8 +426,8 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect(report.changed_jobs.map(&:id)).to eq(%w[rollback-job-second rollback-job-first])
       expect(store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 12).job_ids)
         .to eq(%w[rollback-job-second rollback-job-first])
-      expect(reserve(13).job_id).to eq('rollback-job-second')
-      expect(reserve(14)).to be_nil
+      expect(reserve(13, queue: 'rollback').job_id).to eq('rollback-job-second')
+      expect(reserve(14, queue: 'rollback')).to be_nil
     end
 
     it 'serializes rollback compensation through dependency gating' do
@@ -459,11 +459,11 @@ RSpec.describe Karya::QueueStore::InMemory do
       store.fail_execution(reservation_token: third.token, now: created_at + 10, failure_classification: :error)
       store.rollback_workflow(batch_id: :batch_one, now: created_at + 11, reason: 'operator rollback')
 
-      second_rollback = reserve(12)
+      second_rollback = reserve(12, queue: 'rollback')
       expect(second_rollback.job_id).to eq('rollback-job-second')
-      expect(reserve(13, handler_names: ['undo_first'])).to be_nil
+      expect(reserve(13, handler_names: ['undo_first'], queue: 'rollback')).to be_nil
       run_successfully(second_rollback, start_offset: 14, complete_offset: 15)
-      expect(reserve(16, handler_names: ['undo_first']).job_id).to eq('rollback-job-first')
+      expect(reserve(16, handler_names: ['undo_first'], queue: 'rollback').job_id).to eq('rollback-job-first')
     end
 
     it 'rejects invalid rollback requests without partial rollback writes' do

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -485,6 +485,28 @@ RSpec.describe Karya::QueueStore::InMemory do
         .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
     end
 
+    it 'recovers expired in-flight work before deciding rollback eligibility' do
+      definition = Karya::Workflow.define(:rollback_recovery_gate) do
+        step :root, handler: :root, compensate_with: :undo_root
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: { root: workflow_job(:root) },
+        compensation_jobs_by_step_id: { root: compensation_job(:root) },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      root = reserve(2)
+      store.start_execution(reservation_token: root.token, now: created_at + 3)
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 63, reason: 'operator rollback')
+      end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow batch "batch_one" must be failed before rollback')
+
+      snapshot = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 64)
+      expect(snapshot.jobs.map(&:state)).to eq([:queued])
+    end
+
     it 'rejects invalid rollback reasons with rollback-domain errors' do
       definition = Karya::Workflow.define(:rollback_invalid_reason) do
         step :root, handler: :root, compensate_with: :undo_root

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -523,6 +523,42 @@ RSpec.describe Karya::QueueStore::InMemory do
         .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
     end
 
+    it 'rejects rollback while failed workflows still have runnable waiting jobs' do
+      definition = Karya::Workflow.define(:rollback_runnable_waiting_jobs) do
+        step :root, handler: :root
+        step :first, handler: :first, depends_on: :root, compensate_with: :undo_first
+        step :second, handler: :second, depends_on: :root, compensate_with: :undo_second
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: {
+          root: workflow_job(:root),
+          first: workflow_job(:first),
+          second: workflow_job(:second)
+        },
+        compensation_jobs_by_step_id: {
+          first: compensation_job(:first),
+          second: compensation_job(:second)
+        },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      root = reserve(2)
+      run_successfully(root, start_offset: 3, complete_offset: 4)
+      first = reserve(5, handler_names: ['first'])
+      store.start_execution(reservation_token: first.token, now: created_at + 6)
+      store.fail_execution(reservation_token: first.token, now: created_at + 7, failure_classification: :error)
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 8, reason: 'operator rollback')
+      end.to raise_error(
+        Karya::Workflow::InvalidExecutionError,
+        'workflow batch "batch_one" has active jobs and cannot be rolled back'
+      )
+      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 9) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+    end
+
     it 'recovers expired in-flight work before deciding rollback eligibility' do
       definition = Karya::Workflow.define(:rollback_recovery_gate) do
         step :root, handler: :root, compensate_with: :undo_root

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -559,6 +559,51 @@ RSpec.describe Karya::QueueStore::InMemory do
         .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
     end
 
+    it 'rejects rollback while failed workflows still have retry-pending jobs' do
+      definition = Karya::Workflow.define(:rollback_retry_pending_jobs) do
+        step :root, handler: :root
+        step :first, handler: :first, depends_on: :root, compensate_with: :undo_first
+        step :second, handler: :second, depends_on: :root, compensate_with: :undo_second
+      end
+      retry_policy = Karya::RetryPolicy.new(max_attempts: 3, base_delay: 60, multiplier: 1)
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: {
+          root: workflow_job(:root),
+          first: workflow_job(:first),
+          second: workflow_job(:second)
+        },
+        compensation_jobs_by_step_id: {
+          first: compensation_job(:first),
+          second: compensation_job(:second)
+        },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      root = reserve(2)
+      run_successfully(root, start_offset: 3, complete_offset: 4)
+      first = reserve(5, handler_names: ['first'])
+      second = reserve(6, handler_names: ['second'])
+      store.start_execution(reservation_token: first.token, now: created_at + 7)
+      store.fail_execution(reservation_token: first.token, now: created_at + 8, failure_classification: :error)
+      store.start_execution(reservation_token: second.token, now: created_at + 9)
+      store.fail_execution(
+        reservation_token: second.token,
+        now: created_at + 10,
+        retry_policy:,
+        failure_classification: :error
+      )
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 11, reason: 'operator rollback')
+      end.to raise_error(
+        Karya::Workflow::InvalidExecutionError,
+        'workflow batch "batch_one" has active jobs and cannot be rolled back'
+      )
+      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 12) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+    end
+
     it 'recovers expired in-flight work before deciding rollback eligibility' do
       definition = Karya::Workflow.define(:rollback_recovery_gate) do
         step :root, handler: :root, compensate_with: :undo_root

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -485,6 +485,44 @@ RSpec.describe Karya::QueueStore::InMemory do
         .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
     end
 
+    it 'rejects rollback while failed workflows still have active jobs' do
+      definition = Karya::Workflow.define(:rollback_active_jobs) do
+        step :root, handler: :root
+        step :first, handler: :first, depends_on: :root, compensate_with: :undo_first
+        step :second, handler: :second, depends_on: :root, compensate_with: :undo_second
+      end
+      store.enqueue_workflow(
+        definition:,
+        jobs_by_step_id: {
+          root: workflow_job(:root),
+          first: workflow_job(:first),
+          second: workflow_job(:second)
+        },
+        compensation_jobs_by_step_id: {
+          first: compensation_job(:first),
+          second: compensation_job(:second)
+        },
+        batch_id: :batch_one,
+        now: created_at + 1
+      )
+      root = reserve(2)
+      run_successfully(root, start_offset: 3, complete_offset: 4)
+      first = reserve(5, handler_names: ['first'])
+      second = reserve(6, handler_names: ['second'])
+      store.start_execution(reservation_token: first.token, now: created_at + 7)
+      store.fail_execution(reservation_token: first.token, now: created_at + 8, failure_classification: :error)
+      store.start_execution(reservation_token: second.token, now: created_at + 9)
+
+      expect do
+        store.rollback_workflow(batch_id: :batch_one, now: created_at + 10, reason: 'operator rollback')
+      end.to raise_error(
+        Karya::Workflow::InvalidExecutionError,
+        'workflow batch "batch_one" has active jobs and cannot be rolled back'
+      )
+      expect { store.batch_snapshot(batch_id: 'batch_one.rollback', now: created_at + 11) }
+        .to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_one.rollback" is not registered')
+    end
+
     it 'recovers expired in-flight work before deciding rollback eligibility' do
       definition = Karya::Workflow.define(:rollback_recovery_gate) do
         step :root, handler: :root, compensate_with: :undo_root

--- a/core/karya/spec/karya/queue_store_base_spec.rb
+++ b/core/karya/spec/karya/queue_store_base_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe Karya::QueueStore do
     end.to raise_error(NotImplementedError, /implement #workflow_snapshot/)
   end
 
+  it 'requires rollback_workflow to be implemented' do
+    expect do
+      store.rollback_workflow(batch_id: 'batch-1', now: Time.utc(2026, 3, 27, 12, 0, 0), reason: 'operator rollback')
+    end.to raise_error(NotImplementedError, /implement #rollback_workflow/)
+  end
+
   it 'requires reserve to be implemented' do
     expect do
       store.reserve(

--- a/core/karya/spec/karya/workflow/execution_binding_spec.rb
+++ b/core/karya/spec/karya/workflow/execution_binding_spec.rb
@@ -175,6 +175,24 @@ RSpec.describe 'Karya::Workflow::ExecutionBinding' do
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'unknown workflow compensation job "extra"')
   end
 
+  it 'rejects non-hash compensation job maps with compensation wording' do
+    definition = Karya::Workflow.define(:refund_invoice) do
+      step :capture_payment,
+           handler: :capture_payment,
+           compensate_with: :refund_payment,
+           compensation_arguments: { reason: :workflow_rollback }
+    end
+
+    expect do
+      described_class.new(
+        definition:,
+        jobs_by_step_id: { capture_payment: submission_job(id: 'job-1', handler: :capture_payment) },
+        compensation_jobs_by_step_id: [['capture_payment']],
+        batch_id: 'batch-1'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'compensation_jobs_by_step_id must be a Hash')
+  end
+
   it 'rejects duplicate-normalized compensation step ids with compensation wording' do
     definition = Karya::Workflow.define(:refund_invoice) do
       step :capture_payment,

--- a/core/karya/spec/karya/workflow/execution_binding_spec.rb
+++ b/core/karya/spec/karya/workflow/execution_binding_spec.rb
@@ -175,6 +175,35 @@ RSpec.describe 'Karya::Workflow::ExecutionBinding' do
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'unknown workflow compensation job "extra"')
   end
 
+  it 'rejects duplicate-normalized compensation step ids with compensation wording' do
+    definition = Karya::Workflow.define(:refund_invoice) do
+      step :capture_payment,
+           handler: :capture_payment,
+           compensate_with: :refund_payment,
+           compensation_arguments: { reason: :workflow_rollback }
+    end
+
+    expect do
+      described_class.new(
+        definition:,
+        jobs_by_step_id: { capture_payment: submission_job(id: 'job-1', handler: :capture_payment) },
+        compensation_jobs_by_step_id: {
+          'capture_payment' => compensation_job(
+            id: 'rollback-job-1',
+            handler: :refund_payment,
+            arguments: { reason: :workflow_rollback }
+          ),
+          ' capture_payment ' => compensation_job(
+            id: 'rollback-job-2',
+            handler: :refund_payment,
+            arguments: { reason: :workflow_rollback }
+          )
+        },
+        batch_id: 'batch-1'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'duplicate workflow compensation job "capture_payment"')
+  end
+
   it 'rejects invalid compensation job values' do
     definition = Karya::Workflow.define(:refund_invoice) do
       step :capture_payment,

--- a/core/karya/spec/karya/workflow/execution_binding_spec.rb
+++ b/core/karya/spec/karya/workflow/execution_binding_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'Karya::Workflow::ExecutionBinding' do
     Karya::Job.new(id:, queue: :billing, handler:, arguments:, state: :submission, created_at:)
   end
 
+  def compensation_job(id:, handler:, arguments: {})
+    Karya::Job.new(id:, queue: :rollback, handler:, arguments:, state: :submission, created_at:)
+  end
+
   def jobs_by_step_id
     {
       ' calculate_totals ' => submission_job(
@@ -44,6 +48,31 @@ RSpec.describe 'Karya::Workflow::ExecutionBinding' do
     )
     expect(binding).to be_frozen
     expect(binding.jobs).to be_frozen
+  end
+
+  it 'binds compensation jobs for compensable workflow steps' do
+    definition = Karya::Workflow.define(:refund_invoice) do
+      step :capture_payment,
+           handler: :capture_payment,
+           compensate_with: :refund_payment,
+           compensation_arguments: { reason: :workflow_rollback }
+    end
+    binding = described_class.new(
+      definition:,
+      jobs_by_step_id: { capture_payment: submission_job(id: 'job-1', handler: :capture_payment) },
+      compensation_jobs_by_step_id: {
+        ' capture_payment ' => compensation_job(
+          id: 'rollback-job-1',
+          handler: :refund_payment,
+          arguments: { reason: :workflow_rollback }
+        )
+      },
+      batch_id: 'batch-1'
+    )
+
+    expect(binding.compensation_jobs_by_step_id.keys).to eq(['capture_payment'])
+    expect(binding.compensation_jobs_by_step_id.fetch('capture_payment').id).to eq('rollback-job-1')
+    expect(binding.compensation_jobs_by_step_id).to be_frozen
   end
 
   it 'rejects non-definition input' do
@@ -109,5 +138,99 @@ RSpec.describe 'Karya::Workflow::ExecutionBinding' do
         batch_id: 'batch-1'
       )
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow step "calculate_totals" job arguments must match workflow step arguments')
+  end
+
+  it 'rejects missing and unknown compensation job bindings' do
+    definition = Karya::Workflow.define(:refund_invoice) do
+      step :capture_payment,
+           handler: :capture_payment,
+           compensate_with: :refund_payment,
+           compensation_arguments: { reason: :workflow_rollback }
+    end
+    primary_jobs = { capture_payment: submission_job(id: 'job-1', handler: :capture_payment) }
+
+    expect do
+      described_class.new(definition:, jobs_by_step_id: primary_jobs, compensation_jobs_by_step_id: {}, batch_id: 'batch-1')
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'missing workflow compensation job "capture_payment"')
+
+    expect do
+      described_class.new(
+        definition:,
+        jobs_by_step_id: primary_jobs,
+        compensation_jobs_by_step_id: { extra: compensation_job(id: 'rollback-job-1', handler: :refund_payment) },
+        batch_id: 'batch-1'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'missing workflow compensation job "capture_payment"')
+
+    expect do
+      described_class.new(
+        definition:,
+        jobs_by_step_id: primary_jobs,
+        compensation_jobs_by_step_id: {
+          capture_payment: compensation_job(id: 'rollback-job-1', handler: :refund_payment, arguments: { reason: :workflow_rollback }),
+          extra: compensation_job(id: 'rollback-job-2', handler: :refund_payment)
+        },
+        batch_id: 'batch-1'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'unknown workflow compensation job "extra"')
+  end
+
+  it 'rejects invalid compensation job values' do
+    definition = Karya::Workflow.define(:refund_invoice) do
+      step :capture_payment,
+           handler: :capture_payment,
+           compensate_with: :refund_payment,
+           compensation_arguments: { reason: :workflow_rollback }
+    end
+    primary_jobs = { capture_payment: submission_job(id: 'job-1', handler: :capture_payment) }
+
+    expect do
+      described_class.new(
+        definition:,
+        jobs_by_step_id: primary_jobs,
+        compensation_jobs_by_step_id: { capture_payment: 'rollback-job-1' },
+        batch_id: 'batch-1'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow compensation "capture_payment" job must be a Karya::Job')
+
+    queued_job = compensation_job(id: 'rollback-job-1', handler: :refund_payment).transition_to(:queued, updated_at: created_at + 1)
+    expect do
+      described_class.new(
+        definition:,
+        jobs_by_step_id: primary_jobs,
+        compensation_jobs_by_step_id: { capture_payment: queued_job },
+        batch_id: 'batch-1'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'workflow compensation "capture_payment" job must be in :submission state')
+
+    expect do
+      described_class.new(
+        definition:,
+        jobs_by_step_id: primary_jobs,
+        compensation_jobs_by_step_id: { capture_payment: compensation_job(id: 'rollback-job-1', handler: :wrong) },
+        batch_id: 'batch-1'
+      )
+    end.to raise_error(
+      Karya::Workflow::InvalidExecutionError,
+      'workflow compensation "capture_payment" job handler must match workflow compensation handler'
+    )
+
+    expect do
+      described_class.new(
+        definition:,
+        jobs_by_step_id: primary_jobs,
+        compensation_jobs_by_step_id: {
+          capture_payment: compensation_job(
+            id: 'rollback-job-1',
+            handler: :refund_payment,
+            arguments: { reason: :manual_rollback }
+          )
+        },
+        batch_id: 'batch-1'
+      )
+    end.to raise_error(
+      Karya::Workflow::InvalidExecutionError,
+      'workflow compensation "capture_payment" job arguments must match workflow compensation arguments'
+    )
   end
 end

--- a/core/karya/spec/karya/workflow/step_spec.rb
+++ b/core/karya/spec/karya/workflow/step_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe Karya::Workflow::Step do
     end.to raise_error(ArgumentError, 'unknown keyword: :unknown')
   end
 
+  it 'reports every unknown step option' do
+    expect do
+      described_class.new(id: :capture_payment, handler: :capture_payment, unknown: true, extra: true)
+    end.to raise_error(ArgumentError, 'unknown keywords: :unknown, :extra')
+  end
+
   it 'rejects duplicate dependency ids after normalization' do
     expect do
       described_class.new(id: :emit_receipt, handler: :emit_receipt, depends_on: [:calculate_totals, ' calculate_totals '])

--- a/core/karya/spec/karya/workflow/step_spec.rb
+++ b/core/karya/spec/karya/workflow/step_spec.rb
@@ -24,6 +24,43 @@ RSpec.describe Karya::Workflow::Step do
     expect(step).to be_frozen
   end
 
+  it 'normalizes optional compensation metadata' do
+    step = described_class.new(
+      id: :capture_payment,
+      handler: :capture_payment,
+      compensate_with: ' refund_payment ',
+      compensation_arguments: { reason: :workflow_rollback }
+    )
+
+    expect(step.compensable?).to be(true)
+    expect(step.compensate_with).to eq('refund_payment')
+    expect(step.compensation_arguments).to eq('reason' => :workflow_rollback)
+    expect(step.compensation_arguments).to be_frozen
+  end
+
+  it 'defaults compensation metadata to no-op rollback behavior' do
+    step = described_class.new(id: :capture_payment, handler: :capture_payment)
+
+    expect(step.compensable?).to be(false)
+    expect(step.compensate_with).to be_nil
+    expect(step.compensation_arguments).to eq({})
+  end
+
+  it 'rejects invalid compensation arguments' do
+    expect do
+      described_class.new(id: :capture_payment, handler: :capture_payment, compensation_arguments: [])
+    end.to raise_error(
+      Karya::Workflow::InvalidDefinitionError,
+      'workflow step "capture_payment" (handler "compensation") has invalid arguments: arguments must be a Hash'
+    )
+  end
+
+  it 'rejects unknown step options' do
+    expect do
+      described_class.new(id: :capture_payment, handler: :capture_payment, unknown: true)
+    end.to raise_error(ArgumentError, 'unknown keyword: :unknown')
+  end
+
   it 'rejects duplicate dependency ids after normalization' do
     expect do
       described_class.new(id: :emit_receipt, handler: :emit_receipt, depends_on: [:calculate_totals, ' calculate_totals '])

--- a/core/karya/spec/karya/workflow/step_spec.rb
+++ b/core/karya/spec/karya/workflow/step_spec.rb
@@ -55,6 +55,19 @@ RSpec.describe Karya::Workflow::Step do
     )
   end
 
+  it 'rejects compensation arguments without a compensation handler' do
+    expect do
+      described_class.new(
+        id: :capture_payment,
+        handler: :capture_payment,
+        compensation_arguments: { reason: :workflow_rollback }
+      )
+    end.to raise_error(
+      Karya::Workflow::InvalidDefinitionError,
+      'workflow step "capture_payment" cannot define compensation_arguments without compensate_with'
+    )
+  end
+
   it 'rejects unknown step options' do
     expect do
       described_class.new(id: :capture_payment, handler: :capture_payment, unknown: true)

--- a/core/karya/spec/karya/workflow_spec.rb
+++ b/core/karya/spec/karya/workflow_spec.rb
@@ -47,4 +47,28 @@ RSpec.describe Karya::Workflow do
       expect(catalog.fetch(:invoice_closeout)).to eq(definition)
     end
   end
+
+  describe '.build_execution_binding' do
+    it 'builds a workflow execution binding for existing internal callers' do
+      definition = described_class.define(:invoice_closeout) do
+        step :calculate_totals, handler: :calculate_totals
+      end
+      job = Karya::Job.new(
+        id: 'job-1',
+        queue: :billing,
+        handler: :calculate_totals,
+        state: :submission,
+        created_at: Time.utc(2026, 4, 24, 12, 0, 0)
+      )
+
+      binding = described_class.send(
+        :build_execution_binding,
+        definition:,
+        jobs_by_step_id: { calculate_totals: job },
+        batch_id: 'batch-1'
+      )
+
+      expect(binding.jobs).to eq([job])
+    end
+  end
 end

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -74,9 +74,9 @@ operator search and governance layers choose targets:
   current member job states without mutating the batch membership
 - workflow rollback is an explicit operator action for failed workflow batches;
   it creates one immutable rollback batch only when there are compensation jobs
-  to enqueue, records a no-op rollback boundary when compensation is configured
-  but every compensation step is skipped, and rejects duplicate rollback
-  requests
+  to enqueue, records a no-op rollback boundary when no compensation jobs are
+  enqueued (including when every compensation step is skipped or when no steps
+  are compensable), and rejects duplicate rollback requests
 - bulk retry returns failed or `retry_pending` jobs to normal queued execution
   when they are still eligible and uniqueness-safe
 - bulk cancellation can stop queued, retry-pending, reserved, or running jobs;

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -72,6 +72,10 @@ operator search and governance layers choose targets:
   reservation of dependent steps until prerequisite jobs have succeeded
 - workflow snapshots derive workflow state from stored workflow metadata and
   current member job states without mutating the batch membership
+- workflow rollback is an explicit operator action for failed workflow batches;
+  it creates one immutable rollback batch when compensation jobs exist, records
+  a no-op rollback boundary when every compensation step is skipped, and rejects
+  duplicate rollback requests
 - bulk retry returns failed or `retry_pending` jobs to normal queued execution
   when they are still eligible and uniqueness-safe
 - bulk cancellation can stop queued, retry-pending, reserved, or running jobs;

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -73,9 +73,10 @@ operator search and governance layers choose targets:
 - workflow snapshots derive workflow state from stored workflow metadata and
   current member job states without mutating the batch membership
 - workflow rollback is an explicit operator action for failed workflow batches;
-  it creates one immutable rollback batch when compensation jobs exist, records
-  a no-op rollback boundary when every compensation step is skipped, and rejects
-  duplicate rollback requests
+  it creates one immutable rollback batch only when there are compensation jobs
+  to enqueue, records a no-op rollback boundary when compensation is configured
+  but every compensation step is skipped, and rejects duplicate rollback
+  requests
 - bulk retry returns failed or `retry_pending` jobs to normal queued execution
   when they are still eligible and uniqueness-safe
 - bulk cancellation can stop queued, retry-pending, reserved, or running jobs;

--- a/docs/pages/workflows/basics.md
+++ b/docs/pages/workflows/basics.md
@@ -63,6 +63,25 @@ aggregate state:
 - `failed` when a step failed, was dead-lettered, or terminal mixed outcomes
   prevent workflow success
 
+Steps can also declare compensation work for explicit saga rollback:
+
+```ruby
+workflow = Karya::Workflow.define(:invoice_closeout) do
+  step :capture_payment,
+       handler: :capture_payment,
+       compensate_with: :refund_payment,
+       compensation_arguments: { reason: :workflow_rollback }
+end
+```
+
+Compensation jobs are supplied when the workflow is enqueued, but they are not
+members of the primary workflow batch. When an operator requests rollback for a
+failed workflow, Karya creates a separate rollback batch and enqueues
+compensation jobs for succeeded compensable steps in reverse definition order.
+Queued compensation work is dependency-gated so rollback runs one compensation
+job at a time. If every succeeded step is uncompensated, rollback records the
+operator boundary without adding jobs.
+
 ### Batch Identity And Aggregate State
 
 Workflow batches give related runtime jobs one stable identity. Batch creation

--- a/docs/pages/workflows/basics.md
+++ b/docs/pages/workflows/basics.md
@@ -75,12 +75,17 @@ end
 ```
 
 Compensation jobs are supplied when the workflow is enqueued, but they are not
-members of the primary workflow batch. When an operator requests rollback for a
-failed workflow, Karya creates a separate rollback batch and enqueues
-compensation jobs for succeeded compensable steps in reverse definition order.
-Queued compensation work is dependency-gated so rollback runs one compensation
-job at a time. If every succeeded step is uncompensated, rollback records the
-operator boundary without adding jobs.
+members of the primary workflow batch. For workflows with compensable steps,
+the caller must provide matching `compensation_jobs_by_step_id` at enqueue
+time. Each supplied compensation job must exactly match the step's
+`compensate_with` handler and `compensation_arguments`; Karya validates that
+contract at runtime and does not auto-generate compensation jobs from step
+metadata alone. When an operator requests rollback for a failed workflow,
+Karya creates a separate rollback batch and enqueues compensation jobs for
+succeeded compensable steps in reverse definition order. Queued compensation
+work is dependency-gated so rollback runs one compensation job at a time. If
+every succeeded step is uncompensated, rollback records the operator boundary
+without adding jobs.
 
 ### Batch Identity And Aggregate State
 


### PR DESCRIPTION
- Added `rollback_workflow` method to handle rollback of failed workflows.
- Introduced `compensation_jobs_by_step_id` to support compensation jobs for workflow steps.
- Enhanced `register_workflow` and `register_workflow_rollback` methods to store rollback metadata.
- Created `WorkflowRollback` class to encapsulate rollback details.
- Updated `StoreState` to manage workflow rollbacks and their associated jobs.
- Implemented tests for rollback scenarios, ensuring correct job handling and validation.
- Updated documentation to include details on workflow rollback and compensation jobs.

closes: #89
closes: #75