### PR TITLE
feat: add StepSnapshot and RollbackSnapshot classes

### DIFF
--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -95,7 +95,7 @@ module Karya
               workflow_batch_id = batch.id
               registration = fetch_workflow_registration(workflow_batch_id)
               jobs = fetch_batch_jobs(batch)
-              WorkflowSnapshotBuilder.new(batch:, registration:, jobs:, now: normalized_now).to_snapshot
+              WorkflowSnapshotBuilder.new(batch:, registration:, jobs:, now: normalized_now, state:).to_snapshot
             end
           end
 
@@ -218,7 +218,7 @@ module Karya
             registration = fetch_workflow_registration(workflow_batch_id)
             raise_duplicate_rollback(workflow_batch_id)
             jobs = fetch_batch_jobs(batch)
-            snapshot = WorkflowSnapshotBuilder.new(batch:, registration:, jobs:, now:).to_snapshot
+            snapshot = WorkflowSnapshotBuilder.new(batch:, registration:, jobs:, now:, state:).to_snapshot
             RollbackState.new(snapshot, registration.dependency_job_ids_by_job_id).validate
             plan = RollbackPlan.new(registration:, jobs:).to_plan
             rollback_batch_id = RollbackBatchId.new(workflow_batch_id).to_s
@@ -249,11 +249,12 @@ module Karya
 
           # Builds workflow snapshots from stored workflow metadata.
           class WorkflowSnapshotBuilder
-            def initialize(batch:, registration:, jobs:, now:)
+            def initialize(batch:, registration:, jobs:, now:, state:)
               @batch = batch
               @registration = registration
               @jobs = jobs
               @now = now
+              @state = state
             end
 
             def to_snapshot
@@ -263,13 +264,46 @@ module Karya
                 captured_at: now,
                 step_job_ids: registration.step_job_ids,
                 dependency_job_ids_by_job_id: registration.dependency_job_ids_by_job_id,
-                jobs:
+                jobs:,
+                rollback: rollback_snapshot
               )
             end
 
             private
 
-            attr_reader :batch, :jobs, :now, :registration
+            attr_reader :batch, :jobs, :now, :registration, :state
+
+            def rollback_snapshot
+              rollback = state.workflow_rollbacks_by_batch_id[batch.id]
+              return unless rollback
+
+              RollbackSnapshotAttributes.new(rollback.to_h).to_snapshot
+            end
+          end
+
+          # Converts owner-local rollback storage into public workflow inspection.
+          class RollbackSnapshotAttributes
+            def initialize(attributes)
+              @attributes = attributes
+            end
+
+            def to_snapshot
+              Workflow::RollbackSnapshot.new(
+                workflow_batch_id: fetch(:batch_id),
+                rollback_batch_id: fetch(:rollback_batch_id),
+                reason: fetch(:reason),
+                requested_at: fetch(:requested_at),
+                compensation_job_ids: fetch(:compensation_job_ids)
+              )
+            end
+
+            private
+
+            attr_reader :attributes
+
+            def fetch(name)
+              attributes.fetch(name)
+            end
           end
 
           # Validates rollback state eligibility.
@@ -323,7 +357,7 @@ module Karya
               "workflow batch #{batch_id} has active jobs and cannot be rolled back"
             end
           end
-          private_constant :RollbackState, :WorkflowSnapshotBuilder
+          private_constant :RollbackSnapshotAttributes, :RollbackState, :WorkflowSnapshotBuilder
 
           def workflow_dependencies_satisfied?(job)
             prerequisite_job_ids = state.workflow_dependency_job_ids_by_job_id[job.id]

--- a/core/karya/lib/karya/workflow.rb
+++ b/core/karya/lib/karya/workflow.rb
@@ -12,8 +12,10 @@ require_relative 'workflow/catalog'
 require_relative 'workflow/dependency'
 require_relative 'workflow/definition'
 require_relative 'workflow/execution_binding'
-require_relative 'workflow/snapshot'
+require_relative 'workflow/rollback_snapshot'
 require_relative 'workflow/step'
+require_relative 'workflow/step_snapshot'
+require_relative 'workflow/snapshot'
 
 module Karya
   # Canonical workflow composition model and Ruby-first authoring DSL.

--- a/core/karya/lib/karya/workflow/batch_snapshot.rb
+++ b/core/karya/lib/karya/workflow/batch_snapshot.rb
@@ -28,6 +28,7 @@ module Karya
         @job_ids = JobIdList.new(job_ids).to_a
         @jobs = JobList.new(jobs).to_a
         validate_membership
+        @jobs_by_id = @jobs.to_h { |job| [job.id, job] }.freeze
         summary = Summary.new(@jobs)
         @state_counts = summary.state_counts
         @total_count = @jobs.length
@@ -35,6 +36,23 @@ module Karya
         @failed_count = summary.failed_count
         @aggregate_state = AggregateState.new(@jobs).to_sym
         freeze
+      end
+
+      def include_job?(job_id)
+        normalized_job_id = Workflow.send(:normalize_batch_identifier, :job_id, job_id)
+        jobs_by_id.key?(normalized_job_id)
+      end
+
+      def job(job_id)
+        normalized_job_id = Workflow.send(:normalize_batch_identifier, :job_id, job_id)
+        jobs_by_id[normalized_job_id]
+      end
+
+      def fetch_job(job_id)
+        normalized_job_id = Workflow.send(:normalize_batch_identifier, :job_id, job_id)
+        jobs_by_id.fetch(normalized_job_id) do
+          raise UnknownBatchError, "batch #{batch_id.inspect} does not include job #{normalized_job_id.inspect}"
+        end
       end
 
       # Normalizes timestamps into immutable values.
@@ -156,6 +174,8 @@ module Karya
       private_constant :AggregateState, :COMPLETED_STATES, :FAILED_STATES, :JobIdList, :JobList, :Summary, :Timestamp
 
       private
+
+      attr_reader :jobs_by_id
 
       def validate_membership
         snapshot_job_ids = jobs.map(&:id)

--- a/core/karya/lib/karya/workflow/definition.rb
+++ b/core/karya/lib/karya/workflow/definition.rb
@@ -9,7 +9,13 @@ module Karya
   module Workflow
     # Immutable normalized workflow definition built from ordered steps.
     class Definition
-      attr_reader :dependencies, :id, :steps
+      attr_reader :compensable_step_ids,
+                  :dependencies,
+                  :id,
+                  :leaf_step_ids,
+                  :root_step_ids,
+                  :step_ids,
+                  :steps
 
       def initialize(id:, steps:)
         @id = Workflow.send(:normalize_identifier, :workflow_id, id)
@@ -18,7 +24,14 @@ module Karya
         graph = Graph.new(steps)
         @steps = graph.steps
         @steps_by_id = @steps.to_h { |workflow_step| [workflow_step.id, workflow_step] }.freeze
+        inspection = graph.inspection
+        @step_ids = inspection.step_ids
         @dependencies = graph.dependencies
+        @dependencies_by_step_id = inspection.dependencies_by_step_id
+        @dependents_by_step_id = inspection.dependents_by_step_id
+        @root_step_ids = inspection.root_step_ids
+        @leaf_step_ids = inspection.leaf_step_ids
+        @compensable_step_ids = inspection.compensable_step_ids
         freeze
       end
 
@@ -27,13 +40,30 @@ module Karya
         steps_by_id[normalized_step_id]
       end
 
+      def fetch_step(step_id)
+        normalized_step_id = Workflow.send(:normalize_identifier, :step_id, step_id)
+        steps_by_id.fetch(normalized_step_id) do
+          raise InvalidDefinitionError, "unknown workflow step #{normalized_step_id.inspect}"
+        end
+      end
+
+      def dependencies_for(step_id)
+        workflow_step = fetch_step(step_id)
+        dependencies_by_step_id.fetch(workflow_step.id)
+      end
+
+      def dependents_for(step_id)
+        workflow_step = fetch_step(step_id)
+        dependents_by_step_id.fetch(workflow_step.id)
+      end
+
       private
 
-      attr_reader :steps_by_id
+      attr_reader :dependencies_by_step_id, :dependents_by_step_id, :steps_by_id
 
       # Owner-local graph normalizer and validator for workflow step composition.
       class Graph
-        attr_reader :dependencies, :steps
+        attr_reader :dependencies, :inspection, :steps
 
         def initialize(raw_steps)
           @steps = normalize_steps(raw_steps)
@@ -41,6 +71,7 @@ module Karya
           validate_dependency_targets
           validate_acyclic
           @dependencies = DependencyList.new(@steps).dependencies
+          @inspection = Inspection.new(@steps)
         end
 
         private
@@ -141,7 +172,150 @@ module Karya
           private_constant :StepDependencies
         end
 
