### PR TITLE
feat: introduce versioning and family support

### DIFF
--- a/core/karya/lib/karya/queue_store/in_memory/internal/child_workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/child_workflow_support.rb
@@ -81,7 +81,23 @@ module Karya
           end
 
           # Groups the parent-side child workflow step identity.
-          ParentChildWorkflow = Struct.new(:parent_workflow_id, :parent_batch_id, :parent_job_id)
+          ParentChildWorkflow = Struct.new(
+            :parent_workflow_id,
+            :parent_workflow_family,
+            :parent_workflow_version,
+            :parent_batch_id,
+            :parent_job_id
+          ) do
+            def self.from_registration(parent_registration, parent_batch_id, parent_step_id)
+              new(
+                parent_registration.workflow_id,
+                parent_registration.workflow_family,
+                parent_registration.workflow_version,
+                parent_batch_id,
+                parent_registration.step_job_ids.fetch(parent_step_id)
+              ).freeze
+            end
+          end
 
           # Builds step-to-job metadata in definition order for child enqueues.
           class ChildStepJobIds
@@ -131,27 +147,41 @@ module Karya
             def register
               batch_id = binding.batch_id
               workflow_id = definition.id
+              register_workflow_metadata(batch_id:, workflow_id:)
+              register_child_relationship(batch_id:, workflow_id:)
+            end
+
+            private
+
+            attr_reader :binding, :definition, :parent, :parent_step_id, :state
+
+            def register_workflow_metadata(batch_id:, workflow_id:)
               state.register_workflow(
                 batch_id:,
                 workflow_id:,
                 step_job_ids: ChildStepJobIds.new(definition:, jobs: binding.jobs).to_h,
                 dependency_job_ids_by_job_id: binding.dependency_job_ids_by_job_id,
                 compensation_jobs_by_step_id: binding.compensation_jobs_by_step_id,
-                child_workflow_ids_by_step_id: WorkflowChildIds.new(definition).to_h
+                child_workflow_ids_by_step_id: WorkflowChildIds.new(definition).to_h,
+                workflow_family: definition.workflow_family,
+                workflow_version: definition.workflow_version
               )
+            end
+
+            def register_child_relationship(batch_id:, workflow_id:)
               state.workflow_children.register(
                 parent_workflow_id: parent.parent_workflow_id,
+                parent_workflow_family: parent.parent_workflow_family,
+                parent_workflow_version: parent.parent_workflow_version,
                 parent_batch_id: parent.parent_batch_id,
                 parent_step_id:,
                 parent_job_id: parent.parent_job_id,
                 child_workflow_id: workflow_id,
-                child_batch_id: batch_id
+                child_batch_id: batch_id,
+                child_workflow_family: definition.workflow_family,
+                child_workflow_version: definition.workflow_version
               )
             end
-
-            private
-
-            attr_reader :binding, :definition, :parent, :parent_step_id, :state
           end
 
           # Builds the public child workflow enqueue report.
@@ -212,11 +242,11 @@ module Karya
           end
 
           def validate_child_workflow_parent_job(parent_registration, parent_step_id, parent_batch_id)
-            parent_job_id = parent_registration.step_job_ids.fetch(parent_step_id)
-            parent_job = state.jobs_by_id.fetch(parent_job_id)
+            parent_identity = ParentChildWorkflow.from_registration(parent_registration, parent_batch_id, parent_step_id)
+            parent_job = state.jobs_by_id.fetch(parent_identity.parent_job_id)
             raise Workflow::InvalidExecutionError, "parent child workflow step #{parent_step_id.inspect} must be queued" unless parent_job.state == :queued
 
-            ParentChildWorkflow.new(parent_registration.workflow_id, parent_batch_id, parent_job_id).freeze
+            parent_identity
           end
 
           def validate_child_batch_identity(parent_batch_id:, child_batch_id:)

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state.rb
@@ -48,10 +48,14 @@ module Karya
             # Immutable owner-local child workflow relationship metadata.
             Relationship = Struct.new(
               :parent_workflow_id,
+              :parent_workflow_family,
+              :parent_workflow_version,
               :parent_batch_id,
               :parent_step_id,
               :parent_job_id,
               :child_workflow_id,
+              :child_workflow_family,
+              :child_workflow_version,
               :child_batch_id
             )
             private_constant :Relationship
@@ -69,13 +73,28 @@ module Karya
               expected_child_workflow_id_by_job_id[parent_job_id] = child_workflow_id
             end
 
-            def register(parent_workflow_id:, parent_batch_id:, parent_step_id:, parent_job_id:, child_workflow_id:, child_batch_id:)
+            def register(
+              parent_workflow_id:,
+              parent_batch_id:,
+              parent_step_id:,
+              parent_job_id:,
+              child_workflow_id:,
+              child_batch_id:,
+              parent_workflow_family: parent_workflow_id,
+              parent_workflow_version: 'v1',
+              child_workflow_family: child_workflow_id,
+              child_workflow_version: 'v1'
+            )
               relationship = Relationship.new(
                 parent_workflow_id,
+                parent_workflow_family,
+                parent_workflow_version,
                 parent_batch_id,
                 parent_step_id,
                 parent_job_id,
                 child_workflow_id,
+                child_workflow_family,
+                child_workflow_version,
                 child_batch_id
               ).freeze
               ensure_parent_relationships(parent_batch_id)[parent_step_id] = relationship
@@ -290,10 +309,14 @@ module Karya
               compensation_jobs_by_step_id:,
               approval_requirements_by_job_id: {},
               interaction_requirements_by_job_id: {},