-        private_constant :DependencyList
+        # Builds definition inspection indexes from normalized ordered steps.
+        class Inspection
+          attr_reader :compensable_step_ids,
+                      :dependencies_by_step_id,
+                      :dependents_by_step_id,
+                      :leaf_step_ids,
+                      :root_step_ids,
+                      :step_ids
+
+          def initialize(steps)
+            @steps = steps
+            @step_ids = steps.map(&:id).freeze
+            @dependencies_by_step_id = StepDependencies.new(steps).to_h
+            @dependents_by_step_id = StepDependents.new(steps).to_h
+            @root_step_ids = StepFilter.new(steps).root_ids
+            @leaf_step_ids = StepFilter.new(steps).leaf_ids(@dependents_by_step_id)
+            @compensable_step_ids = StepFilter.new(steps).compensable_ids
+            freeze
+          end
+
+          private
+
+          attr_reader :steps
+        end
+
+        # Builds direct dependency lookup by workflow step id.
+        class StepDependencies
+          def initialize(steps)
+            @steps = steps
+          end
+
+          def to_h
+            steps.to_h { |workflow_step| StepEntry.new(workflow_step).dependencies_pair }.freeze
+          end
+
+          private
+
+          attr_reader :steps
+        end
+
+        # Builds reverse dependency lookup by workflow step id.
+        class StepDependents
+          def initialize(steps)
+            @steps = steps
+          end
+
+          def to_h
+            grouped_pairs = DependencyPairs.new(steps).to_a.group_by(&:first)
+            step_ids.to_h do |step_id|
+              [step_id, grouped_pairs.fetch(step_id, []).map(&:last).freeze]
+            end.freeze
+          end
+
+          private
+
+          attr_reader :steps
+
+          def step_ids
+            steps.map(&:id)
+          end
+        end
+
+        # Builds ordered filtered step id lists.
+        class StepFilter
+          def initialize(steps)
+            @steps = steps
+          end
+
+          def root_ids
+            steps.filter_map { |workflow_step| StepEntry.new(workflow_step).root_id }.freeze
+          end
+
+          def leaf_ids(dependents_by_step_id)
+            steps.filter_map do |workflow_step|
+              StepEntry.new(workflow_step).leaf_id(dependents_by_step_id)
+            end.freeze
+          end
+
+          def compensable_ids
+            steps.filter_map { |workflow_step| StepEntry.new(workflow_step).compensable_id }.freeze
+          end
+
+          private
+
+          attr_reader :steps
+        end
+
+        # Builds reverse dependency edge pairs.
+        class DependencyPairs
+          def initialize(steps)
+            @steps = steps
+          end
+
+          def to_a
+            steps.flat_map { |workflow_step| StepEntry.new(workflow_step).dependent_pairs }
+          end
+
+          private
+
+          attr_reader :steps
+        end
+
+        # Reads one workflow step for inspection index builders.
+        class StepEntry
+          def initialize(workflow_step)
+            @workflow_step = workflow_step
+          end
+
+          def dependencies_pair
+            [id, workflow_step.depends_on]
+          end
+
+          def dependent_pairs
+            workflow_step.depends_on.map { |dependency_id| [dependency_id, id] }
+          end
+
+          def root_id
+            id if workflow_step.depends_on.empty?
+          end
+
+          def leaf_id(dependents_by_step_id)
+            id if dependents_by_step_id.fetch(id).empty?
+          end
+
+          def compensable_id
+            id if workflow_step.compensable?
+          end
+
+          private
+
+          attr_reader :workflow_step
+
+          def id
+            workflow_step.id
+          end
+        end
+
+        private_constant :DependencyList,
+                         :DependencyPairs,
+                         :Inspection,
+                         :StepDependencies,
+                         :StepDependents,
+                         :StepEntry,
+                         :StepFilter
       end
 
       private_constant :Graph

--- a/core/karya/lib/karya/workflow/rollback_snapshot.rb
+++ b/core/karya/lib/karya/workflow/rollback_snapshot.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require_relative '../internal/dead_letter_reason'
+
+module Karya
+  module Workflow
+    # Immutable inspection view for one workflow rollback request.
+    class RollbackSnapshot
+      attr_reader :compensation_count,
+                  :compensation_job_ids,
+                  :reason,
+                  :requested_at,
+                  :rollback_batch_id,
+                  :workflow_batch_id
+
+      def initialize(workflow_batch_id:, rollback_batch_id:, reason:, requested_at:, compensation_job_ids:)
+        @workflow_batch_id = Workflow.send(:normalize_batch_identifier, :workflow_batch_id, workflow_batch_id)
+        @rollback_batch_id = Workflow.send(:normalize_batch_identifier, :rollback_batch_id, rollback_batch_id)
+        @reason = Reason.new(reason).normalize
+        @requested_at = Timestamp.new(:requested_at, requested_at).to_time
+        @compensation_job_ids = CompensationJobIds.new(compensation_job_ids).to_a
+        @compensation_count = @compensation_job_ids.length
+        freeze
+      end
+
+      # Normalizes timestamps into immutable values.
+      class Timestamp
+        def initialize(name, value)
+          @name = name
+          @value = value
+        end
+
+        def to_time
+          return value.dup.freeze if value.is_a?(Time)
+
+          raise InvalidExecutionError, "#{name} must be a Time"
+        end
+
+        private
+
+        attr_reader :name, :value
+      end
+
+      # Normalizes rollback compensation job ids while allowing no-op rollback.
+      class CompensationJobIds
+        def initialize(compensation_job_ids)
+          @compensation_job_ids = compensation_job_ids
+        end
+
+        def to_a
+          raise InvalidExecutionError, 'compensation_job_ids must be an Array' unless compensation_job_ids.is_a?(Array)
+
+          normalized_job_ids = compensation_job_ids.map do |job_id|
+            Workflow.send(:normalize_execution_identifier, :compensation_job_id, job_id)
+          end
+          duplicate_job_id = normalized_job_ids.tally.find { |_job_id, count| count > 1 }&.first
+          raise InvalidExecutionError, "duplicate compensation job id #{duplicate_job_id.inspect}" if duplicate_job_id
+
+          normalized_job_ids.freeze
+        end
+
+        private
+
+        attr_reader :compensation_job_ids
+      end
+
+      # Normalizes operator rollback reasons for public workflow inspection.
+      class Reason
+        def initialize(reason)
+          @reason = reason
+        end
+
+        def normalize
+          Karya::Internal::DeadLetterReason.normalize(reason, error_class: InvalidExecutionError)
+        rescue InvalidExecutionError => e
+          raise InvalidExecutionError, e.message.sub('dead_letter_reason', 'reason'), cause: e
+        end
+
+        private
+
+        attr_reader :reason
+      end
+
+      private_constant :CompensationJobIds, :Reason, :Timestamp
+    end
+  end
+end

--- a/core/karya/lib/karya/workflow/snapshot.rb
+++ b/core/karya/lib/karya/workflow/snapshot.rb
@@ -20,11 +20,15 @@ module Karya
         dependency_job_ids_by_job_id
         jobs
       ].freeze
+      OPTIONAL_ATTRIBUTES = %i[rollback].freeze
+      SUPPORTED_ATTRIBUTES = (REQUIRED_ATTRIBUTES + OPTIONAL_ATTRIBUTES).freeze
 
       def initialize(**attributes)
         attributes = Attributes.new(attributes)
         @identity = attributes.identity
         @membership = attributes.membership
+        @step_inspection = StepInspection.new(identity:, membership:)
+        @rollback = attributes.rollback
         @summary_data = SummaryData.new(membership)
         freeze
       end
@@ -53,6 +57,34 @@ module Karya
         membership.step_states
       end
 
+      def steps
+        step_inspection.steps
+      end
+
+      def step(step_id)
+        step_inspection.step(step_id)
+      end
+
+      def fetch_step(step_id)
+        step_inspection.fetch_step(step_id)
+      end
+
+      def job_for_step(step_id)
+        fetch_step(step_id).job
+      end
+
+      def job_id_for_step(step_id)
+        fetch_step(step_id).job_id
+      end
+
+      def state_for_step(step_id)
+        fetch_step(step_id).state
+      end
+
+      def rollback_requested?
+        !!rollback
+      end
+
       def state_counts
         summary_data.state_counts
       end
@@ -72,6 +104,8 @@ module Karya
       def state
         summary_data.state
       end
+
+      attr_reader :rollback
 
       # Validates and exposes snapshot construction attributes.
       class Attributes
@@ -100,12 +134,19 @@ module Karya
           )
         end
 
+        def rollback
+          value = attributes.fetch(:rollback, nil)
+          raise InvalidExecutionError, 'rollback must be Karya::Workflow::RollbackSnapshot' if value && !value.is_a?(RollbackSnapshot)
+
+          value
+        end
+
         private
 
         attr_reader :attributes
 
         def validate_keys
-          unknown_keys = attributes.keys - REQUIRED_ATTRIBUTES
+          unknown_keys = attributes.keys - SUPPORTED_ATTRIBUTES
           return if unknown_keys.empty?
 
           raise ArgumentError, "unknown keyword: :#{unknown_keys.first}"
@@ -126,7 +167,7 @@ module Karya
 
       # Groups normalized workflow membership and derived step state fields.
       class Membership
-        attr_reader :dependency_job_ids_by_job_id, :job_ids, :jobs, :step_job_ids, :step_states
+        attr_reader :dependency_job_ids_by_job_id, :job_ids, :jobs, :jobs_by_id, :step_job_ids, :step_states
 
         def initialize(step_job_ids:, dependency_job_ids_by_job_id:, jobs:)
           @step_job_ids = step_job_ids
@@ -134,6 +175,7 @@ module Karya
           @jobs = jobs
           validate_membership
           @job_ids = jobs.map(&:id).freeze
+          @jobs_by_id = jobs.to_h { |job| [job.id, job] }.freeze
           @step_states = build_step_states
           freeze
         end
@@ -149,10 +191,60 @@ module Karya
         end
 
         def build_step_states
-          jobs_by_id = jobs.to_h { |job| [job.id, job] }
           step_job_ids.each_with_object({}) do |(step_id, job_id), states|
             states[step_id] = jobs_by_id.fetch(job_id).state
           end.freeze
+        end
+      end
+
+      # Builds ordered per-step runtime inspection values.
+      class StepInspection
+        def initialize(identity:, membership:)
+          @identity = identity
+          @membership = membership
+          @steps = build_steps
+          @steps_by_id = @steps.to_h { |step_snapshot| [step_snapshot.step_id, step_snapshot] }.freeze
+          freeze
+        end
+
+        attr_reader :steps
+
+        def step(step_id)
+          normalized_step_id = Workflow.send(:normalize_execution_identifier, :step_id, step_id)
+          steps_by_id[normalized_step_id]
+        end
+
+        def fetch_step(step_id)
+          normalized_step_id = Workflow.send(:normalize_execution_identifier, :step_id, step_id)
+          steps_by_id.fetch(normalized_step_id) do
+            raise InvalidExecutionError, "unknown workflow step #{normalized_step_id.inspect}"
+          end
+        end
+
+        private
+
+        attr_reader :identity, :membership, :steps_by_id
+
+        def build_steps
+          membership.step_job_ids.map do |step_id, job_id|
+            prerequisite_job_ids = membership.dependency_job_ids_by_job_id.fetch(job_id, [])
+            StepSnapshot.new(
+              workflow_id: identity.workflow_id,
+              batch_id: identity.batch_id,
+              step_id:,
+              job_id:,
+              job: membership.jobs_by_id.fetch(job_id),
+              prerequisite_job_ids:,
+              prerequisite_states: prerequisite_states_for(prerequisite_job_ids)
+            )
+          end.freeze
+        end
+
+        def prerequisite_states_for(prerequisite_job_ids)
+          prerequisite_job_ids.to_h do |job_id|
+            prerequisite_job = membership.jobs_by_id[job_id]
+            [job_id, prerequisite_job&.state]
+          end
         end
       end
 
@@ -384,9 +476,12 @@ module Karya
                        :JobState,
                        :JobList,
                        :Membership,
+                       :OPTIONAL_ATTRIBUTES,
                        :REQUIRED_ATTRIBUTES,
                        :State,
+                       :StepInspection,
                        :StepJobIds,
+                       :SUPPORTED_ATTRIBUTES,
                        :Summary,
                        :SummaryData,
                        :Timestamp,
@@ -394,7 +489,7 @@ module Karya
 
       private
 
-      attr_reader :identity, :membership, :summary_data
+      attr_reader :identity, :membership, :step_inspection, :summary_data
     end
   end
 end

--- a/core/karya/lib/karya/workflow/step_snapshot.rb
+++ b/core/karya/lib/karya/workflow/step_snapshot.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module Workflow
+    # Immutable inspection view for one workflow step at a point in time.
+    class StepSnapshot
+      WAITING_STATES = %i[queued submission].freeze
+
+      attr_reader :batch_id,
+                  :job,
+                  :job_id,
+                  :prerequisite_job_ids,
+                  :prerequisite_states,
+                  :state,
+                  :step_id,
+                  :workflow_id
+
+      def initialize(**attributes)
+        attributes = Attributes.new(attributes)
+        @workflow_id = attributes.workflow_id
+        @batch_id = attributes.batch_id
+        @step_id = attributes.step_id
+        @job_id = attributes.job_id
+        @job = attributes.job
+        @state = @job.state
+        @prerequisite_job_ids = attributes.prerequisite_job_ids
+        @prerequisite_states = PrerequisiteStates.new(
+          prerequisite_job_ids: @prerequisite_job_ids,
+          prerequisite_states: attributes.prerequisite_states
+        ).to_h
+        freeze
+      end
+
+      def ready?
+        waiting? && prerequisite_job_ids.all? { |prerequisite_job_id| prerequisite_states.fetch(prerequisite_job_id) == :succeeded }
+      end
+
+      def blocked?
+        waiting? && !ready?
+      end
+
+      def active?
+        !terminal? && !waiting?
+      end
+
+      def terminal?
+        job.terminal?
+      end
+
+      # Validates and exposes step snapshot construction attributes.
+      class Attributes
+        REQUIRED_ATTRIBUTES = %i[
+          workflow_id
+          batch_id
+          step_id
+          job_id
+          job
+          prerequisite_job_ids
+          prerequisite_states
+        ].freeze
+
+        def initialize(attributes)
+          @attributes = attributes
+          validate_keys
+        end
+
+        def workflow_id
+          Workflow.send(:normalize_identifier, :workflow_id, fetch(:workflow_id))
+        end
+
+        def batch_id
+          Workflow.send(:normalize_batch_identifier, :batch_id, fetch(:batch_id))
+        end
+
+        def step_id
+          Workflow.send(:normalize_execution_identifier, :step_id, fetch(:step_id))
+        end
+
+        def job_id
+          Workflow.send(:normalize_execution_identifier, :job_id, fetch(:job_id))
+        end
+
+        def job
+          JobEntry.new(job_id:, job: fetch(:job)).to_job
+        end
+
+        def prerequisite_job_ids
+          JobIdList.new(:prerequisite_job_id, fetch(:prerequisite_job_ids)).to_a
+        end
+
+        def prerequisite_states
+          fetch(:prerequisite_states)
+        end
+
+        private
+
+        attr_reader :attributes
+
+        def fetch(name)
+          attributes.fetch(name) { raise ArgumentError, "missing keyword: :#{name}" }
+        end
+
+        def validate_keys
+          unknown_keys = attributes.keys - REQUIRED_ATTRIBUTES
+          return if unknown_keys.empty?
+
+          raise ArgumentError, "unknown keyword: :#{unknown_keys.first}"
+        end
+      end
+
+      # Validates the concrete job backing a step snapshot.
+      class JobEntry
+        def initialize(job_id:, job:)
+          @job_id = job_id
+          @job = job
+        end
+
+        def to_job
+          raise InvalidExecutionError, 'job must be Karya::Job' unless job.is_a?(Job)
+          return job if job.id == job_id
+
+          raise InvalidExecutionError, 'job_id must match job id'
+        end
+
+        private
+
+        attr_reader :job, :job_id
+      end
+
+      # Normalizes ordered job id lists.
+      class JobIdList
+        def initialize(field_name, job_ids)
+          @field_name = field_name
+          @job_ids = job_ids
+        end
+
+        def to_a
+          raise InvalidExecutionError, "#{field_name}s must be an Array" unless job_ids.is_a?(Array)
+
+          normalized_job_ids = job_ids.map do |job_id|
+            Workflow.send(:normalize_execution_identifier, field_name, job_id)
+          end
+          duplicate_job_id = normalized_job_ids.tally.find { |_job_id, count| count > 1 }&.first
+          raise InvalidExecutionError, "duplicate #{field_name} #{duplicate_job_id.inspect}" if duplicate_job_id
+
+          normalized_job_ids.freeze
+        end
+
+        private
+
+        attr_reader :field_name, :job_ids
+      end
+
+      # Normalizes prerequisite states keyed by prerequisite job id.
+      class PrerequisiteStates
+        def initialize(prerequisite_job_ids:, prerequisite_states:)
+          @prerequisite_job_ids = prerequisite_job_ids
+          @prerequisite_states = prerequisite_states
+        end
+
+        def to_h
+          raise InvalidExecutionError, 'prerequisite_states must be a Hash' unless prerequisite_states.is_a?(Hash)
+
+          normalized_states = prerequisite_states.each_with_object({}) do |(job_id, state), states|
+            normalized_job_id = Workflow.send(:normalize_execution_identifier, :prerequisite_job_id, job_id)
+            states[normalized_job_id] = state
+          end
+          validate_membership(normalized_states)
+          prerequisite_job_ids.to_h { |job_id| [job_id, normalized_states[job_id]] }.freeze
+        end
+
+        private
+
+        attr_reader :prerequisite_job_ids, :prerequisite_states
+
+        def validate_membership(normalized_states)
+          unknown_job_id = normalized_states.keys.find { |job_id| !prerequisite_job_ids.include?(job_id) }
+          return unless unknown_job_id
+
+          raise InvalidExecutionError, "unknown prerequisite job #{unknown_job_id.inspect}"
+        end
+      end
+
+      private_constant :Attributes, :JobEntry, :JobIdList, :PrerequisiteStates, :WAITING_STATES
+
+      private
+
+      def waiting?
+        WAITING_STATES.include?(state)
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/workflow/step_snapshot.rb
+++ b/core/karya/lib/karya/workflow/step_snapshot.rb
@@ -168,7 +168,9 @@ module Karya
 
           normalized_states = prerequisite_states.each_with_object({}) do |(job_id, state), states|
             normalized_job_id = Workflow.send(:normalize_execution_identifier, :prerequisite_job_id, job_id)