-              child_workflow_ids_by_step_id: {}
+              child_workflow_ids_by_step_id: {},
+              workflow_family: workflow_id,
+              workflow_version: 'v1'
             )
               registration = WorkflowRegistration.build(
                 workflow_id:,
+                workflow_family:,
+                workflow_version:,
                 step_job_ids:,
                 dependency_job_ids_by_job_id:,
                 approval_requirements_by_job_id:,

--- a/core/karya/lib/karya/queue_store/in_memory/internal/store_state_workflow_registration.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/store_state_workflow_registration.rb
@@ -14,6 +14,8 @@ module Karya
           # Immutable owner-local workflow registration metadata for one batch.
           WorkflowRegistration = Struct.new(
             :workflow_id,
+            :workflow_family,
+            :workflow_version,
             :step_job_ids,
             :dependency_job_ids_by_job_id,
             :approval_requirements_by_job_id,
@@ -29,7 +31,9 @@ module Karya
               approval_requirements_by_job_id:,
               interaction_requirements_by_job_id:,
               compensation_jobs_by_step_id:,
-              child_workflow_ids_by_step_id:
+              child_workflow_ids_by_step_id:,
+              workflow_family: workflow_id,
+              workflow_version: 'v1'
             )
               approvals = WorkflowRegistrationRequirements.new(approval_requirements_by_job_id).to_h
               interactions = WorkflowRegistrationRequirements.new(interaction_requirements_by_job_id).to_h
@@ -37,6 +41,8 @@ module Karya
 
               new(
                 workflow_id,
+                workflow_family,
+                workflow_version,
                 step_job_ids.dup.freeze,
                 dependency_job_ids_by_job_id.transform_values { |dependency_job_ids| dependency_job_ids.dup.freeze }.freeze,
                 approvals,

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_child_state.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_child_state.rb
@@ -43,6 +43,8 @@ module Karya
             def state
               Workflow::Snapshot.new(
                 workflow_id: registration.workflow_id,
+                workflow_family: registration.workflow_family,
+                workflow_version: registration.workflow_version,
                 batch_id:,
                 captured_at: now,
                 step_job_ids: registration.step_job_ids,
@@ -116,10 +118,14 @@ module Karya
               def to_snapshot
                 Workflow::ChildWorkflowSnapshot.new(
                   parent_workflow_id: relationship.parent_workflow_id,
+                  parent_workflow_family: relationship.parent_workflow_family,
+                  parent_workflow_version: relationship.parent_workflow_version,
                   parent_batch_id: relationship.parent_batch_id,
                   parent_step_id: relationship.parent_step_id,
                   parent_job_id: relationship.parent_job_id,
                   child_workflow_id: relationship.child_workflow_id,
+                  child_workflow_family: relationship.child_workflow_family,
+                  child_workflow_version: relationship.child_workflow_version,
                   child_batch_id: child_batch_id,
                   child_state: child_state
                 )

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -645,6 +645,7 @@ module Karya
           private_constant :ChildWorkflowSnapshotBuilder,
                            :RollbackSnapshotAttributes,
                            :RollbackState,
+                           :WorkflowRegistrationPayload,
                            :WorkflowSnapshotBuilder
 
           def workflow_dependencies_satisfied?(job, now:)

--- a/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
+++ b/core/karya/lib/karya/queue_store/in_memory/internal/workflow_support.rb
@@ -26,23 +26,15 @@ module Karya
               )
               jobs = binding.jobs
               workflow_batch_id = binding.batch_id
-              batch = build_enqueue_batch(batch_id: workflow_batch_id, jobs:, now: normalized_now)
-              validate_bulk_enqueue_uniqueness(jobs, normalized_now)
+              store_batch(validate_workflow_enqueue_jobs(workflow_batch_id:, jobs:, now: normalized_now))
               expire_reservations_locked(normalized_now)
               queued_jobs = jobs.map { |job| enqueue_validated_job(job, normalized_now) }
-              dependency_job_ids_by_job_id = binding.dependency_job_ids_by_job_id
               step_job_ids = StepJobIds.new(definition:, jobs:).to_h
-              store_batch(batch)
-              state.register_workflow_dependencies(dependency_job_ids_by_job_id)
-              state.register_workflow(
-                batch_id: workflow_batch_id,
-                workflow_id: definition.id,
-                step_job_ids:,
-                dependency_job_ids_by_job_id:,
-                approval_requirements_by_job_id: ApprovalRequirements.new(definition:, step_job_ids:).to_h,
-                interaction_requirements_by_job_id: InteractionRequirements.new(definition:, step_job_ids:).to_h,
-                compensation_jobs_by_step_id: binding.compensation_jobs_by_step_id,
-                child_workflow_ids_by_step_id: WorkflowChildIds.new(definition).to_h
+              register_workflow_enqueue(
+                definition:,
+                binding:,
+                workflow_batch_id:,
+                step_job_ids:
               )
               BulkMutationReport.new(
                 action: :enqueue_many,
@@ -179,6 +171,53 @@ module Karya
           end
 
           private
+
+          def validate_workflow_enqueue_jobs(workflow_batch_id:, jobs:, now:)
+            validate_bulk_enqueue_uniqueness(jobs, now)
+            build_enqueue_batch(batch_id: workflow_batch_id, jobs:, now:)
+          end
+
+          def register_workflow_enqueue(definition:, binding:, workflow_batch_id:, step_job_ids:)
+            dependency_job_ids_by_job_id = binding.dependency_job_ids_by_job_id
+            state.register_workflow_dependencies(dependency_job_ids_by_job_id)
+            state.register_workflow(**WorkflowRegistrationPayload.new(
+              definition:,
+              binding:,
+              workflow_batch_id:,
+              step_job_ids:,
+              dependency_job_ids_by_job_id:
+            ).to_h)
+          end
+
+          # Builds the stored registration payload for one workflow enqueue.
+          class WorkflowRegistrationPayload
+            def initialize(definition:, binding:, workflow_batch_id:, step_job_ids:, dependency_job_ids_by_job_id:)
+              @definition = definition
+              @binding = binding
+              @workflow_batch_id = workflow_batch_id
+              @step_job_ids = step_job_ids
+              @dependency_job_ids_by_job_id = dependency_job_ids_by_job_id
+            end
+
+            def to_h
+              {
+                batch_id: workflow_batch_id,
+                workflow_id: definition.id,
+                workflow_family: definition.workflow_family,
+                workflow_version: definition.workflow_version,
+                step_job_ids:,
+                dependency_job_ids_by_job_id:,
+                approval_requirements_by_job_id: ApprovalRequirements.new(definition:, step_job_ids:).to_h,
+                interaction_requirements_by_job_id: InteractionRequirements.new(definition:, step_job_ids:).to_h,
+                compensation_jobs_by_step_id: binding.compensation_jobs_by_step_id,
+                child_workflow_ids_by_step_id: WorkflowChildIds.new(definition).to_h
+              }
+            end
+
+            private
+
+            attr_reader :binding, :definition, :dependency_job_ids_by_job_id, :step_job_ids, :workflow_batch_id
+          end
 
           def normalize_dead_letter_reason(reason)
             Karya::Internal::DeadLetterReason.normalize(reason, error_class: Workflow::InvalidExecutionError)
@@ -424,6 +463,8 @@ module Karya
               workflow_batch_id = batch.id
               Workflow::Snapshot.new(
                 workflow_id: registration.workflow_id,
+                workflow_family: registration.workflow_family,
+                workflow_version: registration.workflow_version,
                 batch_id: workflow_batch_id,
                 captured_at: now,
                 step_job_ids: registration.step_job_ids,
@@ -503,10 +544,14 @@ module Karya
             def to_snapshot
               Workflow::ChildWorkflowSnapshot.new(
                 parent_workflow_id: relationship.parent_workflow_id,
+                parent_workflow_family: relationship.parent_workflow_family,
+                parent_workflow_version: relationship.parent_workflow_version,
                 parent_batch_id: relationship.parent_batch_id,
                 parent_step_id: relationship.parent_step_id,
                 parent_job_id: relationship.parent_job_id,
                 child_workflow_id: relationship.child_workflow_id,
+                child_workflow_family: relationship.child_workflow_family,
+                child_workflow_version: relationship.child_workflow_version,
                 child_batch_id: relationship.child_batch_id,
                 child_state:
               )

--- a/core/karya/lib/karya/workflow.rb
+++ b/core/karya/lib/karya/workflow.rb
@@ -36,8 +36,8 @@ module Karya
 
     module_function
 
-    def define(id, &block)
-      builder = Builder.new(id)
+    def define(id, workflow_family: nil, workflow_version: nil, default_version: true, &block)
+      builder = Builder.new(id, workflow_family:, workflow_version:, default_version:)
       builder.instance_eval(&block) if block
       builder.to_definition
     end
@@ -73,8 +73,11 @@ module Karya
 
     # Owner-local DSL builder for workflow definition.
     class Builder
-      def initialize(id)
+      def initialize(id, workflow_family:, workflow_version:, default_version:)
         @id = id
+        @workflow_family = workflow_family
+        @workflow_version = workflow_version
+        @default_version = default_version
         @steps = []
       end
 
@@ -106,12 +109,12 @@ module Karya
       end
 
       def to_definition
-        Definition.new(id:, steps:)
+        Definition.new(id:, steps:, workflow_family:, workflow_version:, default_version:)
       end
 
       private
 
-      attr_reader :id, :steps
+      attr_reader :default_version, :id, :steps, :workflow_family, :workflow_version
     end
 
     private_constant :Builder, :ExecutionBinding

--- a/core/karya/lib/karya/workflow/catalog.rb
+++ b/core/karya/lib/karya/workflow/catalog.rb
@@ -52,9 +52,12 @@ module Karya
 
       def resolve(workflow_family:)
         normalized_family = Workflow.send(:normalize_identifier, :workflow_family, workflow_family)
+        family_inspect = normalized_family.inspect
+        raise InvalidDefinitionError, "workflow family #{family_inspect} is not registered" unless definitions_by_family.key?(normalized_family)
+
         @default_definitions_by_family.fetch(normalized_family)
       rescue KeyError => e
-        raise InvalidDefinitionError, "workflow family #{normalized_family.inspect} has no default version", cause: e
+        raise InvalidDefinitionError, "workflow family #{family_inspect} has no default version", cause: e
       end
 
       private

--- a/core/karya/lib/karya/workflow/catalog.rb
+++ b/core/karya/lib/karya/workflow/catalog.rb
@@ -9,7 +9,7 @@ module Karya
   module Workflow
     # Immutable registry of workflow definitions keyed by workflow id.
     class Catalog
-      attr_reader :definitions
+      attr_reader :definitions, :definitions_by_family
 
       def initialize(definitions:)
         raise InvalidDefinitionError, 'definitions must be an Array of Karya::Workflow::Definition' unless definitions.is_a?(Array)
@@ -22,6 +22,8 @@ module Karya
 
           normalized[workflow_id] = definition
         end.freeze
+        @definitions_by_family = build_definitions_by_family
+        @default_definitions_by_family = build_default_definitions_by_family
         freeze
       end
 
@@ -31,6 +33,72 @@ module Karya
         definitions.fetch(normalized_workflow_id)
       rescue KeyError => e
         raise InvalidDefinitionError, "workflow #{normalized_workflow_id.inspect} is not registered", cause: e
+      end
+
+      def fetch_version(workflow_family:, workflow_version:)
+        normalized_family = Workflow.send(:normalize_identifier, :workflow_family, workflow_family)
+        normalized_version = Workflow.send(:normalize_identifier, :workflow_version, workflow_version)
+        family_inspect = normalized_family.inspect
+        family_versions = definitions_by_family.fetch(normalized_family) do
+          raise InvalidDefinitionError, "workflow family #{family_inspect} is not registered"
+        end
+
+        family_versions.fetch(normalized_version)
+      rescue KeyError => e
+        raise InvalidDefinitionError,
+              "workflow family #{family_inspect} does not include version #{normalized_version.inspect}",
+              cause: e
+      end
+
+      def resolve(workflow_family:)
+        normalized_family = Workflow.send(:normalize_identifier, :workflow_family, workflow_family)
+        @default_definitions_by_family.fetch(normalized_family)
+      rescue KeyError => e
+        raise InvalidDefinitionError, "workflow family #{normalized_family.inspect} has no default version", cause: e
+      end
+
+      private
+
+      def build_definitions_by_family
+        grouped_by_family = definitions.values.group_by(&:workflow_family)
+        grouped_by_family.each_with_object({}) do |(workflow_family, family_definitions), grouped|
+          grouped[workflow_family] = FamilyDefinitions.new(workflow_family, family_definitions).to_h
+        end.freeze
+      end
+
+      def build_default_definitions_by_family
+        definitions.values.each_with_object({}) do |definition, defaults|
+          next unless definition.default_version?
+
+          workflow_family = definition.workflow_family
+          raise InvalidDefinitionError, "workflow family #{workflow_family.inspect} declares multiple default versions" if defaults.key?(workflow_family)
+
+          defaults[workflow_family] = definition
+        end.freeze
+      end
+
+      # Builds version-indexed definitions for one workflow family.
+      class FamilyDefinitions
+        def initialize(workflow_family, definitions)
+          @workflow_family = workflow_family
+          @definitions = definitions
+        end
+
+        def to_h
+          definitions.each_with_object({}) do |definition, grouped|
+            workflow_version = definition.workflow_version
+            if grouped.key?(workflow_version)
+              raise InvalidDefinitionError,
+                    "duplicate workflow version #{workflow_version.inspect} for family #{workflow_family.inspect}"
+            end
+
+            grouped[workflow_version] = definition
+          end.freeze
+        end
+
+        private
+
+        attr_reader :definitions, :workflow_family
       end
     end
   end

--- a/core/karya/lib/karya/workflow/child_workflow_snapshot.rb
+++ b/core/karya/lib/karya/workflow/child_workflow_snapshot.rb
@@ -10,26 +10,35 @@ module Karya
     # Immutable inspection view of one parent-child workflow relationship.
     class ChildWorkflowSnapshot
       WORKFLOW_STATES = %i[pending running paused awaiting_approval blocked succeeded failed cancelled].freeze
-
-      attr_reader :child_batch_id,
-                  :child_state,
-                  :child_workflow_id,
-                  :parent_batch_id,
-                  :parent_job_id,
-                  :parent_step_id,
-                  :parent_workflow_id
+      attr_reader :child_state
 
       def initialize(**attributes)
         attributes = Attributes.new(attributes)
-        @parent_workflow_id = attributes.parent_workflow_id
-        @parent_batch_id = attributes.parent_batch_id
-        @parent_step_id = attributes.parent_step_id
-        @parent_job_id = attributes.parent_job_id
-        @child_workflow_id = attributes.child_workflow_id
-        @child_batch_id = attributes.child_batch_id
+        @parent = attributes.parent_identity
+        @child = attributes.child_identity
         @child_state = attributes.child_state
         freeze
       end
+
+      def parent_workflow_id = parent.workflow_id
+
+      def parent_workflow_family = parent.workflow_family
+
+      def parent_workflow_version = parent.workflow_version
+
+      def parent_batch_id = parent.batch_id
+
+      def parent_step_id = parent.step_id
+
+      def parent_job_id = parent.job_id
+
+      def child_workflow_id = child.workflow_id
+
+      def child_workflow_family = child.workflow_family
+
+      def child_workflow_version = child.workflow_version
+
+      def child_batch_id = child.batch_id
 
       # Validates and exposes child workflow relationship attributes.
       class Attributes
@@ -42,6 +51,13 @@ module Karya
           child_batch_id
           child_state
         ].freeze
+        OPTIONAL_ATTRIBUTES = %i[
+          parent_workflow_family
+          parent_workflow_version
+          child_workflow_family
+          child_workflow_version
+        ].freeze
+        SUPPORTED_ATTRIBUTES = (REQUIRED_ATTRIBUTES + OPTIONAL_ATTRIBUTES).freeze
 
         def initialize(attributes)
           @attributes = attributes
@@ -50,6 +66,16 @@ module Karya
 
         def parent_workflow_id
           Workflow.send(:normalize_identifier, :parent_workflow_id, fetch(:parent_workflow_id))
+        end
+
+        def parent_workflow_family
+          value = attributes.fetch(:parent_workflow_family, parent_workflow_id)
+          Workflow.send(:normalize_identifier, :parent_workflow_family, value)
+        end
+
+        def parent_workflow_version
+          value = attributes.fetch(:parent_workflow_version, 'v1')
+          Workflow.send(:normalize_identifier, :parent_workflow_version, value)
         end
 
         def parent_batch_id
@@ -68,6 +94,16 @@ module Karya
           Workflow.send(:normalize_identifier, :child_workflow_id, fetch(:child_workflow_id))
         end
 
+        def child_workflow_family
+          value = attributes.fetch(:child_workflow_family, child_workflow_id)
+          Workflow.send(:normalize_identifier, :child_workflow_family, value)
+        end
+
+        def child_workflow_version
+          value = attributes.fetch(:child_workflow_version, 'v1')
+          Workflow.send(:normalize_identifier, :child_workflow_version, value)
+        end
+
         def child_batch_id
           Workflow.send(:normalize_batch_identifier, :child_batch_id, fetch(:child_batch_id))
         end
@@ -79,6 +115,26 @@ module Karya
           raise InvalidExecutionError, 'child_state must be a workflow state'
         end
 
+        def parent_identity
+          ParentIdentity.new(
+            workflow_id: parent_workflow_id,
+            workflow_family: parent_workflow_family,
+            workflow_version: parent_workflow_version,
+            batch_id: parent_batch_id,
+            step_id: parent_step_id,
+            job_id: parent_job_id
+          )
+        end
+
+        def child_identity
+          ChildIdentity.new(
+            workflow_id: child_workflow_id,
+            workflow_family: child_workflow_family,
+            workflow_version: child_workflow_version,
+            batch_id: child_batch_id
+          )
+        end
+
         private
 
         attr_reader :attributes
@@ -88,14 +144,46 @@ module Karya
         end
 
         def validate_keys
-          unknown_keys = attributes.keys - REQUIRED_ATTRIBUTES
+          unknown_keys = attributes.keys - SUPPORTED_ATTRIBUTES
           return if unknown_keys.empty?
 
           raise ArgumentError, "unknown keyword: :#{unknown_keys.first}"
         end
       end
 
-      private_constant :Attributes, :WORKFLOW_STATES
+      # Immutable parent-side workflow identity for one child relationship.
+      class ParentIdentity
+        attr_reader :batch_id, :job_id, :step_id, :workflow_family, :workflow_id, :workflow_version
+
+        def initialize(attributes)
+          @workflow_id = attributes.fetch(:workflow_id)
+          @workflow_family = attributes.fetch(:workflow_family)
+          @workflow_version = attributes.fetch(:workflow_version)
+          @batch_id = attributes.fetch(:batch_id)
+          @step_id = attributes.fetch(:step_id)
+          @job_id = attributes.fetch(:job_id)
+          freeze
+        end
+      end
+
+      # Immutable child-side workflow identity for one child relationship.
+      class ChildIdentity
+        attr_reader :batch_id, :workflow_family, :workflow_id, :workflow_version
+
+        def initialize(attributes)
+          @workflow_id = attributes.fetch(:workflow_id)
+          @workflow_family = attributes.fetch(:workflow_family)
+          @workflow_version = attributes.fetch(:workflow_version)
+          @batch_id = attributes.fetch(:batch_id)
+          freeze
+        end
+      end
+
+      private
+
+      attr_reader :child, :parent
+
+      private_constant :Attributes, :ChildIdentity, :ParentIdentity, :WORKFLOW_STATES
     end
   end
 end

--- a/core/karya/lib/karya/workflow/definition.rb
+++ b/core/karya/lib/karya/workflow/definition.rb
@@ -11,10 +11,15 @@ module Karya
     class Definition
       attr_reader :dependencies,
                   :id,
-                  :steps
+                  :steps,
+                  :workflow_family,
+                  :workflow_version
 
-      def initialize(id:, steps:)
+      def initialize(id:, steps:, workflow_family: nil, workflow_version: nil, default_version: true)
         @id = Workflow.send(:normalize_identifier, :workflow_id, id)
+        @workflow_family = Workflow.send(:normalize_identifier, :workflow_family, workflow_family || @id)
+        @workflow_version = Workflow.send(:normalize_identifier, :workflow_version, workflow_version || 'v1')
+        @default_version = normalize_default_version(default_version)
         raise InvalidDefinitionError, 'steps must be an Array of Karya::Workflow::Step' unless steps.is_a?(Array)
 
         graph = Graph.new(steps)
@@ -23,6 +28,10 @@ module Karya
         @inspection = graph.inspection
         @dependencies = graph.dependencies
         freeze
+      end
+
+      def default_version?
+        @default_version
       end
 
       def step_ids = inspection.step_ids
@@ -60,6 +69,17 @@ module Karya
       private
 
       attr_reader :inspection, :steps_by_id
+
+      def normalize_default_version(value)
+        return value if case value
+                        when true, false
+                          true
+                        else
+                          false
+                        end
+
+        raise InvalidDefinitionError, 'default_version must be true or false'
+      end
 
       # Owner-local graph normalizer and validator for workflow step composition.
       class Graph

--- a/core/karya/lib/karya/workflow/snapshot.rb
+++ b/core/karya/lib/karya/workflow/snapshot.rb
@@ -28,6 +28,8 @@ module Karya
         interactions
         interaction_requirements_by_job_id
         interaction_received_at_by_job_id
+        workflow_family
+        workflow_version
         pause_requested_at
         parent
         rollback
@@ -62,6 +64,14 @@ module Karya
 
       def workflow_id
         identity.workflow_id
+      end
+
+      def workflow_family
+        identity.workflow_family
+      end
+
+      def workflow_version
+        identity.workflow_version
       end
 
       def batch_id
@@ -188,6 +198,8 @@ module Karya
         def identity
           Identity.new(
             workflow_id: Workflow.send(:normalize_identifier, :workflow_id, fetch(:workflow_id)),
+            workflow_family: normalize_workflow_family,
+            workflow_version: normalize_workflow_version,
             batch_id: Workflow.send(:normalize_batch_identifier, :batch_id, fetch(:batch_id)),
             captured_at: Timestamp.new(:captured_at, fetch(:captured_at)).to_time
           )
@@ -253,6 +265,16 @@ module Karya
 
         attr_reader :attributes
 
+        def normalize_workflow_family
+          value = attributes.fetch(:workflow_family, fetch(:workflow_id))
+          Workflow.send(:normalize_identifier, :workflow_family, value)
+        end
+
+        def normalize_workflow_version
+          value = attributes.fetch(:workflow_version, 'v1')
+          Workflow.send(:normalize_identifier, :workflow_version, value)
+        end
+
         def validate_keys
           unknown_keys = attributes.keys - SUPPORTED_ATTRIBUTES
           return if unknown_keys.empty?
@@ -312,10 +334,12 @@ module Karya
 
       # Groups normalized snapshot identity fields.
       class Identity
-        attr_reader :batch_id, :captured_at, :workflow_id
+        attr_reader :batch_id, :captured_at, :workflow_family, :workflow_id, :workflow_version
 
-        def initialize(workflow_id:, batch_id:, captured_at:)
+        def initialize(workflow_id:, workflow_family:, workflow_version:, batch_id:, captured_at:)
           @workflow_id = workflow_id
+          @workflow_family = workflow_family
+          @workflow_version = workflow_version
           @batch_id = batch_id
           @captured_at = captured_at
           freeze

--- a/core/karya/sig/karya.rbs
+++ b/core/karya/sig/karya.rbs
@@ -77,7 +77,6 @@ module Karya
     Workflow::InteractionSnapshot |
     Workflow::RollbackSnapshot |
     nil
-  type default_version_flag = bool
   type handler_parameter = [Symbol, Symbol?]
   type handler_parameters = Array[handler_parameter]
   type handler_dispatch_mode = :none | :positional_hash | :keywords

--- a/core/karya/sig/karya.rbs
+++ b/core/karya/sig/karya.rbs
@@ -77,6 +77,7 @@ module Karya
     Workflow::InteractionSnapshot |
     Workflow::RollbackSnapshot |
     nil
+  type default_version_flag = bool
   type handler_parameter = [Symbol, Symbol?]
   type handler_parameters = Array[handler_parameter]
   type handler_dispatch_mode = :none | :positional_hash | :keywords

--- a/core/karya/sig/karya/queue_store/in_memory/internal/child_workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/child_workflow_support.rbs
@@ -40,12 +40,22 @@ module Karya
 
           class ParentChildWorkflow
             @parent_workflow_id: String
+            @parent_workflow_family: String
+            @parent_workflow_version: String
             @parent_batch_id: String
             @parent_job_id: String
 
             attr_reader parent_workflow_id: String
+            attr_reader parent_workflow_family: String
+            attr_reader parent_workflow_version: String
             attr_reader parent_batch_id: String
             attr_reader parent_job_id: String
+
+            def self.from_registration: (
+              InMemory::Internal::StoreState::WorkflowRegistration parent_registration,
+              String parent_batch_id,
+              String parent_step_id
+            ) -> ParentChildWorkflow
           end
 
           class ChildStepJobIds

--- a/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/store_state.rbs
@@ -110,6 +110,8 @@ module Karya
           def register_workflow: (
             batch_id: String,
             workflow_id: String,
+            ?workflow_family: String,
+            ?workflow_version: String,
             step_job_ids: Hash[String, String],
             dependency_job_ids_by_job_id: Hash[String, Array[String]],
             compensation_jobs_by_step_id: Hash[String, Job],
@@ -131,6 +133,8 @@ module Karya
 
           class WorkflowRegistration
             @workflow_id: String
+            @workflow_family: String
+            @workflow_version: String
             @step_job_ids: Hash[String, String]
             @dependency_job_ids_by_job_id: Hash[String, Array[String]]
             @approval_requirements_by_job_id: Hash[String, Karya::approval_requirement]
@@ -141,6 +145,8 @@ module Karya
 
             def self.build: (
               workflow_id: String,
+              ?workflow_family: String,
+              ?workflow_version: String,
               step_job_ids: Hash[String, String],
               dependency_job_ids_by_job_id: Hash[String, Array[String]],
               approval_requirements_by_job_id: Hash[String, Karya::approval_requirement],
@@ -151,6 +157,8 @@ module Karya
 
             def initialize: (
               String workflow_id,
+              String workflow_family,
+              String workflow_version,
               Hash[String, String] step_job_ids,
               Hash[String, Array[String]] dependency_job_ids_by_job_id,
               Hash[String, Karya::approval_requirement] approval_requirements_by_job_id,
@@ -161,6 +169,8 @@ module Karya
             ) -> void
 
             attr_reader workflow_id: String
+            attr_reader workflow_family: String
+            attr_reader workflow_version: String
             attr_reader step_job_ids: Hash[String, String]
             attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
             attr_reader approval_requirements_by_job_id: Hash[String, Karya::approval_requirement]
@@ -296,10 +306,14 @@ module Karya
             def register_expected_child: (String parent_job_id, String child_workflow_id) -> String
             def register: (
               parent_workflow_id: String,
+              ?parent_workflow_family: String,
+              ?parent_workflow_version: String,
               parent_batch_id: String,
               parent_step_id: String,
               parent_job_id: String,
               child_workflow_id: String,
+              ?child_workflow_family: String,
+              ?child_workflow_version: String,
               child_batch_id: String
             ) -> WorkflowChildren::Relationship
             def for_parent_step: (String parent_batch_id, String parent_step_id) -> WorkflowChildren::Relationship?
@@ -321,17 +335,25 @@ module Karya
 
             class Relationship
               @parent_workflow_id: String
+              @parent_workflow_family: String
+              @parent_workflow_version: String
               @parent_batch_id: String
               @parent_step_id: String
               @parent_job_id: String
               @child_workflow_id: String
+              @child_workflow_family: String
+              @child_workflow_version: String
               @child_batch_id: String
 
               attr_reader parent_workflow_id: String
+              attr_reader parent_workflow_family: String
+              attr_reader parent_workflow_version: String
               attr_reader parent_batch_id: String
               attr_reader parent_step_id: String
               attr_reader parent_job_id: String
               attr_reader child_workflow_id: String
+              attr_reader child_workflow_family: String
+              attr_reader child_workflow_version: String
               attr_reader child_batch_id: String
             end
           end

--- a/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
+++ b/core/karya/sig/karya/queue_store/in_memory/internal/workflow_support.rbs
@@ -146,6 +146,13 @@ module Karya
 
         private
 
+          def validate_workflow_enqueue_jobs: (workflow_batch_id: String, jobs: Array[Job], now: Time) -> Karya::Workflow::Batch
+          def register_workflow_enqueue: (
+            definition: Karya::Workflow::Definition,
+            binding: Karya::Workflow::ExecutionBinding,
+            workflow_batch_id: String,
+            step_job_ids: Hash[String, String]
+          ) -> InMemory::Internal::StoreState::WorkflowRegistration
           def fetch_workflow_registration: (String batch_id) -> InMemory::Internal::StoreState::WorkflowRegistration
           def normalize_rollback_reason: (String reason) -> String
           def deliver_workflow_interaction: (
@@ -212,6 +219,42 @@ module Karya
             def interaction_received_at_by_job_id: () -> Hash[String, Time]
             def parent_snapshot: () -> Karya::Workflow::ChildWorkflowSnapshot?
             def child_state_resolver: () -> InMemory::Internal::WorkflowChildState
+          end
+
+          class WorkflowRegistrationPayload
+            @definition: Karya::Workflow::Definition
+            @binding: Karya::Workflow::ExecutionBinding
+            @workflow_batch_id: String
+            @step_job_ids: Hash[String, String]
+            @dependency_job_ids_by_job_id: Hash[String, Array[String]]
+
+            def initialize: (
+              definition: Karya::Workflow::Definition,
+              binding: Karya::Workflow::ExecutionBinding,
+              workflow_batch_id: String,
+              step_job_ids: Hash[String, String],
+              dependency_job_ids_by_job_id: Hash[String, Array[String]]
+            ) -> void
+            def to_h: () -> {
+              batch_id: String,
+              workflow_id: String,
+              workflow_family: String,
+              workflow_version: String,
+              step_job_ids: Hash[String, String],
+              dependency_job_ids_by_job_id: Hash[String, Array[String]],
+              approval_requirements_by_job_id: Hash[String, Karya::approval_requirement],
+              interaction_requirements_by_job_id: Hash[String, Karya::interaction_requirement],
+              compensation_jobs_by_step_id: Hash[String, Job],
+              child_workflow_ids_by_step_id: Hash[String, String]
+            }
+
+          private
+
+            attr_reader definition: Karya::Workflow::Definition
+            attr_reader binding: Karya::Workflow::ExecutionBinding
+            attr_reader workflow_batch_id: String
+            attr_reader step_job_ids: Hash[String, String]
+            attr_reader dependency_job_ids_by_job_id: Hash[String, Array[String]]
           end
 
           class ChildWorkflowSnapshotBuilder

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -260,14 +260,14 @@ module Karya
 
       def initialize: (
         parent_workflow_id: state_name,
-        ?parent_workflow_family: state_name?,
-        ?parent_workflow_version: state_name?,
+        ?parent_workflow_family: state_name,
+        ?parent_workflow_version: state_name,
         parent_batch_id: state_name,
         parent_step_id: state_name,
         parent_job_id: state_name,
         child_workflow_id: state_name,
-        ?child_workflow_family: state_name?,
-        ?child_workflow_version: state_name?,
+        ?child_workflow_family: state_name,
+        ?child_workflow_version: state_name,
         child_batch_id: state_name,
         child_state: Karya::workflow_state
       ) -> void
@@ -773,8 +773,8 @@ module Karya
 
       def initialize: (
         workflow_id: state_name,
-        ?workflow_family: state_name?,
-        ?workflow_version: state_name?,
+        ?workflow_family: state_name,
+        ?workflow_version: state_name,
         batch_id: state_name,
         captured_at: Time,
         step_job_ids: Hash[state_name, state_name],
@@ -1453,7 +1453,6 @@ module Karya
 
       attr_reader inspection: Graph::Inspection
       attr_reader steps_by_id: Hash[String, Step]
-      def normalize_definition_identifier: (Symbol field_name, state_name value) -> String
       def normalize_default_version: (bool value) -> bool
 
       class Graph

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -242,16 +242,8 @@ module Karya
     end
 
     class ChildWorkflowSnapshot
-      @parent_workflow_id: String
-      @parent_workflow_family: String
-      @parent_workflow_version: String
-      @parent_batch_id: String
-      @parent_step_id: String
-      @parent_job_id: String
-      @child_workflow_id: String
-      @child_workflow_family: String
-      @child_workflow_version: String
-      @child_batch_id: String
+      @parent: ParentIdentity
+      @child: ChildIdentity
       @child_state: Karya::workflow_state
 
       attr_reader parent_workflow_id: String
@@ -284,6 +276,8 @@ module Karya
 
       class Attributes
         REQUIRED_ATTRIBUTES: Array[Symbol]
+        OPTIONAL_ATTRIBUTES: Array[Symbol]
+        SUPPORTED_ATTRIBUTES: Array[Symbol]
 
         @attributes: Hash[Symbol, child_workflow_snapshot_attribute_value]
 
@@ -299,12 +293,58 @@ module Karya
         def child_workflow_version: () -> String
         def child_batch_id: () -> String
         def child_state: () -> Karya::workflow_state
+        def parent_identity: () -> ParentIdentity
+        def child_identity: () -> ChildIdentity
 
       private
 
         attr_reader attributes: Hash[Symbol, child_workflow_snapshot_attribute_value]
         def fetch: (Symbol name) -> child_workflow_snapshot_attribute_value
         def validate_keys: () -> void
+      end
+
+      class ParentIdentity
+        @workflow_id: String
+        @workflow_family: String
+        @workflow_version: String
+        @batch_id: String
+        @step_id: String
+        @job_id: String
+
+        attr_reader workflow_id: String
+        attr_reader workflow_family: String
+        attr_reader workflow_version: String
+        attr_reader batch_id: String
+        attr_reader step_id: String
+        attr_reader job_id: String
+
+        def initialize: ({
+          workflow_id: String,
+          workflow_family: String,
+          workflow_version: String,
+          batch_id: String,
+          step_id: String,
+          job_id: String
+        } attributes) -> void
+      end
+
+      class ChildIdentity
+        @workflow_id: String
+        @workflow_family: String
+        @workflow_version: String
+        @batch_id: String
+
+        attr_reader workflow_id: String
+        attr_reader workflow_family: String
+        attr_reader workflow_version: String
+        attr_reader batch_id: String
+
+        def initialize: ({
+          workflow_id: String,
+          workflow_family: String,
+          workflow_version: String,
+          batch_id: String
+        } attributes) -> void
       end
     end
 
@@ -1555,6 +1595,7 @@ module Karya
     class Catalog
       @definitions: Hash[String, Definition]
       @definitions_by_family: Hash[String, Hash[String, Definition]]
+      @default_definitions_by_family: Hash[String, Definition]
 
       attr_reader definitions: Hash[String, Definition]
       attr_reader definitions_by_family: Hash[String, Hash[String, Definition]]

--- a/core/karya/sig/karya/workflow.rbs
+++ b/core/karya/sig/karya/workflow.rbs
@@ -20,7 +20,12 @@ module Karya
     class InvalidExecutionError < Error
     end
 
-    def self.define: (state_name id) ?{ -> void } -> Definition
+    def self.define: (
+      state_name id,
+      ?workflow_family: state_name?,
+      ?workflow_version: state_name?,
+      ?default_version: bool
+    ) ?{ -> void } -> Definition
     def self.catalog: (definitions: Array[Definition]) -> Catalog
 
     class Batch
@@ -238,27 +243,39 @@ module Karya
 
     class ChildWorkflowSnapshot
       @parent_workflow_id: String
+      @parent_workflow_family: String
+      @parent_workflow_version: String
       @parent_batch_id: String
       @parent_step_id: String
       @parent_job_id: String
       @child_workflow_id: String
+      @child_workflow_family: String
+      @child_workflow_version: String
       @child_batch_id: String
       @child_state: Karya::workflow_state
 
       attr_reader parent_workflow_id: String
+      attr_reader parent_workflow_family: String
+      attr_reader parent_workflow_version: String
       attr_reader parent_batch_id: String
       attr_reader parent_step_id: String
       attr_reader parent_job_id: String
       attr_reader child_workflow_id: String
+      attr_reader child_workflow_family: String
+      attr_reader child_workflow_version: String
       attr_reader child_batch_id: String
       attr_reader child_state: Karya::workflow_state
 
       def initialize: (
         parent_workflow_id: state_name,
+        ?parent_workflow_family: state_name?,
+        ?parent_workflow_version: state_name?,
         parent_batch_id: state_name,
         parent_step_id: state_name,
         parent_job_id: state_name,
         child_workflow_id: state_name,
+        ?child_workflow_family: state_name?,
+        ?child_workflow_version: state_name?,
         child_batch_id: state_name,
         child_state: Karya::workflow_state
       ) -> void
@@ -272,10 +289,14 @@ module Karya
 
         def initialize: (Hash[Symbol, child_workflow_snapshot_attribute_value] attributes) -> void
         def parent_workflow_id: () -> String
+        def parent_workflow_family: () -> String
+        def parent_workflow_version: () -> String
         def parent_batch_id: () -> String
         def parent_step_id: () -> String
         def parent_job_id: () -> String
         def child_workflow_id: () -> String
+        def child_workflow_family: () -> String
+        def child_workflow_version: () -> String
         def child_batch_id: () -> String
         def child_state: () -> Karya::workflow_state
 
@@ -712,6 +733,8 @@ module Karya
 
       def initialize: (
         workflow_id: state_name,
+        ?workflow_family: state_name?,
+        ?workflow_version: state_name?,
         batch_id: state_name,
         captured_at: Time,
         step_job_ids: Hash[state_name, state_name],
@@ -730,6 +753,8 @@ module Karya
       ) -> void
 
       def workflow_id: () -> String
+      def workflow_family: () -> String
+      def workflow_version: () -> String
       def batch_id: () -> String
       def captured_at: () -> Time
       def job_ids: () -> Array[String]
@@ -836,14 +861,24 @@ module Karya
 
       class Identity
         @workflow_id: String
+        @workflow_family: String
+        @workflow_version: String
         @batch_id: String
         @captured_at: Time
 
         attr_reader workflow_id: String
+        attr_reader workflow_family: String
+        attr_reader workflow_version: String
         attr_reader batch_id: String
         attr_reader captured_at: Time
 
-        def initialize: (workflow_id: String, batch_id: String, captured_at: Time) -> void
+        def initialize: (
+          workflow_id: String,
+          workflow_family: String,
+          workflow_version: String,
+          batch_id: String,
+          captured_at: Time
+        ) -> void
       end
 
       class Membership
@@ -1342,16 +1377,28 @@ module Karya
 
     class Definition
       @id: String
+      @workflow_family: String
+      @workflow_version: String
+      @default_version: bool
       @steps: Array[Step]
       @steps_by_id: Hash[String, Step]
       @inspection: Graph::Inspection
       @dependencies: Array[Dependency]
 
       attr_reader id: String
+      attr_reader workflow_family: String
+      attr_reader workflow_version: String
       attr_reader steps: Array[Step]
       attr_reader dependencies: Array[Dependency]
 
-      def initialize: (id: state_name, steps: Array[Step]) -> void
+      def initialize: (
+        id: state_name,
+        ?workflow_family: state_name?,
+        ?workflow_version: state_name?,
+        ?default_version: bool,
+        steps: Array[Step]
+      ) -> void
+      def default_version?: () -> bool
       def step_ids: () -> Array[String]
       def root_step_ids: () -> Array[String]
       def leaf_step_ids: () -> Array[String]
@@ -1366,6 +1413,8 @@ module Karya
 
       attr_reader inspection: Graph::Inspection
       attr_reader steps_by_id: Hash[String, Step]
+      def normalize_definition_identifier: (Symbol field_name, state_name value) -> String
+      def normalize_default_version: (bool value) -> bool
 
       class Graph
         @steps: Array[Step]
@@ -1505,11 +1554,20 @@ module Karya
 
     class Catalog
       @definitions: Hash[String, Definition]
+      @definitions_by_family: Hash[String, Hash[String, Definition]]
 
       attr_reader definitions: Hash[String, Definition]
+      attr_reader definitions_by_family: Hash[String, Hash[String, Definition]]
 
       def initialize: (definitions: Array[Definition]) -> void
       def fetch: (state_name workflow_id) -> Definition
+      def fetch_version: (workflow_family: state_name, workflow_version: state_name) -> Definition
+      def resolve: (workflow_family: state_name) -> Definition
+
+    private
+
+      def build_definitions_by_family: () -> Hash[String, Hash[String, Definition]]
+      def build_default_definitions_by_family: () -> Hash[String, Definition]
     end
 
   private
@@ -1531,9 +1589,17 @@ module Karya
 
     class Builder
       @id: state_name
+      @workflow_family: state_name?
+      @workflow_version: state_name?
+      @default_version: bool
       @steps: Array[Step]
 
-      def initialize: (state_name id) -> void
+      def initialize: (
+        state_name id,
+        workflow_family: state_name?,
+        workflow_version: state_name?,
+        default_version: bool
+      ) -> void
       def step: (
         state_name id,
         handler: state_name,
@@ -1550,8 +1616,11 @@ module Karya
 
     private
 
+      attr_reader default_version: bool
       attr_reader id: state_name
       attr_reader steps: Array[Step]
+      attr_reader workflow_family: state_name?
+      attr_reader workflow_version: state_name?
     end
 
     class ExecutionBinding

--- a/core/karya/spec/karya/queue_store/in_memory_workflow_validation_spec.rb
+++ b/core/karya/spec/karya/queue_store/in_memory_workflow_validation_spec.rb
@@ -235,4 +235,50 @@ RSpec.describe Karya::QueueStore::InMemory do
     expect(reserve(20, handler_names: ['retrying']).job_id).to eq('job-retrying')
     expect(store.complete_execution(reservation_token: running.token, now: created_at + 21).id).to eq('job-running')
   end
+
+  it 'binds existing workflow runs to their resolved version while newer versions coexist' do
+    v1 = Karya::Workflow.define(
+      :invoice_closeout_v1,
+      workflow_family: :invoice_closeout,
+      workflow_version: :v1
+    ) do
+      step :capture, handler: :capture
+    end
+    v2 = Karya::Workflow.define(
+      :invoice_closeout_v2,
+      workflow_family: :invoice_closeout,
+      workflow_version: :v2,
+      default_version: false
+    ) do
+      step :capture, handler: :capture
+    end
+    catalog = Karya::Workflow.catalog(definitions: [v1, v2])
+
+    store.enqueue_workflow(
+      definition: catalog.resolve(workflow_family: :invoice_closeout),
+      jobs_by_step_id: { capture: workflow_job(:capture, handler: :capture) },
+      batch_id: :batch_v1,
+      now: created_at + 1
+    )
+    store.enqueue_workflow(
+      definition: catalog.fetch_version(workflow_family: :invoice_closeout, workflow_version: :v2),
+      jobs_by_step_id: { capture: workflow_job(:capture_two, handler: :capture) },
+      batch_id: :batch_v2,
+      now: created_at + 2
+    )
+
+    v1_snapshot = store.workflow_snapshot(batch_id: :batch_v1, now: created_at + 3)
+    v2_snapshot = store.workflow_snapshot(batch_id: :batch_v2, now: created_at + 4)
+
+    expect(v1_snapshot).to have_attributes(
+      workflow_id: 'invoice_closeout_v1',
+      workflow_family: 'invoice_closeout',
+      workflow_version: 'v1'
+    )
+    expect(v2_snapshot).to have_attributes(
+      workflow_id: 'invoice_closeout_v2',
+      workflow_family: 'invoice_closeout',
+      workflow_version: 'v2'
+    )
+  end
 end

--- a/core/karya/spec/karya/workflow/catalog_spec.rb
+++ b/core/karya/spec/karya/workflow/catalog_spec.rb
@@ -111,6 +111,12 @@ RSpec.describe Karya::Workflow::Catalog do
       catalog.resolve(workflow_family: :invoice_closeout)
     end.to raise_error(Karya::Workflow::InvalidDefinitionError, 'workflow family "invoice_closeout" has no default version')
     expect do
+      catalog.resolve(workflow_family: :missing_family)
+    end.to raise_error(
+      Karya::Workflow::InvalidDefinitionError,
+      'workflow family "missing_family" is not registered'
+    )
+    expect do
       catalog.fetch_version(workflow_family: :invoice_closeout, workflow_version: :v2)
     end.to raise_error(
       Karya::Workflow::InvalidDefinitionError,

--- a/core/karya/spec/karya/workflow/catalog_spec.rb
+++ b/core/karya/spec/karya/workflow/catalog_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe Karya::Workflow::Catalog do
     catalog = described_class.new(definitions: [definition])
 
     expect(catalog.definitions.keys).to eq(['invoice_closeout'])
+    expect(catalog.definitions_by_family.keys).to eq(['invoice_closeout'])
     expect(catalog.fetch(' invoice_closeout ')).to eq(definition)
+    expect(catalog.resolve(workflow_family: ' invoice_closeout ')).to eq(definition)
     expect(catalog).to be_frozen
   end
 
@@ -36,6 +38,90 @@ RSpec.describe Karya::Workflow::Catalog do
     expect do
       described_class.new(definitions: [definition, duplicate_definition])
     end.to raise_error(Karya::Workflow::InvalidDefinitionError, 'duplicate workflow id "invoice_closeout"')
+  end
+
+  it 'resolves explicit versions within one workflow family' do
+    default_definition = Karya::Workflow.define(
+      :invoice_closeout_v1,
+      workflow_family: :invoice_closeout,
+      workflow_version: :v1
+    ) do
+      step :calculate_totals, handler: :calculate_totals
+    end
+    next_definition = Karya::Workflow.define(
+      :invoice_closeout_v2,
+      workflow_family: :invoice_closeout,
+      workflow_version: :v2,
+      default_version: false
+    ) do
+      step :calculate_totals, handler: :calculate_totals
+    end
+
+    catalog = described_class.new(definitions: [default_definition, next_definition])
+
+    expect(catalog.fetch_version(workflow_family: :invoice_closeout, workflow_version: :v1)).to eq(default_definition)
+    expect(catalog.fetch_version(workflow_family: :invoice_closeout, workflow_version: :v2)).to eq(next_definition)
+    expect(catalog.resolve(workflow_family: :invoice_closeout)).to eq(default_definition)
+  end
+
+  it 'rejects duplicate versions within one workflow family' do
+    first = Karya::Workflow.define(:invoice_closeout_v1, workflow_family: :invoice_closeout, workflow_version: :v1) do
+      step :calculate_totals, handler: :calculate_totals
+    end
+    duplicate = Karya::Workflow.define(:invoice_closeout_v1_copy, workflow_family: :invoice_closeout, workflow_version: :v1) do
+      step :capture_payment, handler: :capture_payment
+    end
+
+    expect do
+      described_class.new(definitions: [first, duplicate])
+    end.to raise_error(
+      Karya::Workflow::InvalidDefinitionError,
+      'duplicate workflow version "v1" for family "invoice_closeout"'
+    )
+  end
+
+  it 'rejects multiple default versions within one workflow family' do
+    first = Karya::Workflow.define(:invoice_closeout_v1, workflow_family: :invoice_closeout, workflow_version: :v1) do
+      step :calculate_totals, handler: :calculate_totals
+    end
+    second = Karya::Workflow.define(:invoice_closeout_v2, workflow_family: :invoice_closeout, workflow_version: :v2) do
+      step :capture_payment, handler: :capture_payment
+    end
+
+    expect do
+      described_class.new(definitions: [first, second])
+    end.to raise_error(
+      Karya::Workflow::InvalidDefinitionError,
+      'workflow family "invoice_closeout" declares multiple default versions'
+    )
+  end
+
+  it 'rejects missing family defaults and unknown versions explicitly' do
+    first = Karya::Workflow.define(
+      :invoice_closeout_v1,
+      workflow_family: :invoice_closeout,
+      workflow_version: :v1,
+      default_version: false
+    ) do
+      step :calculate_totals, handler: :calculate_totals
+    end
+    catalog = described_class.new(definitions: [first])
+
+    expect do
+      catalog.resolve(workflow_family: :invoice_closeout)
+    end.to raise_error(Karya::Workflow::InvalidDefinitionError, 'workflow family "invoice_closeout" has no default version')
+    expect do
+      catalog.fetch_version(workflow_family: :invoice_closeout, workflow_version: :v2)
+    end.to raise_error(
+      Karya::Workflow::InvalidDefinitionError,
+      'workflow family "invoice_closeout" does not include version "v2"'
+    )
+    expect do
+      catalog.fetch_version(workflow_family: :missing_family, workflow_version: :v1)
+    end.to raise_error(
+      Karya::Workflow::InvalidDefinitionError,
+      'workflow family "missing_family" is not registered'
+    )
   end
 
   it 'rejects non-array definition collections' do

--- a/core/karya/spec/karya/workflow/child_workflow_snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/child_workflow_snapshot_spec.rb
@@ -21,14 +21,41 @@ RSpec.describe Karya::Workflow::ChildWorkflowSnapshot do
   it 'normalizes ids and freezes the snapshot' do
     expect(snapshot).to have_attributes(
       parent_workflow_id: 'parent',
+      parent_workflow_family: 'parent',
+      parent_workflow_version: 'v1',
       parent_batch_id: 'parent-batch',
       parent_step_id: 'child-step',
       parent_job_id: 'parent-job',
       child_workflow_id: 'child',
+      child_workflow_family: 'child',
+      child_workflow_version: 'v1',
       child_batch_id: 'child-batch',
       child_state: :running
     )
     expect(snapshot).to be_frozen
+  end
+
+  it 'accepts explicit parent and child version identity' do
+    versioned = described_class.new(
+      parent_workflow_id: :invoice_closeout_v1,
+      parent_workflow_family: :invoice_closeout,
+      parent_workflow_version: :v1,
+      parent_batch_id: :parent_batch,
+      parent_step_id: :child_step,
+      parent_job_id: :parent_job,
+      child_workflow_id: :payment_v2,
+      child_workflow_family: :payment,
+      child_workflow_version: :v2,
+      child_batch_id: :child_batch,
+      child_state: :running
+    )
+
+    expect(versioned).to have_attributes(
+      parent_workflow_family: 'invoice_closeout',
+      parent_workflow_version: 'v1',
+      child_workflow_family: 'payment',
+      child_workflow_version: 'v2'
+    )
   end
 
   it 'rejects invalid workflow states' do

--- a/core/karya/spec/karya/workflow/definition_spec.rb
+++ b/core/karya/spec/karya/workflow/definition_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe Karya::Workflow::Definition do
 
     expect(definition.steps).to eq([calculate_totals, capture_payment, emit_receipt])
     expect(definition.steps).to be_frozen
+    expect(definition.workflow_family).to eq('invoice_closeout')
+    expect(definition.workflow_version).to eq('v1')
+    expect(definition).to be_default_version
     expect(definition.step_ids).to eq(%w[calculate_totals capture_payment emit_receipt])
     expect(definition.step_ids).to be_frozen
     expect(definition.dependencies).to contain_exactly(
@@ -38,6 +41,29 @@ RSpec.describe Karya::Workflow::Definition do
     expect(definition.compensable_step_ids).to eq(['emit_receipt'])
     expect(definition.child_step_ids).to eq(['emit_receipt'])
     expect(definition).to be_frozen
+  end
+
+  it 'accepts explicit family, version, and default metadata' do
+    definition = described_class.new(
+      id: :invoice_closeout_v2,
+      workflow_family: :invoice_closeout,
+      workflow_version: :v2,
+      default_version: false,
+      steps: [calculate_totals]
+    )
+
+    expect(definition).to have_attributes(
+      id: 'invoice_closeout_v2',
+      workflow_family: 'invoice_closeout',
+      workflow_version: 'v2',
+      default_version?: false
+    )
+  end
+
+  it 'rejects non-boolean default_version values' do
+    expect do
+      described_class.new(id: :invoice_closeout, default_version: :yes, steps: [calculate_totals])
+    end.to raise_error(Karya::Workflow::InvalidDefinitionError, 'default_version must be true or false')
   end
 
   it 'raises definition errors when fetching unknown step inspection' do

--- a/core/karya/spec/karya/workflow/snapshot_spec.rb
+++ b/core/karya/spec/karya/workflow/snapshot_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Karya::Workflow::Snapshot do
 
     expect(result).to have_attributes(
       workflow_id: 'invoice_closeout',
+      workflow_family: 'invoice_closeout',
+      workflow_version: 'v1',
       batch_id: 'batch_1',
       captured_at:,
       job_ids: %w[job_root job_child],
@@ -103,6 +105,25 @@ RSpec.describe Karya::Workflow::Snapshot do
     expect(result.jobs).to be_frozen
     expect(result.step_states).to be_frozen
     expect(result.state_counts).to be_frozen
+  end
+
+  it 'exposes explicit workflow family and version on snapshots' do
+    result = described_class.new(
+      workflow_id: :invoice_closeout_v2,
+      workflow_family: :invoice_closeout,
+      workflow_version: :v2,
+      batch_id: :batch_one,
+      captured_at:,
+      step_job_ids: { root: 'job_root' },
+      dependency_job_ids_by_job_id: {},
+      jobs: [job(id: 'job_root', state: :queued)]
+    )
+
+    expect(result).to have_attributes(
+      workflow_id: 'invoice_closeout_v2',
+      workflow_family: 'invoice_closeout',
+      workflow_version: 'v2'
+    )
   end
 
   it 'exposes workflow interaction snapshots and filtered readers' do

--- a/core/karya/spec/karya/workflow_spec.rb
+++ b/core/karya/spec/karya/workflow_spec.rb
@@ -8,7 +8,12 @@
 RSpec.describe Karya::Workflow do
   describe '.define' do
     it 'builds a normalized workflow definition from the Ruby DSL' do
-      definition = described_class.define(:invoice_closeout) do
+      definition = described_class.define(
+        :invoice_closeout,
+        workflow_family: :billing_closeout,
+        workflow_version: :v2,
+        default_version: false
+      ) do
         step :calculate_totals, handler: :calculate_totals
         step :capture_payment, handler: 'capture_payment', depends_on: :calculate_totals
         step :emit_receipt,
@@ -19,6 +24,9 @@ RSpec.describe Karya::Workflow do
 
       expect(definition).to be_a(Karya::Workflow::Definition)
       expect(definition.id).to eq('invoice_closeout')
+      expect(definition.workflow_family).to eq('billing_closeout')
+      expect(definition.workflow_version).to eq('v2')
+      expect(definition.default_version?).to be(false)
       expect(definition.steps.map(&:id)).to eq(%w[calculate_totals capture_payment emit_receipt])
       expect(definition.dependencies.map { |dependency| [dependency.step_id, dependency.depends_on_step_id] }).to eq(
         [
@@ -45,6 +53,7 @@ RSpec.describe Karya::Workflow do
       catalog = described_class.catalog(definitions: [definition])
 
       expect(catalog.fetch(:invoice_closeout)).to eq(definition)
+      expect(catalog.resolve(workflow_family: :invoice_closeout)).to eq(definition)
     end
   end
 

--- a/docs/pages/adoption/cutover-rollback.md
+++ b/docs/pages/adoption/cutover-rollback.md
@@ -32,6 +32,10 @@ rollback_status: ready
 Production adoption is a governed transition, not just a package installation
 step.
 
+For durable workflows, cutover uses a coexistence window: new submissions can
+target a newer workflow version while existing persisted batches continue on
+the version selected at submission time.
+
 ## Related Concepts
 
 - [Rollout](/governance/rollout/): cutover planning depends on rollout

--- a/docs/pages/governance/rollout.md
+++ b/docs/pages/governance/rollout.md
@@ -32,6 +32,10 @@ rollback_path: available
 
 Rollout behavior stays intentional and operator-visible rather than ad hoc.
 
+For workflow families, rollout controls distinguish between the default version
+for new submissions and older versions that remain active for persisted
+workflow batches during a compatibility window.
+
 ## Related Concepts
 
 - [Policies](/governance/policies/): approvals and release controls must agree

--- a/docs/pages/workflows/replay.md
+++ b/docs/pages/workflows/replay.md
@@ -49,6 +49,10 @@ explicitly; Karya does not infer targets from workflow state, create a new
 workflow run, append batch membership, or reconstruct a workflow from a
 timeline.
 
+Replay stays bound to the workflow version already associated with the batch.
+Registering a newer version affects future submissions, not the meaning of the
+batch being recovered.
+
 ### Step Retry
 
 Use retry when a failed or retry-pending primary step job should return to

--- a/docs/pages/workflows/versioning.md
+++ b/docs/pages/workflows/versioning.md
@@ -7,8 +7,8 @@ permalink: /workflows/versioning/
 
 # Workflow Versioning
 
-Long-lived workflows require explicit evolution rules. Karya documents
-versioning so teams can change orchestration safely over time.
+Long-lived workflows require explicit evolution rules. Workflow versioning lets
+teams evolve orchestration safely over time.
 
 ## Covered Behavior
 
@@ -16,6 +16,36 @@ versioning so teams can change orchestration safely over time.
 - safe evolution semantics
 - upgrade and migration expectations for persisted workflow state
 - operator guidance during cutovers and compatibility windows
+
+## Workflow Identity
+
+Workflow versioning is explicit runtime identity rather than a naming
+convention hidden in application code.
+
+- `workflow_family` is the stable product-facing workflow line, such as
+  `invoice-closeout`
+- `workflow_version` is the exact definition version, such as `v1` or `v2`
+- `workflow_id` identifies the concrete registered definition that a run
+  actually uses
+
+New submissions resolve through the workflow family. Running and persisted
+workflow batches stay bound to the exact workflow version selected at
+submission time.
+
+## Safe Evolution Rules
+
+Versioning keeps the coexistence boundary explicit:
+
+- new submissions can resolve to a newer default version within the same
+  workflow family
+- existing workflow batches stay on their captured version
+- replay, rollback, pause or resume, approvals, signals, and child-workflow
+  synchronization continue against that bound version
+- incompatible workflow changes require a new version instead of mutating the
+  meaning of an existing one
+
+This model keeps long-running execution understandable during cutovers and
+avoids silent rebinding when definitions change.
 
 ## Common Scenarios
 
@@ -32,8 +62,41 @@ new_submissions:
 compatibility_window: active
 ```
 
-Version boundaries and operator expectations need to stay explicit, especially
-when long-lived executions cross rollout windows.
+In that window:
+
+- new workflow submissions can target `v2`
+- in-flight `v1` batches continue to inspect, recover, and complete as `v1`
+- operators can reason about recovery without guessing which definition a batch
+  now means
+
+### Safe Change Types
+
+Versioning supports additive and intentional change, not silent semantic drift.
+
+Typical safe patterns include:
+
+- adding a new version for incompatible step ordering or dependency changes
+- introducing new checkpoints or child workflows behind a new version boundary
+- keeping older versions available until active batches have drained
+
+Typical unsafe patterns include:
+
+- changing the meaning of an in-flight step inside the same bound version
+- rebinding persisted batches to a newer definition without an explicit version
+  transition
+- assuming replay reconstructs a workflow from a new definition or event
+  history
+
+### Persisted Workflow Behavior
+
+Persisted workflow state stays version-bound. Coexistence windows are the
+standard cutover shape for live workflow batches.
+
+- version selection happens at submission time
+- persisted workflow snapshots keep both workflow family and workflow version
+- older and newer versions can coexist during rollout
+- migration or rebind controls are separate product surfaces, not an implicit
+  side effect of registering a new definition
 
 ## Related Concepts
 


### PR DESCRIPTION
- Added support for defining workflows with explicit versions and families.
- Updated the workflow definition DSL to accept `workflow_family`, `workflow_version`, and `default_version` parameters.
- Enhanced the Catalog class to manage definitions by family and version, allowing for version-specific fetching and resolution.
- Introduced new methods to fetch and resolve workflow definitions based on family and version.
- Updated ChildWorkflowSnapshot to include parent and child workflow family and version attributes.
- Enhanced tests to cover new versioning features, ensuring correct behavior for multiple versions within the same family.
- Updated documentation to reflect changes in workflow versioning and coexistence during cutover.

closes: #353