-            states[normalized_job_id] = state
+            raise InvalidExecutionError, "duplicate prerequisite job #{normalized_job_id.inspect}" if states.key?(normalized_job_id)
+
+            states[normalized_job_id] = normalize_state(state)
           end
           validate_membership(normalized_states)
           prerequisite_job_ids.to_h { |job_id| [job_id, normalized_states[job_id]] }.freeze
@@ -177,6 +179,17 @@ module Karya
         private
 
         attr_reader :prerequisite_job_ids, :prerequisite_states
+
+        def normalize_state(state)
+          case state
+          when NilClass
+            nil
+          else
+            JobLifecycle.validate_state!(state)
+          end
+        rescue JobLifecycle::InvalidJobStateError => e
+          raise InvalidExecutionError, e.message, cause: e
+        end
 
         def validate_membership(normalized_states)
           unknown_job_id = normalized_states.keys.find { |job_id| !prerequisite_job_ids.include?(job_id) }

--- a/core/karya/sig/karya.rbs
+++ b/core/karya/sig/karya.rbs
@@ -25,6 +25,7 @@ module Karya
   type normalized_state_name = String
   type normalized_state_name_array = Array[normalized_state_name]
   type normalized_transition_map = Hash[normalized_state_name, normalized_state_name_array]
+  type step_snapshot_attribute_value = state_name | Job | Array[state_name] | Hash[state_name, state_name?]
   type workflow_snapshot_attribute_value = state_name | Time | Hash[state_name, state_name] | Hash[state_name, state_name_array] | Array[Job]
   type handler_parameter = [Symbol, Symbol?]
   type handler_parameters = Array[handler_parameter]

--- a/core/karya/sig/karya.rbs
+++ b/core/karya/sig/karya.rbs
@@ -26,7 +26,7 @@ module Karya
   type normalized_state_name_array = Array[normalized_state_name]
   type normalized_transition_map = Hash[normalized_state_name, normalized_state_name_array]
   type step_snapshot_attribute_value = state_name | Job | Array[state_name] | Hash[state_name, state_name?]
-  type workflow_snapshot_attribute_value = state_name | Time | Hash[state_name, state_name] | Hash[state_name, state_name_array] | Array[Job]
+  type workflow_snapshot_attribute_value = state_name | Time | Hash[state_name, state_name] | Hash[state_name, state_name_array] | Array[Job] | Workflow::RollbackSnapshot | nil
   type handler_parameter = [Symbol, Symbol?]
   type handler_parameters = Array[handler_parameter]
   type handler_dispatch_mode = :none | :positional_hash | :keywords

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -99,12 +99,14 @@ module Karya
             @registration: InMemory::Internal::StoreState::WorkflowRegistration
             @jobs: Array[Job]
             @now: Time
+            @state: InMemory::Internal::StoreState
 
             def initialize: (
               batch: Karya::Workflow::Batch,
               registration: InMemory::Internal::StoreState::WorkflowRegistration,
               jobs: Array[Job],
-              now: Time
+              now: Time,
+              state: InMemory::Internal::StoreState
             ) -> void
             def to_snapshot: () -> Karya::Workflow::Snapshot
 
@@ -114,6 +116,20 @@ module Karya
             attr_reader registration: InMemory::Internal::StoreState::WorkflowRegistration
             attr_reader jobs: Array[Job]
             attr_reader now: Time
+            attr_reader state: InMemory::Internal::StoreState
+            def rollback_snapshot: () -> Karya::Workflow::RollbackSnapshot?
+          end
+
+          class RollbackSnapshotAttributes
+            @attributes: Hash[Symbol, String | Time | Array[String]]
+
+            def initialize: (Hash[Symbol, String | Time | Array[String]] attributes) -> void
+            def to_snapshot: () -> Karya::Workflow::RollbackSnapshot
+
+          private
+
+            attr_reader attributes: Hash[Symbol, String | Time | Array[String]]
+            def fetch: (Symbol name) -> (String | Time | Array[String])
           end
 
           class RollbackState

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -78,6 +78,7 @@ module Karya
       @captured_at: Time
       @job_ids: Array[String]
       @jobs: Array[Job]
+      @jobs_by_id: Hash[String, Job]
       @state_counts: Hash[state_name, Integer]
       @total_count: Integer
       @completed_count: Integer
@@ -101,7 +102,13 @@ module Karya
         jobs: Array[Job]
       ) -> void
 
+      def include_job?: (state_name job_id) -> bool
+      def job: (state_name job_id) -> Job?
+      def fetch_job: (state_name job_id) -> Job
+
     private
+
+      attr_reader jobs_by_id: Hash[String, Job]
 
       class Timestamp
         @name: Symbol
@@ -168,9 +175,174 @@ module Karya
       def validate_membership: () -> void
     end
 
+    class RollbackSnapshot
+      @workflow_batch_id: String
+      @rollback_batch_id: String
+      @reason: String
+      @requested_at: Time
+      @compensation_job_ids: Array[String]
+      @compensation_count: Integer
+
+      attr_reader workflow_batch_id: String
+      attr_reader rollback_batch_id: String
+      attr_reader reason: String
+      attr_reader requested_at: Time
+      attr_reader compensation_job_ids: Array[String]
+      attr_reader compensation_count: Integer
+
+      def initialize: (
+        workflow_batch_id: state_name,
+        rollback_batch_id: state_name,
+        reason: String,
+        requested_at: Time,
+        compensation_job_ids: Array[state_name]
+      ) -> void
+
+    private
+
+      class Timestamp
+        @name: Symbol
+        @value: Time
+
+        def initialize: (Symbol name, Time value) -> void
+        def to_time: () -> Time
+
+      private
+
+        attr_reader name: Symbol
+        attr_reader value: Time
+      end
+
+      class CompensationJobIds
+        @compensation_job_ids: Array[state_name]
+
+        def initialize: (Array[state_name] compensation_job_ids) -> void
+        def to_a: () -> Array[String]
+
+      private
+
+        attr_reader compensation_job_ids: Array[state_name]
+      end
+
+      class Reason
+        @reason: String
+
+        def initialize: (String reason) -> void
+        def normalize: () -> String
+
+      private
+
+        attr_reader reason: String
+      end
+    end
+
+    class StepSnapshot
+      @workflow_id: String
+      @batch_id: String
+      @step_id: String
+      @job_id: String
+      @job: Job
+      @state: state_name
+      @prerequisite_job_ids: Array[String]
+      @prerequisite_states: Hash[String, state_name?]
+
+      attr_reader workflow_id: String
+      attr_reader batch_id: String
+      attr_reader step_id: String
+      attr_reader job_id: String
+      attr_reader job: Job
+      attr_reader state: state_name
+      attr_reader prerequisite_job_ids: Array[String]
+      attr_reader prerequisite_states: Hash[String, state_name?]
+
+      def initialize: (
+        workflow_id: state_name,
+        batch_id: state_name,
+        step_id: state_name,
+        job_id: state_name,
+        job: Job,
+        prerequisite_job_ids: Array[state_name],
+        prerequisite_states: Hash[state_name, state_name?]
+      ) -> void
+      def ready?: () -> bool
+      def blocked?: () -> bool
+      def active?: () -> bool
+      def terminal?: () -> bool
+
+    private
+
+      class Attributes
+        REQUIRED_ATTRIBUTES: Array[Symbol]
+
+        @attributes: Hash[Symbol, Object?]
+
+        def initialize: (Hash[Symbol, Object?] attributes) -> void
+        def workflow_id: () -> String
+        def batch_id: () -> String
+        def step_id: () -> String
+        def job_id: () -> String
+        def job: () -> Job
+        def prerequisite_job_ids: () -> Array[String]
+        def prerequisite_states: () -> Object?
+
+      private
+
+        attr_reader attributes: Hash[Symbol, Object?]
+        def fetch: (Symbol name) -> Object?
+        def validate_keys: () -> void
+      end
+
+      class JobEntry
+        @job_id: String
+        @job: Job
+
+        def initialize: (job_id: String, job: Job) -> void
+        def to_job: () -> Job
+
+      private
+
+        attr_reader job_id: String
+        attr_reader job: Job
+      end
+
+      class JobIdList
+        @field_name: Symbol
+        @job_ids: Array[state_name]
+
+        def initialize: (Symbol field_name, Array[state_name] job_ids) -> void
+        def to_a: () -> Array[String]
+
+      private
+
+        attr_reader field_name: Symbol
+        attr_reader job_ids: Array[state_name]
+      end
+
+      class PrerequisiteStates
+        @prerequisite_job_ids: Array[String]
+        @prerequisite_states: Hash[state_name, state_name?]
+
+        def initialize: (
+          prerequisite_job_ids: Array[String],
+          prerequisite_states: Hash[state_name, state_name?]
+        ) -> void
+        def to_h: () -> Hash[String, state_name?]
+
+      private
+
+        attr_reader prerequisite_job_ids: Array[String]
+        attr_reader prerequisite_states: Hash[state_name, state_name?]
+        def validate_membership: (Hash[String, state_name?] normalized_states) -> void
+      end
+
+      def waiting?: () -> bool
+    end
+
     class Snapshot
       @identity: Identity
       @membership: Membership
+      @step_inspection: StepInspection
+      @rollback: RollbackSnapshot?
       @summary_data: SummaryData
 
       def initialize: (
@@ -179,7 +351,8 @@ module Karya
         captured_at: Time,
         step_job_ids: Hash[state_name, state_name],
         dependency_job_ids_by_job_id: Hash[state_name, Array[state_name]],
-        jobs: Array[Job]
+        jobs: Array[Job],
+        ?rollback: RollbackSnapshot?
       ) -> void
 
       def workflow_id: () -> String
@@ -188,6 +361,14 @@ module Karya
       def job_ids: () -> Array[String]
       def jobs: () -> Array[Job]
       def step_states: () -> Hash[String, state_name]
+      def steps: () -> Array[StepSnapshot]
+      def step: (state_name step_id) -> StepSnapshot?
+      def fetch_step: (state_name step_id) -> StepSnapshot
+      def job_for_step: (state_name step_id) -> Job
+      def job_id_for_step: (state_name step_id) -> String
+      def state_for_step: (state_name step_id) -> state_name
+      def rollback_requested?: () -> bool
+      def rollback: () -> RollbackSnapshot?
       def state_counts: () -> Hash[state_name, Integer]
       def total_count: () -> Integer
       def completed_count: () -> Integer
@@ -198,6 +379,7 @@ module Karya
 
       attr_reader identity: Identity
       attr_reader membership: Membership
+      attr_reader step_inspection: StepInspection
       attr_reader summary_data: SummaryData
 
       class Attributes
@@ -207,6 +389,7 @@ module Karya
         def fetch: (Symbol name) -> workflow_snapshot_attribute_value
         def identity: () -> Identity
         def membership: () -> Membership
+        def rollback: () -> RollbackSnapshot?
 
       private
 
@@ -230,12 +413,14 @@ module Karya
         @step_job_ids: Hash[String, String]
         @dependency_job_ids_by_job_id: Hash[String, Array[String]]
         @jobs: Array[Job]
+        @jobs_by_id: Hash[String, Job]
         @job_ids: Array[String]
         @step_states: Hash[String, state_name]
 
         attr_reader step_job_ids: Hash[String, String]
         attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
         attr_reader jobs: Array[Job]
+        attr_reader jobs_by_id: Hash[String, Job]
         attr_reader job_ids: Array[String]
         attr_reader step_states: Hash[String, state_name]
 
@@ -249,6 +434,28 @@ module Karya
 
         def validate_membership: () -> void
         def build_step_states: () -> Hash[String, state_name]
+      end
+
+      class StepInspection
+        @identity: Identity
+        @membership: Membership
+        @steps: Array[StepSnapshot]
+        @steps_by_id: Hash[String, StepSnapshot]
+
+        def initialize: (identity: Identity, membership: Membership) -> void
+
+        attr_reader steps: Array[StepSnapshot]
+
+        def step: (state_name step_id) -> StepSnapshot?
+        def fetch_step: (state_name step_id) -> StepSnapshot
+
+      private
+
+        attr_reader identity: Identity
+        attr_reader membership: Membership
+        attr_reader steps_by_id: Hash[String, StepSnapshot]
+        def build_steps: () -> Array[StepSnapshot]
+        def prerequisite_states_for: (Array[String] prerequisite_job_ids) -> Hash[String, state_name?]
       end
 
       class SummaryData
@@ -475,27 +682,44 @@ module Karya
     class Definition
       @id: String
       @steps: Array[Step]
+      @step_ids: Array[String]
       @steps_by_id: Hash[String, Step]
       @dependencies: Array[Dependency]
+      @dependencies_by_step_id: Hash[String, Array[String]]
+      @dependents_by_step_id: Hash[String, Array[String]]
+      @root_step_ids: Array[String]
+      @leaf_step_ids: Array[String]
+      @compensable_step_ids: Array[String]
 
       attr_reader id: String
       attr_reader steps: Array[Step]
+      attr_reader step_ids: Array[String]
       attr_reader dependencies: Array[Dependency]
+      attr_reader root_step_ids: Array[String]
+      attr_reader leaf_step_ids: Array[String]
+      attr_reader compensable_step_ids: Array[String]
 
       def initialize: (id: state_name, steps: Array[Step]) -> void
       def step: (state_name step_id) -> Step?
+      def fetch_step: (state_name step_id) -> Step
+      def dependencies_for: (state_name step_id) -> Array[String]
+      def dependents_for: (state_name step_id) -> Array[String]
 
     private
 
+      attr_reader dependencies_by_step_id: Hash[String, Array[String]]
+      attr_reader dependents_by_step_id: Hash[String, Array[String]]
       attr_reader steps_by_id: Hash[String, Step]
 
       class Graph
         @steps: Array[Step]
         @steps_by_id: Hash[String, Step]
         @dependencies: Array[Dependency]
+        @inspection: Graph::Inspection
 
         attr_reader steps: Array[Step]
         attr_reader dependencies: Array[Dependency]
+        attr_reader inspection: Graph::Inspection
 
         def initialize: (Array[Step] raw_steps) -> void
 
@@ -529,6 +753,92 @@ module Karya
 
             attr_reader workflow_step: Step
           end
+        end
+
+        class Inspection
+          @steps: Array[Step]
+          @step_ids: Array[String]
+          @dependencies_by_step_id: Hash[String, Array[String]]
+          @dependents_by_step_id: Hash[String, Array[String]]
+          @root_step_ids: Array[String]
+          @leaf_step_ids: Array[String]
+          @compensable_step_ids: Array[String]
+
+          attr_reader step_ids: Array[String]
+          attr_reader dependencies_by_step_id: Hash[String, Array[String]]
+          attr_reader dependents_by_step_id: Hash[String, Array[String]]
+          attr_reader root_step_ids: Array[String]
+          attr_reader leaf_step_ids: Array[String]
+          attr_reader compensable_step_ids: Array[String]
+
+          def initialize: (Array[Step] steps) -> void
+
+        private
+
+          attr_reader steps: Array[Step]
+        end
+
+        class StepDependencies
+          @steps: Array[Step]
+
+          def initialize: (Array[Step] steps) -> void
+          def to_h: () -> Hash[String, Array[String]]
+
+        private
+
+          attr_reader steps: Array[Step]
+        end
+
+        class StepDependents
+          @steps: Array[Step]
+
+          def initialize: (Array[Step] steps) -> void
+          def to_h: () -> Hash[String, Array[String]]
+
+        private
+
+          attr_reader steps: Array[Step]
+          def step_ids: () -> Array[String]
+        end
+
+        class StepFilter
+          @steps: Array[Step]
+
+          def initialize: (Array[Step] steps) -> void
+          def root_ids: () -> Array[String]
+          def leaf_ids: (Hash[String, Array[String]] dependents_by_step_id) -> Array[String]
+          def compensable_ids: () -> Array[String]
+
+        private
+
+          attr_reader steps: Array[Step]
+        end
+
+        class DependencyPairs
+          @steps: Array[Step]
+
+          def initialize: (Array[Step] steps) -> void
+          def to_a: () -> Array[[String, String]]
+
+        private
+
+          attr_reader steps: Array[Step]
+        end
+
+        class StepEntry
+          @workflow_step: Step
+
+          def initialize: (Step workflow_step) -> void
+          def dependencies_pair: () -> [String, Array[String]]
+          def dependent_pairs: () -> Array[[String, String]]
+          def root_id: () -> String?
+          def leaf_id: (Hash[String, Array[String]] dependents_by_step_id) -> String?
+          def compensable_id: () -> String?
+
+        private
+
+          attr_reader workflow_step: Step
+          def id: () -> String
         end
       end
     end

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -274,21 +274,21 @@ module Karya
       class Attributes
         REQUIRED_ATTRIBUTES: Array[Symbol]
 
-        @attributes: Hash[Symbol, Object?]
+        @attributes: Hash[Symbol, step_snapshot_attribute_value]
 
-        def initialize: (Hash[Symbol, Object?] attributes) -> void
+        def initialize: (Hash[Symbol, step_snapshot_attribute_value] attributes) -> void
         def workflow_id: () -> String
         def batch_id: () -> String
         def step_id: () -> String
         def job_id: () -> String
         def job: () -> Job
         def prerequisite_job_ids: () -> Array[String]
-        def prerequisite_states: () -> Object?
+        def prerequisite_states: () -> Hash[state_name, state_name?]
 
       private
 
-        attr_reader attributes: Hash[Symbol, Object?]
-        def fetch: (Symbol name) -> Object?
+        attr_reader attributes: Hash[Symbol, step_snapshot_attribute_value]
+        def fetch: (Symbol name) -> step_snapshot_attribute_value
         def validate_keys: () -> void
       end
 

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -287,6 +287,10 @@ RSpec.describe Karya::QueueStore::InMemory do
         step_states: { 'root' => :queued, 'child' => :queued },
         state: :blocked
       )
+      expect(blocked.steps.map(&:step_id)).to eq(%w[root child])
+      expect(blocked.step(:root)).to be_ready
+      expect(blocked.step(:child)).to be_blocked
+      expect(blocked.step(:child).prerequisite_states).to eq('job-root' => :queued)
 
       root = reserve(3, handler_names: ['root'])
       expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 4).state).to eq(:running)
@@ -294,6 +298,10 @@ RSpec.describe Karya::QueueStore::InMemory do
 
       ready = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 7)
       expect(ready.step_states).to eq('root' => :succeeded, 'child' => :queued)
+      expect(ready.fetch_step(:child)).to be_ready
+      expect(ready.job_id_for_step(:child)).to eq('job-child')
+      expect(ready.job_for_step(:root).state).to eq(:succeeded)
+      expect(ready.state_for_step(:root)).to eq(:succeeded)
       expect(ready.state).to eq(:running)
     end
 
@@ -359,6 +367,9 @@ RSpec.describe Karya::QueueStore::InMemory do
       run_successfully(pack, start_offset: 8, complete_offset: 9)
 
       expect(store.workflow_snapshot(batch_id: :batch_one, now: created_at + 10).state).to eq(:running)
+      snapshot = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 11)
+      expect(snapshot.steps.map(&:step_id)).to eq(%w[capture pack notify])
+      expect(snapshot.fetch_step(:notify)).to be_ready
     end
 
     it 'moves failed workflows out of failed when prerequisite jobs are retried' do
@@ -430,6 +441,14 @@ RSpec.describe Karya::QueueStore::InMemory do
 
       expect(report.action).to eq(:rollback_workflow)
       expect(report.changed_jobs.map(&:id)).to eq(%w[rollback-job-second rollback-job-first])
+      rollback_snapshot = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 12).rollback
+      expect(rollback_snapshot).to have_attributes(
+        workflow_batch_id: 'batch_one',
+        rollback_batch_id: rollback_batch_id('batch_one'),
+        reason: 'operator rollback',
+        compensation_job_ids: %w[rollback-job-second rollback-job-first],
+        compensation_count: 2
+      )
       expect(store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 12).job_ids)
         .to eq(%w[rollback-job-second rollback-job-first])
       expect(reserve(13, queue: 'rollback').job_id).to eq('rollback-job-second')
@@ -671,6 +690,13 @@ RSpec.describe Karya::QueueStore::InMemory do
       expect(report.action).to eq(:rollback_workflow)
       expect(report.requested_job_ids).to eq([])
       expect(report.changed_jobs).to eq([])
+      rollback_snapshot = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 9).rollback
+      expect(rollback_snapshot).to have_attributes(
+        workflow_batch_id: 'batch_one',
+        rollback_batch_id: 'batch_one.rollback',
+        compensation_job_ids: [],
+        compensation_count: 0
+      )
       expect(reserve(9)).to be_nil
       expect { store.batch_snapshot(batch_id: rollback_batch_id('batch_one'), now: created_at + 10) }
         .to raise_error(Karya::Workflow::UnknownBatchError, "batch #{rollback_batch_id('batch_one').inspect} is not registered")

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_spec.rb
@@ -693,7 +693,7 @@ RSpec.describe Karya::QueueStore::InMemory do
       rollback_snapshot = store.workflow_snapshot(batch_id: :batch_one, now: created_at + 9).rollback
       expect(rollback_snapshot).to have_attributes(
         workflow_batch_id: 'batch_one',
-        rollback_batch_id: 'batch_one.rollback',
+        rollback_batch_id: rollback_batch_id('batch_one'),
         compensation_job_ids: [],
         compensation_count: 0
       )

--- a/core/karya/spec/karya/workflow/batch_snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/batch_snapshot_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe Karya::Workflow::BatchSnapshot do
     expect(snapshot).to be_frozen
     expect(snapshot.jobs).to be_frozen
     expect(snapshot.state_counts).to be_frozen
+    expect(snapshot.include_job?('job_1')).to be(true)
+    expect(snapshot.job(' job_2 ')).to eq(jobs.fetch(1))
+    expect(snapshot.fetch_job('job_1')).to eq(jobs.fetch(0))
   end
 
   it 'keeps membership validation private' do
@@ -104,6 +107,21 @@ RSpec.describe Karya::Workflow::BatchSnapshot do
         jobs: [job(id: 'job_1', state: :queued), job(id: 'job_3', state: :queued)]
       )
     end.to raise_error(Karya::Workflow::InvalidBatchError, 'job_ids must match jobs in order')
+  end
+
+  it 'raises unknown batch errors for missing member lookup' do
+    snapshot = described_class.new(
+      batch_id: 'batch_1',
+      captured_at:,
+      job_ids: ['job_1'],
+      jobs: [job(id: 'job_1', state: :queued)]
+    )
+
+    expect(snapshot.include_job?(:missing)).to be(false)
+    expect(snapshot.job(:missing)).to be_nil
+    expect do
+      snapshot.fetch_job(:missing)
+    end.to raise_error(Karya::Workflow::UnknownBatchError, 'batch "batch_1" does not include job "missing"')
   end
 
   it 'validates captured time' do

--- a/core/karya/spec/karya/workflow/definition_spec.rb
+++ b/core/karya/spec/karya/workflow/definition_spec.rb
@@ -12,15 +12,45 @@ RSpec.describe Karya::Workflow::Definition do
   end
 
   it 'keeps steps ordered and exposes step lookup by normalized id' do
-    definition = described_class.new(id: :invoice_closeout, steps: [calculate_totals, capture_payment])
+    emit_receipt = Karya::Workflow::Step.new(
+      id: :emit_receipt,
+      handler: :emit_receipt,
+      depends_on: :capture_payment,
+      compensate_with: :void_receipt
+    )
+    definition = described_class.new(id: :invoice_closeout, steps: [calculate_totals, capture_payment, emit_receipt])
 
-    expect(definition.steps).to eq([calculate_totals, capture_payment])
+    expect(definition.steps).to eq([calculate_totals, capture_payment, emit_receipt])
     expect(definition.steps).to be_frozen
+    expect(definition.step_ids).to eq(%w[calculate_totals capture_payment emit_receipt])
+    expect(definition.step_ids).to be_frozen
     expect(definition.dependencies).to contain_exactly(
-      have_attributes(step_id: 'capture_payment', depends_on_step_id: 'calculate_totals')
+      have_attributes(step_id: 'capture_payment', depends_on_step_id: 'calculate_totals'),
+      have_attributes(step_id: 'emit_receipt', depends_on_step_id: 'capture_payment')
     )
     expect(definition.step(' capture_payment ')).to eq(capture_payment)
+    expect(definition.fetch_step(' emit_receipt ')).to eq(emit_receipt)
+    expect(definition.dependencies_for(:emit_receipt)).to eq(['capture_payment'])
+    expect(definition.dependents_for(:calculate_totals)).to eq(['capture_payment'])
+    expect(definition.root_step_ids).to eq(['calculate_totals'])
+    expect(definition.leaf_step_ids).to eq(['emit_receipt'])
+    expect(definition.compensable_step_ids).to eq(['emit_receipt'])
     expect(definition).to be_frozen
+  end
+
+  it 'raises definition errors when fetching unknown step inspection' do
+    definition = described_class.new(id: :invoice_closeout, steps: [calculate_totals])
+
+    expect(definition.step(:missing)).to be_nil
+    expect do
+      definition.fetch_step(:missing)
+    end.to raise_error(Karya::Workflow::InvalidDefinitionError, 'unknown workflow step "missing"')
+    expect do
+      definition.dependencies_for(:missing)
+    end.to raise_error(Karya::Workflow::InvalidDefinitionError, 'unknown workflow step "missing"')
+    expect do
+      definition.dependents_for(:missing)
+    end.to raise_error(Karya::Workflow::InvalidDefinitionError, 'unknown workflow step "missing"')
   end
 
   it 'rejects duplicate step ids' do

--- a/core/karya/spec/karya/workflow/rollback_snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/rollback_snapshot_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+RSpec.describe Karya::Workflow::RollbackSnapshot do
+  let(:requested_at) { Time.utc(2026, 4, 24, 12, 0, 0) }
+
+  it 'builds immutable rollback metadata and allows no-op compensation' do
+    snapshot = described_class.new(
+      workflow_batch_id: ' batch_1 ',
+      rollback_batch_id: ' batch_1.rollback ',
+      reason: 'operator rollback',
+      requested_at:,
+      compensation_job_ids: []
+    )
+
+    expect(snapshot).to have_attributes(
+      workflow_batch_id: 'batch_1',
+      rollback_batch_id: 'batch_1.rollback',
+      reason: 'operator rollback',
+      requested_at:,
+      compensation_job_ids: [],
+      compensation_count: 0
+    )
+    expect(snapshot).to be_frozen
+    expect(snapshot.compensation_job_ids).to be_frozen
+  end
+
+  it 'normalizes compensation job ids' do
+    snapshot = described_class.new(
+      workflow_batch_id: 'batch_1',
+      rollback_batch_id: :'batch_1.rollback',
+      reason: 'operator rollback',
+      requested_at:,
+      compensation_job_ids: [:first, ' second ']
+    )
+
+    expect(snapshot.compensation_job_ids).to eq(%w[first second])
+    expect(snapshot.compensation_count).to eq(2)
+  end
+
+  it 'rejects invalid rollback metadata' do
+    expect do
+      described_class.new(
+        workflow_batch_id: nil,
+        rollback_batch_id: :'batch_1.rollback',
+        reason: 'operator rollback',
+        requested_at:,
+        compensation_job_ids: []
+      )
+    end.to raise_error(Karya::Workflow::InvalidBatchError, 'workflow_batch_id must be present')
+
+    expect do
+      described_class.new(
+        workflow_batch_id: 'batch_1',
+        rollback_batch_id: nil,
+        reason: 'operator rollback',
+        requested_at:,
+        compensation_job_ids: []
+      )
+    end.to raise_error(Karya::Workflow::InvalidBatchError, 'rollback_batch_id must be present')
+
+    expect do
+      described_class.new(
+        workflow_batch_id: 'batch_1',
+        rollback_batch_id: :'batch_1.rollback',
+        reason: '',
+        requested_at:,
+        compensation_job_ids: []
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'reason must be present')
+
+    expect do
+      described_class.new(
+        workflow_batch_id: 'batch_1',
+        rollback_batch_id: :'batch_1.rollback',
+        reason: 'operator rollback',
+        requested_at: 'now',
+        compensation_job_ids: []
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'requested_at must be a Time')
+
+    expect do
+      described_class.new(
+        workflow_batch_id: 'batch_1',
+        rollback_batch_id: :'batch_1.rollback',
+        reason: 'operator rollback',
+        requested_at:,
+        compensation_job_ids: 'rollback-job-1'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'compensation_job_ids must be an Array')
+  end
+
+  it 'rejects duplicate compensation job ids after normalization' do
+    expect do
+      described_class.new(
+        workflow_batch_id: 'batch_1',
+        rollback_batch_id: :'batch_1.rollback',
+        reason: 'operator rollback',
+        requested_at:,
+        compensation_job_ids: ['rollback_job_1', ' rollback_job_1 ']
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'duplicate compensation job id "rollback_job_1"')
+  end
+end

--- a/core/karya/spec/karya/workflow/snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/snapshot_spec.rb
@@ -18,14 +18,25 @@ RSpec.describe Karya::Workflow::Snapshot do
     Karya::Job.new(id:, queue: :billing, handler: :sync_billing, state:, created_at: captured_at)
   end
 
-  def snapshot(jobs:, step_job_ids: nil, dependencies: {})
+  def rollback
+    Karya::Workflow::RollbackSnapshot.new(
+      workflow_batch_id: 'batch_1',
+      rollback_batch_id: :'batch_1.rollback',
+      reason: 'operator rollback',
+      requested_at: captured_at + 1,
+      compensation_job_ids: ['rollback-job-root']
+    )
+  end
+
+  def snapshot(jobs:, step_job_ids: nil, dependencies: {}, rollback: nil)
     described_class.new(
       workflow_id: ' invoice_closeout ',
       batch_id: ' batch_1 ',
       captured_at:,
       step_job_ids: step_job_ids || jobs.to_h { |workflow_job| [workflow_job.id.delete_prefix('job_'), workflow_job.id] },
       dependency_job_ids_by_job_id: dependencies,
-      jobs:
+      jobs:,
+      rollback:
     )
   end
 
@@ -46,10 +57,45 @@ RSpec.describe Karya::Workflow::Snapshot do
       failed_count: 0,
       state: :running
     )
+    expect(result.steps.map(&:step_id)).to eq(%w[root child])
+    expect(result.step(:child)).to have_attributes(
+      step_id: 'child',
+      job_id: 'job_child',
+      state: :queued,
+      prerequisite_job_ids: ['job_root'],
+      prerequisite_states: { 'job_root' => :succeeded }
+    )
+    expect(result.fetch_step(' root ').job).to eq(jobs.fetch(0))
+    expect(result.job_for_step(:child)).to eq(jobs.fetch(1))
+    expect(result.job_id_for_step(:child)).to eq('job_child')
+    expect(result.state_for_step(:child)).to eq(:queued)
+    expect(result.rollback_requested?).to be(false)
+    expect(result.rollback).to be_nil
     expect(result).to be_frozen
     expect(result.jobs).to be_frozen
     expect(result.step_states).to be_frozen
     expect(result.state_counts).to be_frozen
+  end
+
+  it 'exposes rollback metadata when requested' do
+    result = snapshot(jobs: [job(id: 'job_root', state: :failed)], rollback:)
+
+    expect(result.rollback_requested?).to be(true)
+    expect(result.rollback).to have_attributes(
+      workflow_batch_id: 'batch_1',
+      rollback_batch_id: 'batch_1.rollback',
+      reason: 'operator rollback',
+      compensation_job_ids: ['rollback-job-root']
+    )
+  end
+
+  it 'raises execution errors for unknown runtime step lookup' do
+    result = snapshot(jobs: [job(id: 'job_root', state: :queued)])
+
+    expect(result.step(:missing)).to be_nil
+    expect do
+      result.fetch_step(:missing)
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'unknown workflow step "missing"')
   end
 
   it 'rejects invalid identifiers and timestamps' do
@@ -152,6 +198,22 @@ RSpec.describe Karya::Workflow::Snapshot do
         unexpected: true
       )
     end.to raise_error(ArgumentError, 'unknown keyword: :unexpected')
+  end
+
+  it 'validates rollback metadata input' do
+    jobs = [job(id: 'job_root', state: :queued)]
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        captured_at:,
+        step_job_ids: { root: 'job_root' },
+        dependency_job_ids_by_job_id: {},
+        jobs:,
+        rollback: 'rollback'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'rollback must be Karya::Workflow::RollbackSnapshot')
   end
 
   it 'validates dependency mappings and membership' do

--- a/core/karya/spec/karya/workflow/step_snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/step_snapshot_spec.rb
@@ -152,4 +152,40 @@ RSpec.describe Karya::Workflow::StepSnapshot do
       )
     end.to raise_error(Karya::Workflow::InvalidExecutionError, 'prerequisite_states must be a Hash')
   end
+
+  it 'rejects duplicate normalized prerequisite job ids' do
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :'job-child',
+        job: job,
+        prerequisite_job_ids: ['job-root'],
+        prerequisite_states: { ' job-root ' => :queued, 'job-root' => :succeeded }
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'duplicate prerequisite job "job-root"')
+  end
+
+  it 'rejects invalid prerequisite state values' do
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :'job-child',
+        job: job,
+        prerequisite_job_ids: ['job-root'],
+        prerequisite_states: { 'job-root' => ' not-a-state ' }
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'Unknown job state: "not_a_state"')
+  end
+
+  it 'normalizes prerequisite state values and allows nil' do
+    result = snapshot(prerequisite_states: { ' job-root ' => ' SUCCEEDED ' })
+    missing = snapshot(prerequisite_states: { ' job-root ' => nil })
+
+    expect(result.prerequisite_states).to eq('job-root' => :succeeded)
+    expect(missing.prerequisite_states).to eq('job-root' => nil)
+  end
 end

--- a/core/karya/spec/karya/workflow/step_snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/step_snapshot_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+RSpec.describe Karya::Workflow::StepSnapshot do
+  let(:created_at) { Time.utc(2026, 4, 24, 12, 0, 0) }
+
+  around do |example|
+    Karya::JobLifecycle.send(:clear_extensions!)
+    example.run
+    Karya::JobLifecycle.send(:clear_extensions!)
+  end
+
+  def job(id: 'job-child', state: :queued)
+    Karya::Job.new(id:, queue: :billing, handler: :sync_billing, state:, created_at:)
+  end
+
+  def snapshot(state: :queued, prerequisite_states: { 'job-root' => :succeeded })
+    described_class.new(
+      workflow_id: ' invoice_closeout ',
+      batch_id: ' batch_1 ',
+      step_id: ' child ',
+      job_id: ' job-child ',
+      job: job(state:),
+      prerequisite_job_ids: [' job-root '],
+      prerequisite_states:
+    )
+  end
+
+  it 'builds immutable per-step inspection data' do
+    result = snapshot
+
+    expect(result).to have_attributes(
+      workflow_id: 'invoice_closeout',
+      batch_id: 'batch_1',
+      step_id: 'child',
+      job_id: 'job-child',
+      state: :queued,
+      prerequisite_job_ids: ['job-root'],
+      prerequisite_states: { 'job-root' => :succeeded }
+    )
+    expect(result).to be_ready
+    expect(result).not_to be_blocked
+    expect(result).not_to be_active
+    expect(result).not_to be_terminal
+    expect(result).to be_frozen
+    expect(result.prerequisite_job_ids).to be_frozen
+    expect(result.prerequisite_states).to be_frozen
+  end
+
+  it 'derives blocked, active, and terminal state' do
+    expect(snapshot(prerequisite_states: { 'job-root' => :queued })).to be_blocked
+    expect(snapshot(prerequisite_states: {})).to be_blocked
+    expect(snapshot(state: :running)).to be_active
+    expect(snapshot(state: :succeeded)).to be_terminal
+  end
+
+  it 'treats custom nonterminal lifecycle states as active' do
+    Karya::JobLifecycle.register_state(:awaiting_review)
+
+    expect(snapshot(state: :awaiting_review)).to be_active
+  end
+
+  it 'validates job and prerequisite membership' do
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :other,
+        job: job,
+        prerequisite_job_ids: [],
+        prerequisite_states: {}
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'job_id must match job id')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :'job-child',
+        job: 'job-child',
+        prerequisite_job_ids: [],
+        prerequisite_states: {}
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'job must be Karya::Job')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :'job-child',
+        job: job,
+        prerequisite_job_ids: ['job-root'],
+        prerequisite_states: { 'job-other' => :succeeded }
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'unknown prerequisite job "job-other"')
+  end
+
+  it 'validates prerequisite id collections and state maps' do
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :'job-child',
+        job: job,
+        prerequisite_job_ids: [],
+        prerequisite_states: {},
+        unexpected: true
+      )
+    end.to raise_error(ArgumentError, 'unknown keyword: :unexpected')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :'job-child',
+        job: job,
+        prerequisite_job_ids: 'job-root',
+        prerequisite_states: {}
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'prerequisite_job_ids must be an Array')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :'job-child',
+        job: job,
+        prerequisite_job_ids: %w[job-root job-root],
+        prerequisite_states: {}
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'duplicate prerequisite_job_id "job-root"')
+
+    expect do
+      described_class.new(
+        workflow_id: :workflow,
+        batch_id: :batch,
+        step_id: :child,
+        job_id: :'job-child',
+        job: job,
+        prerequisite_job_ids: ['job-root'],
+        prerequisite_states: 'job-root'
+      )
+    end.to raise_error(Karya::Workflow::InvalidExecutionError, 'prerequisite_states must be a Hash')
+  end
+end

--- a/docs/pages/runtime/controls.md
+++ b/docs/pages/runtime/controls.md
@@ -71,7 +71,9 @@ operator search and governance layers choose targets:
 - workflow enqueue stores all step jobs in one immutable batch and gates
   reservation of dependent steps until prerequisite jobs have succeeded
 - workflow snapshots derive workflow state from stored workflow metadata and
-  current member job states without mutating the batch membership
+  current member job states without mutating the batch membership; this is the
+  operator/runtime read model for per-step readiness, blocking prerequisites,
+  and rollback request metadata
 - workflow rollback is an explicit operator action for failed workflow batches;
   it creates one immutable rollback batch only when there are compensation jobs
   to enqueue, records a no-op rollback boundary when no compensation jobs are

--- a/docs/pages/workflows/basics.md
+++ b/docs/pages/workflows/basics.md
@@ -78,7 +78,7 @@ snapshot.fetch_step(:capture_payment).prerequisite_states
 #=> {"job-calculate_totals" => :succeeded}
 
 snapshot.fetch_step(:capture_payment).blocked?
-#=> true
+#=> false
 ```
 
 Steps can also declare compensation work for explicit saga rollback:
@@ -112,7 +112,7 @@ snapshot.rollback_requested?
 #=> true
 
 snapshot.rollback.rollback_batch_id
-#=> "invoice_closeout_123.rollback"
+#=> "opaque rollback batch id"
 ```
 
 ### Batch Identity And Aggregate State
@@ -137,10 +137,10 @@ APIs:
 
 ```ruby
 batch = store.batch_snapshot(batch_id: :invoice_closeout_123, now: Time.now)
-batch.include_job?(:job_capture_payment)
+batch.include_job?("job-capture_payment")
 #=> true
 
-batch.fetch_job(:job_capture_payment)
+batch.fetch_job("job-capture_payment")
 #=> #<Karya::Job ...>
 ```
 

--- a/docs/pages/workflows/basics.md
+++ b/docs/pages/workflows/basics.md
@@ -63,6 +63,24 @@ aggregate state:
 - `failed` when a step failed, was dead-lettered, or terminal mixed outcomes
   prevent workflow success
 
+The definition and runtime snapshots are also inspectable without reaching into
+queue-store internals:
+
+```ruby
+workflow.step_ids
+#=> ["calculate_totals", "capture_payment", "emit_receipt"]
+
+workflow.dependencies_for(:emit_receipt)
+#=> ["calculate_totals", "capture_payment"]
+
+snapshot = store.workflow_snapshot(batch_id: :invoice_closeout_123, now: Time.now)
+snapshot.fetch_step(:emit_receipt).prerequisite_states
+#=> {"job-calculate_totals" => :succeeded, "job-capture_payment" => :queued}
+
+snapshot.fetch_step(:emit_receipt).blocked?
+#=> true
+```
+
 Steps can also declare compensation work for explicit saga rollback:
 
 ```ruby
@@ -87,6 +105,16 @@ work is dependency-gated so rollback runs one compensation job at a time. If
 every succeeded step is uncompensated, rollback records the operator boundary
 without adding jobs.
 
+Rollback request metadata is exposed from the same workflow snapshot:
+
+```ruby
+snapshot.rollback_requested?
+#=> true
+
+snapshot.rollback.rollback_batch_id
+#=> "invoice_closeout_123.rollback"
+```
+
 ### Batch Identity And Aggregate State
 
 Workflow batches give related runtime jobs one stable identity. Batch creation
@@ -103,6 +131,18 @@ Batch aggregate state is derived from member job lifecycle state:
 - `succeeded` when every member succeeded
 - `cancelled` when every member was cancelled
 - `completed` for terminal mixed success and cancellation outcomes
+
+Batch snapshots support direct member lookup without adding list or search
+APIs:
+
+```ruby
+batch = store.batch_snapshot(batch_id: :invoice_closeout_123, now: Time.now)
+batch.include_job?(:job_capture_payment)
+#=> true
+
+batch.fetch_job(:job_capture_payment)
+#=> #<Karya::Job ...>
+```
 
 ## Related Concepts
 

--- a/docs/pages/workflows/basics.md
+++ b/docs/pages/workflows/basics.md
@@ -70,14 +70,14 @@ queue-store internals:
 workflow.step_ids
 #=> ["calculate_totals", "capture_payment", "emit_receipt"]
 
-workflow.dependencies_for(:emit_receipt)
-#=> ["calculate_totals", "capture_payment"]
+workflow.dependencies_for(:capture_payment)
+#=> ["calculate_totals"]
 
 snapshot = store.workflow_snapshot(batch_id: :invoice_closeout_123, now: Time.now)
-snapshot.fetch_step(:emit_receipt).prerequisite_states
-#=> {"job-calculate_totals" => :succeeded, "job-capture_payment" => :queued}
+snapshot.fetch_step(:capture_payment).prerequisite_states
+#=> {"job-calculate_totals" => :succeeded}
 
-snapshot.fetch_step(:emit_receipt).blocked?
+snapshot.fetch_step(:capture_payment).blocked?
 #=> true
 ```
 


### PR DESCRIPTION
- Introduced `Karya::Workflow::StepSnapshot` to provide an immutable inspection view of a workflow step at a specific point in time.
- Implemented methods for checking the readiness, blocking, and active states of a step.
- Added `Karya::Workflow::RollbackSnapshot` to encapsulate rollback metadata for workflows, including compensation job IDs and reasons for rollback.
- Enhanced the workflow snapshot functionality to include step snapshots and rollback metadata.
- Updated related specs to ensure proper functionality and validation of new classes and methods.
- Improved documentation to reflect the new features and usage examples for step and rollback snapshots.

closes: #92