### PR TITLE
feat: add MySQL support across Karya frameworks

### DIFF
--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -188,6 +188,7 @@ jobs:
           - "4.0"
     env:
       RAILS_ENV: test
+      MYSQL_DATABASE_URL: mysql2://root:rootROOT!1@127.0.0.1:3306/mysql
       PG_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
       REDIS_URL: redis://127.0.0.1:6379/0
       KARYA_REDIS_URL: redis://127.0.0.1:6379/0

--- a/core/karya/Gemfile
+++ b/core/karya/Gemfile
@@ -11,6 +11,7 @@ gemspec
 
 gem 'activerecord', '>= 7.1', '< 9.0'
 gem 'bundler-audit', require: false
+gem 'mysql2'
 gem 'pg'
 gem 'rake', require: false
 gem 'redis', '~> 5.4'

--- a/core/karya/Gemfile.lock
+++ b/core/karya/Gemfile.lock
@@ -37,8 +37,8 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -75,13 +75,19 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    parallel (1.28.0)
+    mysql2 (0.5.7)
+      bigdecimal
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     prism (1.9.0)
     racc (1.8.1)
     rainbow (3.1.1)
@@ -156,17 +162,23 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
-  arm64-darwin-24
-  ruby
-  x86_64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   activerecord (>= 7.1, < 9.0)
   bundler-audit
   karya!
+  mysql2
   pg
   rake
   redis (~> 5.4)

--- a/core/karya/lib/karya/active_record.rb
+++ b/core/karya/lib/karya/active_record.rb
@@ -7,10 +7,11 @@
 
 require 'fileutils'
 
+require_relative 'internal/mysql_schema_catalog'
 require_relative 'internal/postgres_schema_catalog'
 
 module Karya
-  # Active Record migration/install support for the Postgres backend.
+  # Active Record migration/install support for SQL-backed Karya backends.
   module ActiveRecord
     module_function
 
@@ -26,6 +27,25 @@ module Karya
       File.write(
         path,
         Karya::Internal::PostgresSchemaCatalog.render_active_record_migration(
+          class_name:,
+          migration_version:
+        )
+      )
+      path
+    end
+
+    def install_mysql_migration(target_dir:, migration_name: 'Create Karya MySQL Backend')
+      require_activerecord!
+
+      class_name = normalize_migration_name(migration_name)
+      migration_version = "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}"
+      file_name = "#{timestamp}_#{underscore(class_name)}.rb"
+      path = File.expand_path(file_name, target_dir)
+
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(
+        path,
+        Karya::Internal::MySQLSchemaCatalog.render_active_record_migration(
           class_name:,
           migration_version:
         )

--- a/core/karya/lib/karya/active_record.rb
+++ b/core/karya/lib/karya/active_record.rb
@@ -18,7 +18,7 @@ module Karya
     def install_postgres_migration(target_dir:, migration_name: 'Create Karya Postgres Backend')
       require_activerecord!
 
-      class_name = normalize_migration_name(migration_name)
+      class_name = normalize_migration_name(migration_name, fallback: 'CreateKaryaPostgresBackend')
       migration_version = "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}"
       file_name = "#{timestamp}_#{underscore(class_name)}.rb"
       path = File.expand_path(file_name, target_dir)
@@ -37,7 +37,7 @@ module Karya
     def install_mysql_migration(target_dir:, migration_name: 'Create Karya MySQL Backend')
       require_activerecord!
 
-      class_name = normalize_migration_name(migration_name)
+      class_name = normalize_migration_name(migration_name, fallback: 'CreateKaryaMySQLBackend')
       migration_version = "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}"
       file_name = "#{timestamp}_#{underscore(class_name)}.rb"
       path = File.expand_path(file_name, target_dir)
@@ -58,11 +58,11 @@ module Karya
       require 'active_support/inflector'
     rescue LoadError => e
       raise LoadError,
-            "#{e.message}. Add `gem 'activerecord'` to your Gemfile to use Karya::ActiveRecord Postgres migration support.",
+            "#{e.message}. Add `gem 'activerecord'` to your Gemfile to use Karya::ActiveRecord SQL migration support.",
             cause: e
     end
 
-    def normalize_migration_name(name)
+    def normalize_migration_name(name, fallback: 'CreateKaryaPostgresBackend')
       normalized = name.to_s.each_char.with_object(+'') do |char, buffer|
         if alphanumeric?(char)
           buffer << char
@@ -72,7 +72,7 @@ module Karya
       end.split.map!(&:capitalize).join
       return normalized unless normalized.empty?
 
-      'CreateKaryaPostgresBackend'
+      fallback
     end
 
     def underscore(value)

--- a/core/karya/lib/karya/active_record.rb
+++ b/core/karya/lib/karya/active_record.rb
@@ -37,7 +37,7 @@ module Karya
     def install_mysql_migration(target_dir:, migration_name: 'Create Karya MySQL Backend')
       require_activerecord!
 
-      class_name = normalize_migration_name(migration_name, fallback: 'CreateKaryaMySQLBackend')
+      class_name = normalize_migration_name(migration_name, fallback: 'CreateKaryaMysqlBackend')
       migration_version = "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}"
       file_name = "#{timestamp}_#{underscore(class_name)}.rb"
       path = File.expand_path(file_name, target_dir)

--- a/core/karya/lib/karya/backend.rb
+++ b/core/karya/lib/karya/backend.rb
@@ -13,6 +13,7 @@ module Karya
   module Backend
     autoload :Base, 'karya/backend/base'
     autoload :InMemory, 'karya/backend/in_memory'
+    autoload :MySQL, 'karya/backend/mysql'
     autoload :Postgres, 'karya/backend/postgres'
     autoload :Redis, 'karya/backend/redis'
   end

--- a/core/karya/lib/karya/backend/mysql.rb
+++ b/core/karya/lib/karya/backend/mysql.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require_relative '../base'
+require_relative '../backend'
+require_relative '../backpressure'
+require_relative '../circuit_breaker'
+require_relative '../fairness'
+require_relative '../queue_store/mysql'
+
+module Karya
+  module Backend
+    # MySQL-backed backend wrapper for durable queue-store boot.
+    class MySQL
+      include Base
+
+      def initialize(url:, namespace: QueueStore::MySQL::DEFAULT_NAMESPACE, **queue_store_options)
+        @identifier = 'mysql'
+        @queue_store_options = {
+          url:,
+          namespace:,
+          **queue_store_options
+        }.freeze
+      end
+
+      attr_reader :identifier
+
+      def build_queue_store
+        QueueStore::MySQL.new(**queue_store_options)
+      rescue ArgumentError, TypeError, InvalidQueueStoreOperationError => e
+        raise InvalidBackendConfigurationError, "#{queue_store_configuration_error_message}: #{e.message}", cause: e
+      end
+
+      private
+
+      attr_reader :queue_store_options
+
+      def queue_store_configuration_error_message
+        invalid_keys = queue_store_options.keys - valid_queue_store_option_keys
+        return "invalid MySQL backend queue-store configuration: unexpected option keys #{invalid_keys.map(&:inspect).join(', ')}" unless invalid_keys.empty?
+
+        'invalid MySQL backend queue-store configuration'
+      end
+
+      def valid_queue_store_option_keys
+        %i[
+          url
+          namespace
+          expired_tombstone_limit
+          completed_batch_retention_limit
+          max_batch_size
+          policy_set
+          circuit_breaker_policy_set
+          fairness_policy
+        ]
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/internal/mysql_schema_catalog.rb
+++ b/core/karya/lib/karya/internal/mysql_schema_catalog.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module Internal
+    # Shared MySQL persistence catalog for the durable queue-store snapshot.
+    module MySQLSchemaCatalog
+      module_function
+
+      TABLE_NAME = 'karya_queue_store_states'
+
+      def create_table_sql
+        <<~SQL
+          CREATE TABLE IF NOT EXISTS #{TABLE_NAME} (
+            namespace varchar(255) PRIMARY KEY,
+            payload longtext NOT NULL,
+            updated_at datetime(6) NOT NULL
+              DEFAULT CURRENT_TIMESTAMP(6)
+              ON UPDATE CURRENT_TIMESTAMP(6)
+          ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+        SQL
+      end
+
+      def drop_table_sql
+        "DROP TABLE IF EXISTS #{TABLE_NAME}"
+      end
+
+      def render_active_record_migration(class_name:, migration_version:)
+        <<~RUBY
+          # frozen_string_literal: true
+
+          class #{class_name} < ActiveRecord::Migration[#{migration_version}]
+            def up
+              execute <<~SQL
+                #{create_table_sql.rstrip}
+              SQL
+            end
+
+            def down
+              execute <<~SQL
+                #{drop_table_sql}
+              SQL
+            end
+          end
+        RUBY
+      end
+
+      def render_sequel_migration
+        <<~RUBY
+          # frozen_string_literal: true
+
+          Sequel.migration do
+            up do
+              run <<~SQL
+                #{create_table_sql.rstrip}
+              SQL
+            end
+
+            down do
+              run <<~SQL
+                #{drop_table_sql}
+              SQL
+            end
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store.rb
+++ b/core/karya/lib/karya/queue_store.rb
@@ -37,6 +37,7 @@ module Karya
     autoload :Base, 'karya/queue_store/base'
     autoload :InMemory, 'karya/queue_store/in_memory'
     autoload :Internal, 'karya/queue_store/internal'
+    autoload :MySQL, 'karya/queue_store/mysql'
     autoload :Postgres, 'karya/queue_store/postgres'
     autoload :Redis, 'karya/queue_store/redis'
   end

--- a/core/karya/lib/karya/queue_store/mysql.rb
+++ b/core/karya/lib/karya/queue_store/mysql.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require 'securerandom'
+require 'uri'
+
+require_relative 'internal/reference_queue_store'
+require_relative 'mysql/internal'
+
+module Karya
+  module QueueStore
+    # MySQL-backed durable queue store that persists canonical queue state in MySQL.
+    class MySQL
+      include Karya::QueueStore::Internal::ReferenceQueueStore
+
+      module Internal
+        StoreState = Karya::QueueStore::Internal::StoreState
+      end
+
+      DEFAULT_NAMESPACE = 'karya'
+      DEFAULT_EXPIRED_TOMBSTONE_LIMIT = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_EXPIRED_TOMBSTONE_LIMIT
+      DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT
+      DEFAULT_MAX_BATCH_SIZE = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_MAX_BATCH_SIZE
+      RESERVE_QUEUES_ERROR_MESSAGE = Karya::QueueStore::Internal::ReferenceQueueStore::RESERVE_QUEUES_ERROR_MESSAGE
+      private_constant :Internal
+
+      # Normalizes required non-empty MySQL string configuration values.
+      class PresentString
+        def initialize(value)
+          @value = value
+        end
+
+        def normalize
+          return unless value.is_a?(String)
+
+          normalized_value = value.strip
+          normalized_value unless normalized_value.empty?
+        end
+
+        private
+
+        attr_reader :value
+      end
+
+      # Parses a MySQL URL into mysql2 connection options.
+      class ConnectionOptions
+        def self.build(url:, present_string_class:)
+          new(url:, present_string_class:).build
+        end
+
+        def initialize(url:, present_string_class:)
+          @url = url
+          @present_string_class = present_string_class
+        end
+
+        def build
+          uri = URI.parse(url)
+          validate_scheme(uri)
+          database_name = uri.path.to_s.delete_prefix('/')
+          raise InvalidQueueStoreOperationError, 'url must include a database name' if database_name.empty?
+
+          socket, encoding = transport_options(uri)
+          options = {
+            username: normalize_string(uri.user),
+            password: uri.password,
+            database: database_name,
+            encoding:
+          }.compact
+
+          if socket
+            options[:socket] = socket
+          else
+            options[:host] = uri.host || '127.0.0.1'
+            options[:port] = uri.port || 3306
+          end
+
+          options
+        rescue URI::InvalidURIError => e
+          raise InvalidQueueStoreOperationError, "invalid MySQL url: #{e.message}", cause: e
+        end
+
+        private
+
+        attr_reader :present_string_class, :url
+
+        def normalize_string(value)
+          present_string_class.new(value).normalize
+        end
+
+        def transport_options(uri)
+          query_options = URI.decode_www_form(uri.query.to_s).to_h
+          socket = normalize_string(query_options['socket'])
+          encoding = normalize_string(query_options['encoding']) || 'utf8mb4'
+          [socket, encoding]
+        end
+
+        def validate_scheme(uri)
+          return if %w[mysql mysql2].include?(uri.scheme)
+
+          raise InvalidQueueStoreOperationError, 'url must use mysql:// or mysql2://'
+        end
+      end
+
+      def initialize(url:, namespace: DEFAULT_NAMESPACE, **options)
+        raise InvalidQueueStoreOperationError, 'token_generator is managed internally by Karya::QueueStore::MySQL' if options.key?(:token_generator)
+
+        Internal::DependencyLoader.require_mysql2!
+        @url = normalize_url(url)
+        @namespace = normalize_namespace(namespace)
+        @connection = Mysql2::Client.new(**ConnectionOptions.build(url: @url, present_string_class: PresentString))
+        configure_reference_queue_store(
+          initializer_options_class: Karya::QueueStore::Internal::InitializerOptions,
+          store_state_class: Internal::StoreState,
+          token_generator: -> { SecureRandom.uuid },
+          **options
+        )
+        @persistence_mutex = Internal::PersistenceMutex.new(connection:, owner: self)
+        @mutex = @persistence_mutex
+        @persistence_mutex.ensure_schema
+        load_persisted_state
+      rescue StandardError
+        @connection&.close
+        raise
+      end
+
+      attr_reader :connection, :mutex, :namespace, :persistence_mutex, :reservation_token_sequence, :url
+
+      def load_persisted_state
+        restore_state_snapshot(persistence_mutex.load_state_snapshot)
+      end
+
+      def dump_state_payload
+        Internal::StateCodec.dump(
+          state:,
+          reservation_token_sequence:
+        )
+      end
+
+      def restore_authoritative_state_after_failure
+        load_persisted_state
+        nil
+      rescue StandardError
+        nil
+      end
+
+      private
+
+      attr_reader :state
+
+      def normalize_url(value)
+        normalized = PresentString.new(value).normalize
+        return normalized if normalized
+
+        raise InvalidQueueStoreOperationError, 'url must be a non-empty String'
+      end
+
+      def normalize_namespace(value)
+        normalized = PresentString.new(value).normalize
+        return normalized if normalized
+
+        raise InvalidQueueStoreOperationError, 'namespace must be a non-empty String'
+      end
+
+      def restore_state_snapshot(snapshot)
+        if snapshot
+          @state = snapshot.fetch(:state)
+          @reservation_token_sequence = snapshot.fetch(:reservation_token_sequence)
+        else
+          @state = Internal::StoreState.new(expired_tombstone_limit:)
+          @reservation_token_sequence = 0
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/mysql.rb
+++ b/core/karya/lib/karya/queue_store/mysql.rb
@@ -25,6 +25,7 @@ module Karya
       DEFAULT_EXPIRED_TOMBSTONE_LIMIT = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_EXPIRED_TOMBSTONE_LIMIT
       DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT
       DEFAULT_MAX_BATCH_SIZE = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_MAX_BATCH_SIZE
+      MAX_NAMESPACE_BYTES = 255
       RESERVE_QUEUES_ERROR_MESSAGE = Karya::QueueStore::Internal::ReferenceQueueStore::RESERVE_QUEUES_ERROR_MESSAGE
       private_constant :Internal
 
@@ -79,7 +80,7 @@ module Karya
           end
 
           options
-        rescue URI::InvalidURIError => e
+        rescue URI::InvalidURIError, ArgumentError => e
           raise InvalidQueueStoreOperationError, "invalid MySQL url: #{e.message}", cause: e
         end
 
@@ -160,9 +161,10 @@ module Karya
 
       def normalize_namespace(value)
         normalized = PresentString.new(value).normalize
-        return normalized if normalized
+        raise InvalidQueueStoreOperationError, 'namespace must be a non-empty String' unless normalized
+        return normalized if normalized.bytesize <= MAX_NAMESPACE_BYTES
 
-        raise InvalidQueueStoreOperationError, 'namespace must be a non-empty String'
+        raise InvalidQueueStoreOperationError, "namespace must be at most #{MAX_NAMESPACE_BYTES} bytes"
       end
 
       def restore_state_snapshot(snapshot)

--- a/core/karya/lib/karya/queue_store/mysql.rb
+++ b/core/karya/lib/karya/queue_store/mysql.rb
@@ -25,7 +25,7 @@ module Karya
       DEFAULT_EXPIRED_TOMBSTONE_LIMIT = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_EXPIRED_TOMBSTONE_LIMIT
       DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT
       DEFAULT_MAX_BATCH_SIZE = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_MAX_BATCH_SIZE
-      MAX_NAMESPACE_BYTES = 255
+      MAX_NAMESPACE_CHARACTERS = 255
       RESERVE_QUEUES_ERROR_MESSAGE = Karya::QueueStore::Internal::ReferenceQueueStore::RESERVE_QUEUES_ERROR_MESSAGE
       private_constant :Internal
 
@@ -162,9 +162,9 @@ module Karya
       def normalize_namespace(value)
         normalized = PresentString.new(value).normalize
         raise InvalidQueueStoreOperationError, 'namespace must be a non-empty String' unless normalized
-        return normalized if normalized.bytesize <= MAX_NAMESPACE_BYTES
+        return normalized if normalized.length <= MAX_NAMESPACE_CHARACTERS
 
-        raise InvalidQueueStoreOperationError, "namespace must be at most #{MAX_NAMESPACE_BYTES} bytes"
+        raise InvalidQueueStoreOperationError, "namespace must be at most #{MAX_NAMESPACE_CHARACTERS} characters"
       end
 
       def restore_state_snapshot(snapshot)

--- a/core/karya/lib/karya/queue_store/mysql/internal.rb
+++ b/core/karya/lib/karya/queue_store/mysql/internal.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require_relative 'internal/dependency_loader'
+require_relative 'internal/persistence_mutex'
+require_relative 'internal/state_codec'

--- a/core/karya/lib/karya/queue_store/mysql/internal/dependency_loader.rb
+++ b/core/karya/lib/karya/queue_store/mysql/internal/dependency_loader.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class MySQL
+      module Internal
+        # Loads optional runtime dependencies for the MySQL-backed queue store.
+        module DependencyLoader
+          module_function
+
+          def require_mysql2!
+            require 'mysql2'
+          rescue LoadError => e
+            raise LoadError,
+                  "#{e.message}. Add `gem 'mysql2'` to your Gemfile to use Karya::Backend::MySQL and Karya::QueueStore::MySQL.",
+                  cause: e
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/mysql/internal/persistence_mutex.rb
+++ b/core/karya/lib/karya/queue_store/mysql/internal/persistence_mutex.rb
@@ -133,7 +133,8 @@ module Karya
             <<~SQL
               INSERT INTO #{Karya::Internal::MySQLSchemaCatalog::TABLE_NAME} (namespace, payload, updated_at)
               VALUES ('#{escaped_namespace}', '#{escaped_payload}', CURRENT_TIMESTAMP(6))
-              ON DUPLICATE KEY UPDATE payload = VALUES(payload), updated_at = VALUES(updated_at)
+              AS new
+              ON DUPLICATE KEY UPDATE payload = new.payload, updated_at = new.updated_at
             SQL
           end
         end

--- a/core/karya/lib/karya/queue_store/mysql/internal/persistence_mutex.rb
+++ b/core/karya/lib/karya/queue_store/mysql/internal/persistence_mutex.rb
@@ -69,6 +69,7 @@ module Karya
           end
 
           def lock_current_row
+            ensure_lockable_row
             connection.query(select_sql(lock: true), as: :hash, symbolize_keys: false)
             nil
           end
@@ -105,6 +106,26 @@ module Karya
               WHERE namespace = '#{escaped_namespace}'
             SQL
             lock ? "#{sql.rstrip} FOR UPDATE" : sql
+          end
+
+          def ensure_lockable_row
+            connection.query(insert_placeholder_sql)
+            nil
+          end
+
+          def insert_placeholder_sql
+            escaped_payload = connection.escape(initial_payload)
+            <<~SQL
+              INSERT IGNORE INTO #{Karya::Internal::MySQLSchemaCatalog::TABLE_NAME} (namespace, payload, updated_at)
+              VALUES ('#{escaped_namespace}', '#{escaped_payload}', CURRENT_TIMESTAMP(6))
+            SQL
+          end
+
+          def initial_payload
+            StateCodec.dump(
+              state: StoreState.new(expired_tombstone_limit: owner.send(:expired_tombstone_limit)),
+              reservation_token_sequence: 0
+            )
           end
 
           def upsert_sql(payload)

--- a/core/karya/lib/karya/queue_store/mysql/internal/persistence_mutex.rb
+++ b/core/karya/lib/karya/queue_store/mysql/internal/persistence_mutex.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require_relative '../../../internal/mysql_schema_catalog'
+
+module Karya
+  module QueueStore
+    class MySQL
+      module Internal
+        # MySQL-backed synchronization boundary for shared queue-store state.
+        class PersistenceMutex
+          def initialize(connection:, owner:)
+            @connection = connection
+            @owner = owner
+            @local_mutex = Thread::Mutex.new
+          end
+
+          def ensure_schema
+            connection.query(Karya::Internal::MySQLSchemaCatalog.create_table_sql)
+            nil
+          end
+
+          def synchronize(persist_if: nil, &)
+            synchronize_owned_state(persist_if:, &)
+          end
+
+          def read_only_synchronize(&)
+            synchronize_owned_state(read_only: true, &)
+          end
+
+          def load_state_snapshot
+            rows = connection.query(select_sql(lock: false), as: :hash, symbolize_keys: false).to_a
+            return nil if rows.empty?
+
+            StateCodec.load(rows[0].fetch('payload'))
+          end
+
+          private
+
+          attr_reader :connection, :local_mutex, :owner
+
+          def synchronize_owned_state(read_only: false, persist_if: nil)
+            local_mutex.synchronize do
+              with_transaction do
+                owner.send(:restore_state_snapshot, load_state_snapshot)
+                result = yield
+                persist_snapshot_if_needed(result, persist_if) unless read_only
+                result
+              end
+            rescue StandardError
+              restore_owner_state_after_failure
+              raise
+            end
+          end
+
+          def with_transaction
+            connection.query('START TRANSACTION')
+            lock_current_row
+            result = yield
+            connection.query('COMMIT')
+            result
+          rescue StandardError
+            safe_rollback
+            raise
+          end
+
+          def lock_current_row
+            connection.query(select_sql(lock: true), as: :hash, symbolize_keys: false)
+            nil
+          end
+
+          def persist_snapshot_if_needed(result, persist_if)
+            return if persist_if && !persist_if.call(result)
+
+            connection.query(upsert_sql(owner.send(:dump_state_payload)))
+            nil
+          end
+
+          def restore_owner_state_after_failure
+            owner.send(:restore_authoritative_state_after_failure)
+            nil
+          rescue StandardError
+            nil
+          end
+
+          def safe_rollback
+            connection.query('ROLLBACK')
+            nil
+          rescue StandardError
+            nil
+          end
+
+          def escaped_namespace
+            connection.escape(owner.namespace)
+          end
+
+          def select_sql(lock:)
+            sql = <<~SQL
+              SELECT payload
+              FROM #{Karya::Internal::MySQLSchemaCatalog::TABLE_NAME}
+              WHERE namespace = '#{escaped_namespace}'
+            SQL
+            lock ? "#{sql.rstrip} FOR UPDATE" : sql
+          end
+
+          def upsert_sql(payload)
+            escaped_payload = connection.escape(payload)
+            <<~SQL
+              INSERT INTO #{Karya::Internal::MySQLSchemaCatalog::TABLE_NAME} (namespace, payload, updated_at)
+              VALUES ('#{escaped_namespace}', '#{escaped_payload}', CURRENT_TIMESTAMP(6))
+              ON DUPLICATE KEY UPDATE payload = VALUES(payload), updated_at = VALUES(updated_at)
+            SQL
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/mysql/internal/state_codec.rb
+++ b/core/karya/lib/karya/queue_store/mysql/internal/state_codec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class MySQL
+      module Internal
+        # Encodes the durable queue-store state payload stored in MySQL.
+        module StateCodec
+          module_function
+
+          def dump(state:, reservation_token_sequence:)
+            [
+              Marshal.dump(
+                {
+                  state:,
+                  reservation_token_sequence:
+                }
+              )
+            ].pack('m0')
+          end
+
+          def load(payload)
+            # The payload is produced internally by `dump` and never accepted
+            # from user input or external network callers.
+            # rubocop:disable Security/MarshalLoad
+            snapshot = Marshal.load(payload.unpack1('m0'))
+            # rubocop:enable Security/MarshalLoad
+            validate_snapshot(snapshot)
+          rescue ArgumentError, TypeError => e
+            raise InvalidQueueStoreOperationError, "invalid MySQL state snapshot: #{e.class}: #{e.message}", cause: e
+          end
+
+          def validate_snapshot(snapshot)
+            unless snapshot.is_a?(Hash) &&
+                   snapshot.fetch(:state).is_a?(Karya::QueueStore::Internal::StoreState) &&
+                   snapshot.fetch(:reservation_token_sequence).is_a?(Integer)
+              raise InvalidQueueStoreOperationError, 'invalid MySQL state snapshot payload'
+            end
+
+            snapshot
+          rescue KeyError => e
+            raise InvalidQueueStoreOperationError, "invalid MySQL state snapshot: #{e.message}", cause: e
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/sequel.rb
+++ b/core/karya/lib/karya/sequel.rb
@@ -7,10 +7,11 @@
 
 require 'fileutils'
 
+require_relative 'internal/mysql_schema_catalog'
 require_relative 'internal/postgres_schema_catalog'
 
 module Karya
-  # Sequel migration/install support for the Postgres backend.
+  # Sequel migration/install support for SQL-backed Karya backends.
   module Sequel
     module_function
 
@@ -23,6 +24,18 @@ module Karya
 
       FileUtils.mkdir_p(File.dirname(path))
       File.write(path, Karya::Internal::PostgresSchemaCatalog.render_sequel_migration)
+      path
+    end
+
+    def install_mysql_migration(target_dir:, migration_name: 'create_karya_mysql_backend')
+      require_sequel!
+
+      normalized_name = normalize_migration_name(migration_name)
+      file_name = "#{timestamp}_#{normalized_name}.rb"
+      path = File.expand_path(file_name, target_dir)
+
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, Karya::Internal::MySQLSchemaCatalog.render_sequel_migration)
       path
     end
 

--- a/core/karya/lib/karya/sequel.rb
+++ b/core/karya/lib/karya/sequel.rb
@@ -18,7 +18,7 @@ module Karya
     def install_postgres_migration(target_dir:, migration_name: 'create_karya_postgres_backend')
       require_sequel!
 
-      normalized_name = normalize_migration_name(migration_name)
+      normalized_name = normalize_migration_name(migration_name, fallback: 'create_karya_postgres_backend')
       file_name = "#{timestamp}_#{normalized_name}.rb"
       path = File.expand_path(file_name, target_dir)
 
@@ -30,7 +30,7 @@ module Karya
     def install_mysql_migration(target_dir:, migration_name: 'create_karya_mysql_backend')
       require_sequel!
 
-      normalized_name = normalize_migration_name(migration_name)
+      normalized_name = normalize_migration_name(migration_name, fallback: 'create_karya_mysql_backend')
       file_name = "#{timestamp}_#{normalized_name}.rb"
       path = File.expand_path(file_name, target_dir)
 
@@ -43,11 +43,11 @@ module Karya
       require 'sequel'
     rescue LoadError => e
       raise LoadError,
-            "#{e.message}. Add `gem 'sequel'` to your Gemfile to use Karya::Sequel Postgres migration support.",
+            "#{e.message}. Add `gem 'sequel'` to your Gemfile to use Karya::Sequel SQL migration support.",
             cause: e
     end
 
-    def normalize_migration_name(name)
+    def normalize_migration_name(name, fallback: 'create_karya_postgres_backend')
       normalized = name.to_s.each_char.with_object(+'') do |char, buffer|
         if letter?(char) || digit?(char)
           buffer << char.downcase
@@ -57,7 +57,7 @@ module Karya
       end.delete_suffix('_')
       return normalized unless normalized.empty?
 
-      'create_karya_postgres_backend'
+      fallback
     end
 
     def timestamp

--- a/core/karya/sig/karya/active_record.rbs
+++ b/core/karya/sig/karya/active_record.rbs
@@ -4,6 +4,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_mysql_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
     def self.require_activerecord!: () -> void
     def self.normalize_migration_name: (String? name) -> String
     def self.underscore: (String value) -> String

--- a/core/karya/sig/karya/active_record.rbs
+++ b/core/karya/sig/karya/active_record.rbs
@@ -9,7 +9,7 @@ module Karya
       ?migration_name: String
     ) -> String
     def self.require_activerecord!: () -> void
-    def self.normalize_migration_name: (String? name) -> String
+    def self.normalize_migration_name: (String? name, ?fallback: String) -> String
     def self.underscore: (String value) -> String
     def self.timestamp: () -> String
   end

--- a/core/karya/sig/karya/backend.rbs
+++ b/core/karya/sig/karya/backend.rbs
@@ -14,6 +14,7 @@ module Karya
 
     type backend_class =
       singleton(InMemory) |
+      singleton(MySQL) |
       singleton(Postgres) |
       singleton(Redis) |
       (::Class & _BackendClass)

--- a/core/karya/sig/karya/backend/mysql.rbs
+++ b/core/karya/sig/karya/backend/mysql.rbs
@@ -1,0 +1,28 @@
+module Karya
+  module Backend
+    class MySQL
+      include Base
+
+      def initialize: (
+        url: String,
+        ?namespace: String,
+        ?expired_tombstone_limit: Integer,
+        ?completed_batch_retention_limit: Integer,
+        ?max_batch_size: Integer,
+        ?policy_set: Backpressure::PolicySet,
+        ?circuit_breaker_policy_set: CircuitBreaker::PolicySet,
+        ?fairness_policy: Fairness::Policy
+      ) -> void
+
+      attr_reader identifier: "mysql"
+
+      def build_queue_store: () -> QueueStore::MySQL
+
+      private
+
+      attr_reader queue_store_options: Hash[Symbol, Karya::backend_option_value]
+      def queue_store_configuration_error_message: () -> String
+      def valid_queue_store_option_keys: () -> Array[Symbol]
+    end
+  end
+end

--- a/core/karya/sig/karya/internal/mysql_schema_catalog.rbs
+++ b/core/karya/sig/karya/internal/mysql_schema_catalog.rbs
@@ -1,0 +1,15 @@
+module Karya
+  module Internal
+    module MySQLSchemaCatalog
+      TABLE_NAME: String
+
+      def self.create_table_sql: () -> String
+      def self.drop_table_sql: () -> String
+      def self.render_active_record_migration: (
+        class_name: String,
+        migration_version: String
+      ) -> String
+      def self.render_sequel_migration: () -> String
+    end
+  end
+end

--- a/core/karya/sig/karya/queue_store/mysql.rbs
+++ b/core/karya/sig/karya/queue_store/mysql.rbs
@@ -34,8 +34,12 @@ module Karya
       end
 
       module Internal
+        interface _Result
+          def to_a: () -> Array[Hash[String, String]]
+        end
+
         interface _Connection
-          def query: (String sql, ?as: Symbol, ?symbolize_keys: bool) -> Array[Hash[String, String]]
+          def query: (String sql, ?as: Symbol, ?symbolize_keys: bool) -> _Result
           def escape: (String value) -> String
           def close: () -> void
         end

--- a/core/karya/sig/karya/queue_store/mysql.rbs
+++ b/core/karya/sig/karya/queue_store/mysql.rbs
@@ -1,0 +1,63 @@
+module Karya
+  module QueueStore
+    class MySQL
+      include Karya::QueueStore::Internal::ReferenceQueueStore
+
+      DEFAULT_NAMESPACE: String
+      DEFAULT_EXPIRED_TOMBSTONE_LIMIT: Integer
+      DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT: Integer
+      DEFAULT_MAX_BATCH_SIZE: Integer
+      RESERVE_QUEUES_ERROR_MESSAGE: String
+
+      def initialize: (
+        url: String,
+        ?namespace: String,
+        ?expired_tombstone_limit: Integer,
+        ?completed_batch_retention_limit: Integer,
+        ?max_batch_size: Integer,
+        ?policy_set: Backpressure::PolicySet,
+        ?circuit_breaker_policy_set: CircuitBreaker::PolicySet,
+        ?fairness_policy: Fairness::Policy
+      ) -> void
+
+      class PresentString
+        def initialize: (String? value) -> void
+        def normalize: () -> String?
+
+        private
+
+        attr_reader value: String?
+      end
+
+      class ConnectionOptions
+        def self.build: (url: String, present_string_class: singleton(PresentString)) -> Hash[Symbol, String | Integer]
+      end
+
+      module Internal
+        interface _Connection
+          def query: (String sql, ?as: Symbol, ?symbolize_keys: bool) -> Array[Hash[String, String]]
+          def escape: (String value) -> String
+          def close: () -> void
+        end
+      end
+
+      attr_reader connection: Internal::_Connection
+      attr_reader mutex: Internal::PersistenceMutex
+      attr_reader namespace: String
+      attr_reader persistence_mutex: Internal::PersistenceMutex
+      attr_reader reservation_token_sequence: Integer
+      attr_reader url: String
+
+      def load_persisted_state: () -> void
+      def dump_state_payload: () -> String
+      def restore_authoritative_state_after_failure: () -> nil
+
+      private
+
+      attr_reader state: Karya::QueueStore::Internal::StoreState
+      def normalize_url: (String? value) -> String
+      def normalize_namespace: (String? value) -> String
+      def restore_state_snapshot: (Internal::StateCodec::snapshot? snapshot) -> void
+    end
+  end
+end

--- a/core/karya/sig/karya/queue_store/mysql/internal/dependency_loader.rbs
+++ b/core/karya/sig/karya/queue_store/mysql/internal/dependency_loader.rbs
@@ -1,0 +1,11 @@
+module Karya
+  module QueueStore
+    class MySQL
+      module Internal
+        module DependencyLoader
+          def self.require_mysql2!: () -> void
+        end
+      end
+    end
+  end
+end

--- a/core/karya/sig/karya/queue_store/mysql/internal/persistence_mutex.rbs
+++ b/core/karya/sig/karya/queue_store/mysql/internal/persistence_mutex.rbs
@@ -1,0 +1,34 @@
+module Karya
+  module QueueStore
+    class MySQL
+      module Internal
+        class PersistenceMutex
+          def initialize: (
+            connection: Karya::QueueStore::MySQL::Internal::_Connection,
+            owner: Karya::QueueStore::MySQL
+          ) -> void
+          def ensure_schema: () -> nil
+          def synchronize: [A] (?persist_if: ^(A) -> bool) { () -> A } -> A
+          def read_only_synchronize: [A] () { () -> A } -> A
+          def load_state_snapshot: () -> StateCodec::snapshot?
+
+          private
+
+          attr_reader connection: Karya::QueueStore::MySQL::Internal::_Connection
+          attr_reader local_mutex: Thread::Mutex
+          attr_reader owner: Karya::QueueStore::MySQL
+
+          def synchronize_owned_state: [A] (?read_only: bool, ?persist_if: ^(A) -> bool) { () -> A } -> A
+          def with_transaction: [A] () { () -> A } -> A
+          def lock_current_row: () -> nil
+          def persist_snapshot_if_needed: [A] (A result, (^ (A) -> bool)? persist_if) -> nil
+          def restore_owner_state_after_failure: () -> nil
+          def safe_rollback: () -> nil
+          def escaped_namespace: () -> String
+          def select_sql: (?lock: bool) -> String
+          def upsert_sql: (String payload) -> String
+        end
+      end
+    end
+  end
+end

--- a/core/karya/sig/karya/queue_store/mysql/internal/persistence_mutex.rbs
+++ b/core/karya/sig/karya/queue_store/mysql/internal/persistence_mutex.rbs
@@ -8,7 +8,7 @@ module Karya
             owner: Karya::QueueStore::MySQL
           ) -> void
           def ensure_schema: () -> nil
-          def synchronize: [A] (?persist_if: ^(A) -> bool) { () -> A } -> A
+          def synchronize: [A] (?persist_if: (^ (A) -> bool)?) { () -> A } -> A
           def read_only_synchronize: [A] () { () -> A } -> A
           def load_state_snapshot: () -> StateCodec::snapshot?
 
@@ -18,7 +18,7 @@ module Karya
           attr_reader local_mutex: Thread::Mutex
           attr_reader owner: Karya::QueueStore::MySQL
 
-          def synchronize_owned_state: [A] (?read_only: bool, ?persist_if: ^(A) -> bool) { () -> A } -> A
+          def synchronize_owned_state: [A] (?read_only: bool, ?persist_if: (^ (A) -> bool)?) { () -> A } -> A
           def with_transaction: [A] () { () -> A } -> A
           def lock_current_row: () -> nil
           def persist_snapshot_if_needed: [A] (A result, (^ (A) -> bool)? persist_if) -> nil

--- a/core/karya/sig/karya/queue_store/mysql/internal/state_codec.rbs
+++ b/core/karya/sig/karya/queue_store/mysql/internal/state_codec.rbs
@@ -1,0 +1,21 @@
+module Karya
+  module QueueStore
+    class MySQL
+      module Internal
+        module StateCodec
+          type snapshot = {
+            state: Karya::QueueStore::Internal::StoreState,
+            reservation_token_sequence: Integer
+          }
+
+          def self.dump: (
+            state: Karya::QueueStore::Internal::StoreState,
+            reservation_token_sequence: Integer
+          ) -> String
+          def self.load: (String payload) -> snapshot
+          def self.validate_snapshot: (snapshot snapshot) -> snapshot
+        end
+      end
+    end
+  end
+end

--- a/core/karya/sig/karya/sequel.rbs
+++ b/core/karya/sig/karya/sequel.rbs
@@ -9,7 +9,7 @@ module Karya
       ?migration_name: String
     ) -> String
     def self.require_sequel!: () -> void
-    def self.normalize_migration_name: (String? name) -> String
+    def self.normalize_migration_name: (String? name, ?fallback: String) -> String
     def self.timestamp: () -> String
   end
 end

--- a/core/karya/sig/karya/sequel.rbs
+++ b/core/karya/sig/karya/sequel.rbs
@@ -4,6 +4,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_mysql_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
     def self.require_sequel!: () -> void
     def self.normalize_migration_name: (String? name) -> String
     def self.timestamp: () -> String

--- a/core/karya/spec/e2e/karya/cli_worker_mysql_spec.rb
+++ b/core/karya/spec/e2e/karya/cli_worker_mysql_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require File.expand_path('../../../../../spec/support/mysql_e2e_support', __dir__)
+
+RSpec.describe Karya::CLI, :e2e, :integration do
+  def mysql_boot_file(mysql_url:, namespace:, marker_file:)
+    <<~RUBY
+      # frozen_string_literal: true
+
+      now = Time.utc(2026, 5, 5, 12, 0, 0)
+      queue_store = Karya::Backend::MySQL.new(
+        url: #{mysql_url.inspect},
+        namespace: #{namespace.inspect}
+      ).build_queue_store
+      queue_store.enqueue(
+        job: Karya::Job.new(
+          id: 'job-mysql-1',
+          queue: 'billing',
+          handler: 'billing_sync',
+          arguments: { 'account_id' => 42, 'marker_path' => #{marker_file.inspect} },
+          state: :submission,
+          created_at: now
+        ),
+        now: now
+      )
+      Karya.configure_backend(Karya::Backend::MySQL, url: #{mysql_url.inspect}, namespace: #{namespace.inspect})
+
+      class CliWorkerMySQLHandler
+        def self.call(account_id:, marker_path:)
+          File.write(marker_path, JSON.generate('account_id' => account_id, 'pid' => Process.pid))
+        end
+      end
+    RUBY
+  end
+
+  it 'boots a worker through the MySQL backend path when an external MySQL server is configured' do
+    mysql_admin_url = ENV.fetch('MYSQL_DATABASE_URL', nil)
+    skip 'set MYSQL_DATABASE_URL for MySQL e2e coverage' unless mysql_admin_url
+
+    with_mysql_database(prefix: 'karya_cli_mysql_e2e') do |database_url|
+      Dir.mktmpdir('karya-cli-mysql-e2e') do |directory|
+        state_file = File.join(directory, 'runtime.json')
+        marker_file = File.join(directory, 'handler.json')
+        namespace = "karya-mysql-e2e-#{Process.pid}-#{File.basename(directory)}"
+        boot_file = File.join(directory, 'worker_boot.rb')
+
+        File.write(boot_file, mysql_boot_file(mysql_url: database_url, namespace:, marker_file:))
+
+        stdout, stderr, status = Open3.capture3(
+          *karya_command(
+            'worker',
+            'billing',
+            '--require',
+            boot_file,
+            '--handler',
+            'billing_sync=CliWorkerMySQLHandler',
+            '--worker-id',
+            'worker-cli-mysql-e2e',
+            '--processes',
+            '1',
+            '--threads',
+            '1',
+            '--poll-interval',
+            '0',
+            '--max-iterations',
+            '1',
+            '--state-file',
+            state_file
+          ),
+          chdir: KaryaE2EHelpers::PACKAGE_ROOT
+        )
+
+        expect(status.exitstatus).to eq(0), -> { "stdout:\n#{stdout}\n\nstderr:\n#{stderr}" }
+        expect(JSON.parse(File.read(marker_file))).to include('account_id' => 42)
+        expect(read_runtime_state(state_file).fetch('snapshot').fetch('phase')).to eq('stopped')
+      end
+    end
+  end
+end

--- a/core/karya/spec/karya/active_record_spec.rb
+++ b/core/karya/spec/karya/active_record_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Karya::ActiveRecord do
     end
   end
 
+  it 'falls back to the default MySQL migration name when the requested name is blank' do
+    Dir.mktmpdir('karya-ar-mysql-migration-default-') do |dir|
+      path = described_class.install_mysql_migration(target_dir: dir, migration_name: '')
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_my_sql_backend\.rb\z/)
+    end
+  end
+
   it 'normalizes punctuation-heavy migration names into Rails class and file names' do
     expect(described_class.normalize_migration_name('create karya/API v2 backend')).to eq('CreateKaryaApiV2Backend')
     expect(described_class.normalize_migration_name('create!! karya')).to eq('CreateKarya')
@@ -47,7 +55,7 @@ RSpec.describe Karya::ActiveRecord do
       described_class.require_activerecord!
     end.to raise_error(
       LoadError,
-      /Add `gem 'activerecord'` to your Gemfile to use Karya::ActiveRecord Postgres migration support\./
+      /Add `gem 'activerecord'` to your Gemfile to use Karya::ActiveRecord SQL migration support\./
     )
   end
 

--- a/core/karya/spec/karya/active_record_spec.rb
+++ b/core/karya/spec/karya/active_record_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Karya::ActiveRecord do
     end
   end
 
+  it 'writes an Active Record migration for the MySQL backend' do
+    Dir.mktmpdir('karya-ar-mysql-migration-') do |dir|
+      path = described_class.install_mysql_migration(target_dir: dir)
+      contents = File.read(path)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+      expect(contents).to include("class CreateKaryaMysqlBackend < ActiveRecord::Migration[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]")
+      expect(contents).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+      expect(contents).to include('payload longtext NOT NULL')
+    end
+  end
+
   it 'normalizes punctuation-heavy migration names into Rails class and file names' do
     expect(described_class.normalize_migration_name('create karya/API v2 backend')).to eq('CreateKaryaApiV2Backend')
     expect(described_class.normalize_migration_name('create!! karya')).to eq('CreateKarya')

--- a/core/karya/spec/karya/active_record_spec.rb
+++ b/core/karya/spec/karya/active_record_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Karya::ActiveRecord do
     Dir.mktmpdir('karya-ar-mysql-migration-default-') do |dir|
       path = described_class.install_mysql_migration(target_dir: dir, migration_name: '')
 
-      expect(File.basename(path)).to match(/\A\d{14}_create_karya_my_sql_backend\.rb\z/)
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
     end
   end
 

--- a/core/karya/spec/karya/backend/my_sql_spec.rb
+++ b/core/karya/spec/karya/backend/my_sql_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'rbconfig'
+
+RSpec.describe Karya::Backend::MySQL do
+  subject(:backend) { described_class.new(url: 'mysql2://example.test/karya') }
+
+  let(:fake_connection_class) do
+    Class.new do
+      def initialize
+        @rows = {}
+      end
+
+      def query(sql, **_options)
+        namespace = sql[/WHERE namespace = '([^']+)'/, 1]
+        if sql.include?('SELECT payload')
+          payload = @rows[namespace]
+          return payload ? [{ 'payload' => payload }] : []
+        end
+
+        if sql.include?('INSERT INTO karya_queue_store_states')
+          values = sql.scan(/'([^']+)'/)
+          @rows[values[0][0]] = values[1][0] if values.length >= 2
+        end
+
+        []
+      end
+
+      def escape(value)
+        value.gsub("'", "\\\\'")
+      end
+
+      def close
+        @closed = true
+      end
+    end
+  end
+
+  def standalone_queue_store_script
+    <<~RUBY
+      module Kernel
+        alias_method :__karya_original_require_for_standalone_mysql, :require
+
+        def require(name)
+          return true if name == 'mysql2'
+
+          __karya_original_require_for_standalone_mysql(name)
+        end
+      end
+
+      require 'karya/queue_store/mysql'
+
+      Object.send(:remove_const, :Mysql2) if Object.const_defined?(:Mysql2)
+
+      module Mysql2
+        class Client
+          def initialize(**_options)
+            @rows = {}
+          end
+
+          def query(sql, **)
+            namespace = sql[/WHERE namespace = '([^']+)'/, 1]
+            if sql.include?('SELECT payload')
+              payload = @rows[namespace]
+              return payload ? [{ 'payload' => payload }] : []
+            end
+
+            if sql.include?('INSERT INTO karya_queue_store_states')
+              values = sql.scan(/'([^']+)'/)
+              @rows[values[0][0]] = values[1][0] if values.length >= 2
+            end
+
+            []
+          end
+
+          def escape(value)
+            value.gsub("'", "\\\\'")
+          end
+        end
+      end
+
+      now = Time.utc(2026, 5, 5, 12, 0, 0)
+      store = Karya::QueueStore::MySQL.new(url: 'mysql2://example.test/karya', namespace: 'standalone')
+      job = Karya::Job.new(id: 'job-1', queue: 'billing', handler: 'billing_sync', state: :submission, created_at: now)
+      store.enqueue(job:, now: now + 1)
+      reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 60, now: now + 2)
+      store.start_execution(reservation_token: reservation.token, now: now + 3)
+      failed = store.fail_execution(reservation_token: reservation.token, now: now + 4, failure_classification: :error)
+      puts failed.state
+    RUBY
+  end
+
+  it 'loads as a standalone backend file' do
+    lib_path = File.expand_path('../../../lib', __dir__)
+    script = <<~RUBY
+      require 'karya/backend/mysql'
+      puts Karya::Backend::MySQL.new(url: 'mysql2://example.test/karya').identifier
+    RUBY
+
+    stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', lib_path, '-e', script)
+
+    expect(status.success?).to be(true), stderr
+    expect(stdout).to eq("mysql\n")
+  end
+
+  it 'loads MySQL queue-store execution paths as a standalone file' do
+    lib_path = File.expand_path('../../../lib', __dir__)
+    stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', lib_path, '-e', standalone_queue_store_script)
+
+    expect(status.success?).to be(true), stderr
+    expect(stdout).to eq("failed\n")
+  end
+
+  it 'raises an actionable load error when the mysql2 gem is not available' do
+    lib_path = File.expand_path('../../../lib', __dir__)
+    script = <<~RUBY
+      module Kernel
+        alias_method :__karya_original_require_for_mysql_spec, :require
+
+        def require(name)
+          raise LoadError, 'cannot load such file -- mysql2' if name == 'mysql2'
+
+          __karya_original_require_for_mysql_spec(name)
+        end
+      end
+
+      begin
+        require 'karya/backend/mysql'
+        Karya::Backend::MySQL.new(url: 'mysql2://example.test/karya').build_queue_store
+      rescue LoadError => e
+        warn e.message
+        exit 0
+      end
+
+      exit 1
+    RUBY
+
+    _stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', lib_path, '-e', script)
+
+    expect(status.success?).to be(true)
+    expect(stderr).to include("Add `gem 'mysql2'` to your Gemfile to use Karya::Backend::MySQL and Karya::QueueStore::MySQL.")
+  end
+
+  it 'raises an actionable load error from the dependency loader when mysql2 is unavailable' do
+    dependency_loader = Karya::QueueStore::MySQL.send(:const_get, :Internal).const_get(:DependencyLoader)
+    allow(dependency_loader).to receive(:require).with('mysql2').and_raise(LoadError, 'cannot load such file -- mysql2')
+
+    expect do
+      dependency_loader.require_mysql2!
+    end.to raise_error(
+      LoadError,
+      /Add `gem 'mysql2'` to your Gemfile to use Karya::Backend::MySQL and Karya::QueueStore::MySQL\./
+    )
+  end
+
+  it 'exposes the backend identifier' do
+    expect(backend.identifier).to eq('mysql')
+  end
+
+  it 'builds the MySQL queue store owned by the backend definition' do
+    allow(Karya::QueueStore::MySQL.send(:const_get, :Internal).const_get(:DependencyLoader)).to receive(:require_mysql2!).and_return(true)
+    stub_const('Mysql2', Module.new) unless defined?(Mysql2)
+    stub_const('Mysql2::Client', Class.new)
+    allow(Mysql2::Client).to receive(:new).with(hash_including(host: 'example.test', port: 3306, database: 'karya')).and_return(fake_connection)
+
+    queue_store = backend.build_queue_store
+
+    expect(queue_store).to be_a(Karya::QueueStore::MySQL)
+  end
+
+  it 'forwards namespace and queue-store options to the queue store' do
+    allow(Karya::QueueStore::MySQL.send(:const_get, :Internal).const_get(:DependencyLoader)).to receive(:require_mysql2!).and_return(true)
+    stub_const('Mysql2', Module.new) unless defined?(Mysql2)
+    stub_const('Mysql2::Client', Class.new)
+    allow(Mysql2::Client).to receive(:new).and_return(fake_connection)
+
+    queue_store = described_class.new(
+      url: 'mysql2://example.test/karya',
+      namespace: 'payments',
+      max_batch_size: 50
+    ).build_queue_store
+
+    expect(queue_store.send(:namespace)).to eq('payments')
+    expect(queue_store.send(:max_batch_size)).to eq(50)
+  end
+
+  it 'normalizes invalid queue-store keyword errors into backend configuration errors' do
+    allow(Karya::QueueStore::MySQL.send(:const_get, :Internal).const_get(:DependencyLoader)).to receive(:require_mysql2!).and_return(true)
+    stub_const('Mysql2', Module.new) unless defined?(Mysql2)
+    stub_const('Mysql2::Client', Class.new)
+    allow(Mysql2::Client).to receive(:new).and_return(fake_connection)
+
+    invalid_backend = described_class.new(
+      url: 'mysql2://example.test/karya',
+      namespace: 'payments',
+      unsupported_option: true
+    )
+
+    expect do
+      invalid_backend.build_queue_store
+    end.to raise_error(
+      Karya::InvalidBackendConfigurationError,
+      /invalid MySQL backend queue-store configuration: unexpected option keys :unsupported_option: unknown keywords: unsupported_option/
+    ) { |error| expect(error.cause).to be_a(ArgumentError) }
+  end
+
+  it 'normalizes queue-store validation failures into backend configuration errors' do
+    invalid_backend = described_class.new(url: ' ', namespace: 'payments')
+
+    expect do
+      invalid_backend.build_queue_store
+    end.to raise_error(
+      Karya::InvalidBackendConfigurationError,
+      /invalid MySQL backend queue-store configuration: url must be a non-empty String/
+    ) { |error| expect(error.cause).to be_a(Karya::InvalidQueueStoreOperationError) }
+  end
+
+  it 'declares no-op lifecycle hooks around queue-store usage' do
+    allow(Karya::QueueStore::MySQL.send(:const_get, :Internal).const_get(:DependencyLoader)).to receive(:require_mysql2!).and_return(true)
+    stub_const('Mysql2', Module.new) unless defined?(Mysql2)
+    stub_const('Mysql2::Client', Class.new)
+    allow(Mysql2::Client).to receive(:new).and_return(fake_connection)
+    queue_store = backend.build_queue_store
+
+    expect(backend.before_start(queue_store:)).to be_nil
+    expect(backend.after_stop(queue_store:)).to be_nil
+  end
+
+  def fake_connection
+    @fake_connection ||= fake_connection_class.new
+  end
+end

--- a/core/karya/spec/karya/queue_store/my_sql_spec.rb
+++ b/core/karya/spec/karya/queue_store/my_sql_spec.rb
@@ -115,12 +115,20 @@ RSpec.describe Karya::QueueStore::MySQL do
     end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid MySQL url:/)
 
     expect do
+      described_class.new(url: 'mysql2:///karya?socket=%zz', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid MySQL url:/)
+
+    expect do
       described_class.new(url: 'mysql2://example.test', namespace:)
     end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must include a database name')
 
     expect do
       described_class.new(url: mysql_url, namespace: ' ')
     end.to raise_error(Karya::InvalidQueueStoreOperationError, 'namespace must be a non-empty String')
+
+    expect do
+      described_class.new(url: mysql_url, namespace: 'n' * 256)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'namespace must be at most 255 bytes')
 
     expect do
       described_class.new(url: mysql_url, max_batch_size: 0)
@@ -250,6 +258,31 @@ RSpec.describe Karya::QueueStore::MySQL do
     mutex = internal_namespace.const_get(:PersistenceMutex).new(connection:, owner:)
 
     expect(mutex.send(:restore_owner_state_after_failure)).to be_nil
+  end
+
+  it 'creates a placeholder row before acquiring a FOR UPDATE lock on first write' do
+    recorded_sql = []
+    recording_connection = Class.new do
+      def initialize(recorded_sql)
+        @recorded_sql = recorded_sql
+      end
+
+      def query(sql, **_options)
+        @recorded_sql << sql
+        []
+      end
+
+      def escape(value)
+        value.gsub("'", "\\\\'")
+      end
+    end.new(recorded_sql)
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: recording_connection, owner: store)
+
+    mutex.send(:lock_current_row)
+
+    expect(recorded_sql[0]).to include('INSERT IGNORE INTO karya_queue_store_states')
+    expect(recorded_sql[1]).to include('SELECT payload')
+    expect(recorded_sql[1]).to include('FOR UPDATE')
   end
 
   it 'rejects malformed MySQL state payloads' do

--- a/core/karya/spec/karya/queue_store/my_sql_spec.rb
+++ b/core/karya/spec/karya/queue_store/my_sql_spec.rb
@@ -128,7 +128,15 @@ RSpec.describe Karya::QueueStore::MySQL do
 
     expect do
       described_class.new(url: mysql_url, namespace: 'n' * 256)
-    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'namespace must be at most 255 bytes')
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'namespace must be at most 255 characters')
+
+    expect do
+      described_class.new(url: mysql_url, namespace: 'あ' * 255)
+    end.not_to raise_error
+
+    expect do
+      described_class.new(url: mysql_url, namespace: 'あ' * 256)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'namespace must be at most 255 characters')
 
     expect do
       described_class.new(url: mysql_url, max_batch_size: 0)
@@ -283,6 +291,14 @@ RSpec.describe Karya::QueueStore::MySQL do
     expect(recorded_sql[0]).to include('INSERT IGNORE INTO karya_queue_store_states')
     expect(recorded_sql[1]).to include('SELECT payload')
     expect(recorded_sql[1]).to include('FOR UPDATE')
+  end
+
+  it 'uses alias-based MySQL upsert syntax for persisted snapshots' do
+    sql = internal_namespace.const_get(:PersistenceMutex).new(connection:, owner: store).send(:upsert_sql, 'payload')
+
+    expect(sql).to include('AS new')
+    expect(sql).to include('payload = new.payload')
+    expect(sql).to include('updated_at = new.updated_at')
   end
 
   it 'rejects malformed MySQL state payloads' do

--- a/core/karya/spec/karya/queue_store/my_sql_spec.rb
+++ b/core/karya/spec/karya/queue_store/my_sql_spec.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+RSpec.describe Karya::QueueStore::MySQL do
+  subject(:store) { described_class.new(url: mysql_url, namespace:) }
+
+  let(:mysql_url) { 'mysql2://example.test/karya' }
+  let(:created_at) { Time.utc(2026, 5, 5, 12, 0, 0) }
+  let(:internal_namespace) { described_class.send(:const_get, :Internal) }
+  let(:namespace) { 'mysql-unit' }
+  let(:fake_connection_class) do
+    Class.new do
+      def initialize
+        @rows = {}
+        @fail_next_upsert = false
+      end
+
+      def query(sql, **_options)
+        namespace = sql[/WHERE namespace = '([^']+)'/, 1]
+
+        if sql.include?('SELECT payload')
+          payload = @rows[namespace]
+          return payload ? [{ 'payload' => payload }] : []
+        end
+
+        if sql.include?('INSERT INTO karya_queue_store_states')
+          raise 'forced mysql write failure' if consume_fail_next_upsert
+
+          values = sql.match(/VALUES \('([^']+)', '([^']+)', CURRENT_TIMESTAMP\(6\)\)/)
+          @rows[values[1]] = values[2] if values
+        end
+
+        []
+      end
+
+      def escape(value)
+        value.gsub("'", "\\\\'")
+      end
+
+      def fail_next_upsert!
+        @fail_next_upsert = true
+      end
+
+      def close
+        @closed = true
+      end
+
+      def closed?
+        @closed
+      end
+
+      private
+
+      def consume_fail_next_upsert
+        should_fail = @fail_next_upsert
+        @fail_next_upsert = false
+        should_fail
+      end
+    end
+  end
+  let(:connection) { fake_connection_class.new }
+  let(:dependency_loader) { internal_namespace.const_get(:DependencyLoader) }
+
+  before do
+    stub_const('Mysql2', Module.new) unless defined?(Mysql2)
+    stub_const('Mysql2::Client', Class.new)
+    allow(dependency_loader).to receive(:require_mysql2!).and_return(true)
+    allow(Mysql2::Client).to receive(:new).and_return(connection)
+  end
+
+  def submission_job(
+    id:,
+    queue: 'billing',
+    handler: 'billing_sync',
+    retry_policy: nil,
+    uniqueness_key: nil,
+    uniqueness_scope: nil
+  )
+    Karya::Job.new(
+      id:,
+      queue:,
+      handler:,
+      state: :submission,
+      created_at:,
+      retry_policy:,
+      uniqueness_key:,
+      uniqueness_scope:
+    )
+  end
+
+  def workflow_job(step_id, handler: step_id)
+    Karya::Job.new(
+      id: "job-#{step_id}",
+      queue: :billing,
+      handler:,
+      state: :submission,
+      created_at:
+    )
+  end
+
+  it 'validates constructor inputs' do
+    expect do
+      described_class.new(url: '', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must be a non-empty String')
+
+    expect do
+      described_class.new(url: Object.new, namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must be a non-empty String')
+
+    expect do
+      described_class.new(url: 'postgres://example.test/karya', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must use mysql:// or mysql2://')
+
+    expect do
+      described_class.new(url: 'mysql2://[invalid', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid MySQL url:/)
+
+    expect do
+      described_class.new(url: 'mysql2://example.test', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must include a database name')
+
+    expect do
+      described_class.new(url: mysql_url, namespace: ' ')
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'namespace must be a non-empty String')
+
+    expect do
+      described_class.new(url: mysql_url, max_batch_size: 0)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /max_batch_size must be a positive Integer/)
+    expect(connection).to be_closed
+
+    expect do
+      described_class.new(url: mysql_url, token_generator: -> { 'manual-token' })
+    end.to raise_error(
+      Karya::InvalidQueueStoreOperationError,
+      'token_generator is managed internally by Karya::QueueStore::MySQL'
+    )
+  end
+
+  it 'supports socket-based MySQL URLs' do
+    socket_url = 'mysql2:///karya?socket=%2Ftmp%2Fmysql.sock&encoding=utf8mb4'
+
+    described_class.new(url: socket_url, namespace:)
+
+    expect(Mysql2::Client).to have_received(:new).with(
+      hash_including(
+        socket: '/tmp/mysql.sock',
+        database: 'karya',
+        encoding: 'utf8mb4'
+      )
+    )
+  end
+
+  it 'does not inherit from the in-memory concrete store' do
+    expect(described_class.superclass).not_to eq(Karya::QueueStore::InMemory)
+  end
+
+  it 'persists queued, reserved, and succeeded job state across instances' do
+    store.enqueue(
+      job: submission_job(
+        id: 'job-1',
+        uniqueness_key: 'account-1',
+        uniqueness_scope: :queued
+      ),
+      now: created_at + 1
+    )
+
+    second_store = described_class.new(url: mysql_url, namespace:)
+    uniqueness_decision = second_store.uniqueness_decision(
+      job: submission_job(
+        id: 'job-2',
+        uniqueness_key: 'account-1',
+        uniqueness_scope: :queued
+      ),
+      now: created_at + 2
+    )
+    reservation = second_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 60, now: created_at + 3)
+
+    third_store = described_class.new(url: mysql_url, namespace:)
+    running = third_store.start_execution(reservation_token: reservation.token, now: created_at + 4)
+    succeeded = third_store.complete_execution(reservation_token: reservation.token, now: created_at + 5)
+
+    expect(uniqueness_decision.fetch(:action)).to eq(:reject)
+    expect(running.state).to eq(:running)
+    expect(succeeded.state).to eq(:succeeded)
+  end
+
+  it 'persists workflow control state across instances' do
+    definition = Karya::Workflow.define(:approval_flow) do
+      step :review, handler: :review, wait_for_approval: :manager_approved
+    end
+
+    store.enqueue_workflow(
+      definition:,
+      jobs_by_step_id: { review: workflow_job(:review, handler: :review) },
+      batch_id: :approval_batch,
+      now: created_at + 1
+    )
+
+    second_store = described_class.new(url: mysql_url, namespace:)
+    pause_report = second_store.pause_workflow(batch_id: :approval_batch, now: created_at + 2)
+    resume_report = second_store.resume_workflow(batch_id: :approval_batch, now: created_at + 3)
+    approval_report = second_store.approve_workflow_checkpoints(batch_id: :approval_batch, step_ids: [:review], now: created_at + 4)
+
+    snapshot = described_class.new(url: mysql_url, namespace:).workflow_snapshot(batch_id: :approval_batch, now: created_at + 5)
+    history = described_class.new(url: mysql_url, namespace:).workflow_history(batch_id: :approval_batch, now: created_at + 5)
+
+    expect(pause_report.action).to eq(:pause_workflow)
+    expect(resume_report.action).to eq(:resume_workflow)
+    expect(approval_report.action).to eq(:approve_workflow_checkpoints)
+    expect(snapshot.step_states).to eq('review' => :queued)
+    expect(history.entries.map(&:action)).to include('pause_requested', 'resumed', 'approval_approved')
+  end
+
+  it 'restores persisted state after a failed mutation transaction' do
+    store.enqueue(job: submission_job(id: 'job-1'), now: created_at + 1)
+    connection.fail_next_upsert!
+
+    expect do
+      store.enqueue(job: submission_job(id: 'job-2'), now: created_at + 2)
+    end.to raise_error(StandardError, /forced mysql write failure/)
+
+    recovered_store = described_class.new(url: mysql_url, namespace:)
+    first = recovered_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 60, now: created_at + 3)
+    expect(first.job_id).to eq('job-1')
+    expect(
+      recovered_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 60, now: created_at + 4)
+    ).to be_nil
+  end
+
+  it 'returns nil when restoring authoritative state also fails' do
+    failing_store = described_class.allocate
+    allow(failing_store).to receive(:load_persisted_state).and_raise(StandardError, 'reload failed')
+
+    expect(failing_store.restore_authoritative_state_after_failure).to be_nil
+  end
+
+  it 'returns nil when persistence mutex rollback also fails' do
+    failing_connection = Class.new do
+      def query(_sql, **_options)
+        raise 'rollback failed'
+      end
+    end.new
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: failing_connection, owner: store)
+
+    expect(mutex.send(:safe_rollback)).to be_nil
+  end
+
+  it 'returns nil when owner state restoration fails inside the persistence mutex' do
+    owner = instance_double(described_class)
+    allow(owner).to receive(:restore_authoritative_state_after_failure).and_raise(StandardError, 'restore failed')
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection:, owner:)
+
+    expect(mutex.send(:restore_owner_state_after_failure)).to be_nil
+  end
+
+  it 'rejects malformed MySQL state payloads' do
+    expect do
+      internal_namespace.const_get(:StateCodec).load('not-base64')
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid MySQL state snapshot/)
+  end
+
+  it 'rejects invalid decoded MySQL state payloads' do
+    payload = [Marshal.dump({ state: Object.new, reservation_token_sequence: 1 })].pack('m0')
+
+    expect do
+      internal_namespace.const_get(:StateCodec).load(payload)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid MySQL state snapshot/)
+  end
+
+  it 'rejects decoded MySQL state payloads with missing keys' do
+    payload = [Marshal.dump({ reservation_token_sequence: 1 })].pack('m0')
+
+    expect do
+      internal_namespace.const_get(:StateCodec).load(payload)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid MySQL state snapshot/)
+  end
+end

--- a/core/karya/spec/karya/sequel_spec.rb
+++ b/core/karya/spec/karya/sequel_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe Karya::Sequel do
     end
   end
 
+  it 'writes a Sequel migration for the MySQL backend' do
+    allow(Kernel).to receive(:require).and_call_original
+    allow(Kernel).to receive(:require).with('sequel').and_return(true)
+
+    Dir.mktmpdir('karya-sequel-mysql-migration-') do |dir|
+      path = described_class.install_mysql_migration(target_dir: dir)
+      contents = File.read(path)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+      expect(contents).to include('Sequel.migration do')
+      expect(contents).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+      expect(contents).to include('payload longtext NOT NULL')
+    end
+  end
+
   it 'normalizes punctuation-heavy migration names into snake case' do
     expect(described_class.normalize_migration_name('create karya/API v2 backend')).to eq('create_karya_api_v2_backend')
     expect(described_class.normalize_migration_name('create!! karya')).to eq('create_karya')

--- a/core/karya/spec/karya/sequel_spec.rb
+++ b/core/karya/spec/karya/sequel_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Karya::Sequel do
     end
   end
 
+  it 'falls back to the default MySQL migration name when the requested name is blank' do
+    Dir.mktmpdir('karya-sequel-default-mysql-migration-') do |dir|
+      path = described_class.install_mysql_migration(target_dir: dir, migration_name: '')
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+    end
+  end
+
   it 'normalizes punctuation-heavy migration names into snake case' do
     expect(described_class.normalize_migration_name('create karya/API v2 backend')).to eq('create_karya_api_v2_backend')
     expect(described_class.normalize_migration_name('create!! karya')).to eq('create_karya')
@@ -52,7 +60,7 @@ RSpec.describe Karya::Sequel do
       described_class.require_sequel!
     end.to raise_error(
       LoadError,
-      /Add `gem 'sequel'` to your Gemfile to use Karya::Sequel Postgres migration support\./
+      /Add `gem 'sequel'` to your Gemfile to use Karya::Sequel SQL migration support\./
     )
   end
 end

--- a/docs/pages/backends.md
+++ b/docs/pages/backends.md
@@ -90,6 +90,21 @@ Choose MySQL when:
 - the deployment is centered on MySQL operations
 - queue, workflow, and operator state should live in the primary SQL system
 
+Add the MySQL client gem before configuring the backend:
+
+```ruby
+# Gemfile
+gem 'mysql2', '~> 0.5'
+```
+
+```ruby
+Karya.configure_backend(
+  Karya::Backend::MySQL,
+  url: 'mysql2://app:secret@127.0.0.1:3306/karya',
+  namespace: 'karya'
+)
+```
+
 ## What Backends Influence
 
 Backend choice affects more than persistence:

--- a/gems/karya-hanami/Gemfile
+++ b/gems/karya-hanami/Gemfile
@@ -12,6 +12,7 @@ gem 'karya-dashboard', path: '../karya-dashboard'
 
 gemspec
 
+gem 'mysql2'
 gem 'pg'
 gem 'rack-test', require: false
 gem 'rake', require: false

--- a/gems/karya-hanami/Gemfile.lock
+++ b/gems/karya-hanami/Gemfile.lock
@@ -27,12 +27,12 @@ GEM
     concurrent-ruby (1.3.6)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    dry-auto_inject (1.1.0)
+    dry-auto_inject (1.2.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
     dry-cli (1.4.1)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -105,11 +105,19 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    parallel (1.28.0)
+    mysql2 (0.5.7)
+      bigdecimal
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     prism (1.9.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -175,16 +183,23 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
-  arm64-darwin-24
-  arm64-darwin-25
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   karya!
   karya-dashboard!
   karya-hanami!
+  mysql2
   pg
   rack-test
   rake

--- a/gems/karya-hanami/lib/karya/hanami.rb
+++ b/gems/karya-hanami/lib/karya/hanami.rb
@@ -20,6 +20,10 @@ module Karya
       Karya::Sequel.install_postgres_migration(target_dir:, migration_name:)
     end
 
+    def install_mysql_migration(target_dir:, migration_name: 'create_karya_mysql_backend')
+      Karya::Sequel.install_mysql_migration(target_dir:, migration_name:)
+    end
+
     def mount_path(prefix: nil)
       Karya::Internal::MountPath.build(DEFAULT_MOUNT_PATH, scope: prefix)
     end

--- a/gems/karya-hanami/sig/karya/hanami.rbs
+++ b/gems/karya-hanami/sig/karya/hanami.rbs
@@ -6,6 +6,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_mysql_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
 
     def self.mount_path: (?prefix: String?) -> String
 

--- a/gems/karya-hanami/spec/karya/hanami_integration_spec.rb
+++ b/gems/karya-hanami/spec/karya/hanami_integration_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Karya::Hanami, :dashboard_manifest_fixture do
     end
   end
 
+  it 'delegates MySQL migration install through the folded Sequel support' do
+    Dir.mktmpdir('karya-hanami-mysql-migration-') do |dir|
+      path = described_class.install_mysql_migration(target_dir: dir)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+      expect(File.read(path)).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'renders the dashboard document for the Hanami mount path' do
     document = described_class.render_dashboard_page
 

--- a/gems/karya-hanami/spec/karya/hanami_mysql_e2e_spec.rb
+++ b/gems/karya-hanami/spec/karya/hanami_mysql_e2e_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Karya::Hanami, :dashboard_manifest_fixture, :integration do
           described_class.install_mysql_migration(target_dir: migration_dir)
           db = Sequel.connect(database_url)
           Sequel::Migrator.run(db, migration_dir)
-          Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace: 'hanami_mysql_e2e')
           example.run
         ensure
           db&.disconnect

--- a/gems/karya-hanami/spec/karya/hanami_mysql_e2e_spec.rb
+++ b/gems/karya-hanami/spec/karya/hanami_mysql_e2e_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'tmpdir'
+
+RSpec.describe Karya::Hanami, :dashboard_manifest_fixture, :integration do
+  if ENV['E2E'] == '1'
+    require 'rack/test'
+    require 'sequel'
+    require 'sequel/extensions/migration'
+    include Rack::Test::Methods
+  end
+
+  around do |example|
+    skip 'set MYSQL_DATABASE_URL for MySQL e2e coverage' unless ENV['MYSQL_DATABASE_URL']
+
+    KaryaHanamiDummyAppSupport.with_dummy_app do |_app_root, rack_app|
+      self.current_rack_app = rack_app
+      with_mysql_backend(prefix: 'karya_hanami_mysql_e2e', namespace: 'hanami_mysql_e2e') do |database_url|
+        Dir.mktmpdir('karya-hanami-mysql-migrations-') do |migration_dir|
+          described_class.install_mysql_migration(target_dir: migration_dir)
+          db = Sequel.connect(database_url)
+          Sequel::Migrator.run(db, migration_dir)
+          Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace: 'hanami_mysql_e2e')
+          example.run
+        ensure
+          db&.disconnect
+        end
+      end
+    end
+  ensure
+    self.current_rack_app = nil
+  end
+
+  def app
+    current_rack_app
+  end
+
+  it 'serves the packaged dashboard document' do
+    get '/karya'
+
+    expect(last_response.status).to eq(200)
+    expect_dashboard_document(last_response.body, mount_path: '/karya', title: 'Karya Dashboard')
+  end
+
+  it 'uses the configured MySQL backend through the Hanami host route' do
+    get '/karya/runtime-probe'
+
+    expect(last_response.status).to eq(200)
+    payload = JSON.parse(last_response.body)
+    expect(payload.fetch('backend')).to eq('mysql')
+    expect(payload.fetch('job_id')).to start_with('hanami-probe-')
+  end
+end

--- a/gems/karya-hanami/spec/karya/hanami_postgres_e2e_spec.rb
+++ b/gems/karya-hanami/spec/karya/hanami_postgres_e2e_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Karya::Hanami, :dashboard_manifest_fixture, :integration do
           described_class.install_postgres_migration(target_dir: migration_dir)
           db = Sequel.connect(database_url)
           Sequel::Migrator.run(db, migration_dir)
-          Karya.configure_backend(Karya::Backend::Postgres, url: database_url, namespace: 'hanami_e2e')
           example.run
         ensure
           db&.disconnect

--- a/gems/karya-rails/Gemfile
+++ b/gems/karya-rails/Gemfile
@@ -12,6 +12,7 @@ gem 'karya-dashboard', path: '../karya-dashboard'
 
 gemspec
 
+gem 'mysql2'
 gem 'pg'
 gem 'rack-test', require: false
 gem 'rake', require: false

--- a/gems/karya-rails/Gemfile.lock
+++ b/gems/karya-rails/Gemfile.lock
@@ -105,8 +105,8 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -159,11 +159,13 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.1.1)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mysql2 (0.5.7)
+      bigdecimal
     net-imap (0.6.4)
       date
       net-protocol
@@ -174,13 +176,33 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-musl)
+      racc (~> 1.4)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    parallel (1.28.0)
+    nokogiri (1.19.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-musl)
+      racc (~> 1.4)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -285,7 +307,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.1)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -309,7 +331,14 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    sqlite3 (2.9.4-aarch64-linux-gnu)
+    sqlite3 (2.9.4-aarch64-linux-musl)
+    sqlite3 (2.9.4-arm-linux-gnu)
+    sqlite3 (2.9.4-arm-linux-musl)
     sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
+    sqlite3 (2.9.4-x86_64-linux-musl)
     stringio (3.2.0)
     thor (1.5.0)
     timeout (0.6.1)
@@ -325,16 +354,23 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
-  arm64-darwin-24
-  arm64-darwin-25
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   karya!
   karya-dashboard!
   karya-rails!
+  mysql2
   pg
   rack-test
   rake

--- a/gems/karya-rails/gemfiles/rails_7_2.gemfile.lock
+++ b/gems/karya-rails/gemfiles/rails_7_2.gemfile.lock
@@ -106,8 +106,8 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -160,11 +160,13 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.1.1)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mysql2 (0.5.7)
+      bigdecimal
     net-imap (0.6.4)
       date
       net-protocol
@@ -191,7 +193,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    parallel (1.28.0)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -307,7 +309,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.1)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -353,7 +355,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -369,6 +371,7 @@ DEPENDENCIES
   karya!
   karya-dashboard!
   karya-rails!
+  mysql2
   pg
   rack-test
   rails (~> 7.2)

--- a/gems/karya-rails/gemfiles/rails_8_0.gemfile.lock
+++ b/gems/karya-rails/gemfiles/rails_8_0.gemfile.lock
@@ -103,8 +103,8 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -157,11 +157,13 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.1.1)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mysql2 (0.5.7)
+      bigdecimal
     net-imap (0.6.4)
       date
       net-protocol
@@ -188,7 +190,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    parallel (1.28.0)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -303,7 +305,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.1)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -350,7 +352,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -366,6 +368,7 @@ DEPENDENCIES
   karya!
   karya-dashboard!
   karya-rails!
+  mysql2
   pg
   rack-test
   rails (~> 8.0.0)

--- a/gems/karya-rails/gemfiles/rails_8_1.gemfile.lock
+++ b/gems/karya-rails/gemfiles/rails_8_1.gemfile.lock
@@ -105,8 +105,8 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -159,11 +159,13 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.1.1)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mysql2 (0.5.7)
+      bigdecimal
     net-imap (0.6.4)
       date
       net-protocol
@@ -190,7 +192,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    parallel (1.28.0)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -305,7 +307,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.1)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -352,7 +354,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -368,6 +370,7 @@ DEPENDENCIES
   karya!
   karya-dashboard!
   karya-rails!
+  mysql2
   pg
   rack-test
   rails (~> 8.1.0)

--- a/gems/karya-rails/gemfiles/rails_edge.gemfile.lock
+++ b/gems/karya-rails/gemfiles/rails_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 127183d8fc44a9fb52542f7650c1ccc2eaa97f29
+  revision: dea80f716790b2b5ec41c3c4356905e82d6a55d2
   branch: main
   specs:
     actioncable (8.2.0.alpha)
@@ -189,11 +189,13 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.1.1)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mysql2 (0.5.7)
+      bigdecimal
     net-imap (0.6.4)
       date
       net-protocol
@@ -312,7 +314,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.1)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -359,7 +361,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -375,6 +377,7 @@ DEPENDENCIES
   karya!
   karya-dashboard!
   karya-rails!
+  mysql2
   pg
   rack-test
   rails!

--- a/gems/karya-rails/lib/karya/rails.rb
+++ b/gems/karya-rails/lib/karya/rails.rb
@@ -23,6 +23,10 @@ module Karya
       Karya::ActiveRecord.install_postgres_migration(target_dir:, migration_name:)
     end
 
+    def install_mysql_migration(target_dir:, migration_name: 'Create Karya MySQL Backend')
+      Karya::ActiveRecord.install_mysql_migration(target_dir:, migration_name:)
+    end
+
     def render_dashboard_page(
       scope: nil,
       mount_path: DEFAULT_MOUNT_PATH,

--- a/gems/karya-rails/sig/karya/rails.rbs
+++ b/gems/karya-rails/sig/karya/rails.rbs
@@ -6,6 +6,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_mysql_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
 
     def self.render_dashboard_page: (
       ?scope: String?,

--- a/gems/karya-rails/spec/karya/rails_mysql_e2e_spec.rb
+++ b/gems/karya-rails/spec/karya/rails_mysql_e2e_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'securerandom'
+require 'tmpdir'
+
+RSpec.describe Karya::Rails, :dashboard_manifest_fixture, :integration do
+  if ENV['E2E'] == '1'
+    require 'rails_helper'
+    require 'rack/test'
+    include Rack::Test::Methods
+  end
+
+  around do |example|
+    skip 'set MYSQL_DATABASE_URL for MySQL e2e coverage' unless ENV['MYSQL_DATABASE_URL']
+
+    with_mysql_backend(prefix: 'karya_rails_mysql_e2e', namespace: 'rails_mysql_e2e') do |database_url|
+      Dir.mktmpdir('karya-rails-mysql-migrations-') do |migration_dir|
+        migration_name = "Create Karya MySQL Backend #{SecureRandom.hex(4)}"
+        migration_path = described_class.install_mysql_migration(target_dir: migration_dir, migration_name:)
+        migration_class_name = Karya::ActiveRecord.normalize_migration_name(migration_name)
+        ActiveRecord::Base.establish_connection(database_url)
+        ActiveRecord::Migration.verbose = false
+        load migration_path
+        Object.const_get(migration_class_name).migrate(:up)
+        Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace: 'rails_mysql_e2e')
+        example.run
+      ensure
+        ActiveRecord::Base.connection_pool.disconnect!
+      end
+    end
+  end
+
+  it 'mounts the dashboard engine and serves the packaged document' do
+    get '/karya'
+
+    expect(last_response).to have_http_status(:ok)
+    expect_dashboard_document(last_response.body, mount_path: '/karya', title: 'Karya Dashboard')
+  end
+
+  it 'uses the configured MySQL backend through the mounted engine' do
+    get '/karya/runtime-probe'
+
+    expect(last_response).to have_http_status(:ok)
+    payload = JSON.parse(last_response.body)
+    expect(payload.fetch('backend')).to eq('mysql')
+    expect(payload.fetch('job_id')).to start_with('rails-probe-')
+    expect(payload.fetch('mount_path')).to eq('/karya')
+  end
+
+  def app
+    Rails.application
+  end
+end

--- a/gems/karya-rails/spec/karya/rails_mysql_e2e_spec.rb
+++ b/gems/karya-rails/spec/karya/rails_mysql_e2e_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Karya::Rails, :dashboard_manifest_fixture, :integration do
         ActiveRecord::Migration.verbose = false
         load migration_path
         Object.const_get(migration_class_name).migrate(:up)
-        Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace: 'rails_mysql_e2e')
         example.run
       ensure
         ActiveRecord::Base.connection_pool.disconnect!

--- a/gems/karya-rails/spec/karya/rails_postgres_e2e_spec.rb
+++ b/gems/karya-rails/spec/karya/rails_postgres_e2e_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Karya::Rails, :dashboard_manifest_fixture, :integration do
         ActiveRecord::Migration.verbose = false
         load migration_path
         Object.const_get(migration_class_name).migrate(:up)
-        Karya.configure_backend(Karya::Backend::Postgres, url: database_url, namespace: 'rails_e2e')
         example.run
       ensure
         ActiveRecord::Base.connection_pool.disconnect!

--- a/gems/karya-rails/spec/karya/rails_spec.rb
+++ b/gems/karya-rails/spec/karya/rails_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe Karya::Rails, :dashboard_manifest_fixture do
     end
   end
 
+  it 'delegates MySQL migration install through the folded Active Record support' do
+    Dir.mktmpdir('karya-rails-mysql-migration-') do |dir|
+      path = described_class.install_mysql_migration(target_dir: dir)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+      expect(File.read(path)).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'renders the dashboard document for the mounted Rails path' do
     document = described_class.render_dashboard_page
 

--- a/gems/karya-roda/Gemfile
+++ b/gems/karya-roda/Gemfile
@@ -12,6 +12,7 @@ gem 'karya-dashboard', path: '../karya-dashboard'
 
 gemspec
 
+gem 'mysql2'
 gem 'pg'
 gem 'rack-test', require: false
 gem 'rake', require: false

--- a/gems/karya-roda/Gemfile.lock
+++ b/gems/karya-roda/Gemfile.lock
@@ -27,8 +27,8 @@ GEM
     concurrent-ruby (1.3.6)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -60,11 +60,19 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    parallel (1.28.0)
+    mysql2 (0.5.7)
+      bigdecimal
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     prism (1.9.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -132,16 +140,23 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
-  arm64-darwin-24
-  arm64-darwin-25
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   karya!
   karya-dashboard!
   karya-roda!
+  mysql2
   pg
   rack-test
   rake

--- a/gems/karya-roda/lib/karya/roda.rb
+++ b/gems/karya-roda/lib/karya/roda.rb
@@ -19,6 +19,10 @@ module Karya
       Karya::Sequel.install_postgres_migration(target_dir:, migration_name:)
     end
 
+    def install_mysql_migration(target_dir:, migration_name: 'create_karya_mysql_backend')
+      Karya::Sequel.install_mysql_migration(target_dir:, migration_name:)
+    end
+
     def render_dashboard_page(scope: nil, title: Karya::Dashboard::DEFAULT_TITLE, asset_prefix: nil, name: 'dashboard')
       Karya::Dashboard.render_document(title:, mount_path: mount_path(scope:), asset_prefix:, name:)
     end

--- a/gems/karya-roda/sig/karya/roda.rbs
+++ b/gems/karya-roda/sig/karya/roda.rbs
@@ -6,6 +6,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_mysql_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
 
     def self.render_dashboard_page: (
       ?scope: String?,

--- a/gems/karya-roda/spec/karya/roda_mysql_e2e_spec.rb
+++ b/gems/karya-roda/spec/karya/roda_mysql_e2e_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'tmpdir'
+
+RSpec.describe Karya::Roda, :dashboard_manifest_fixture, :integration do
+  if ENV['E2E'] == '1'
+    require 'rack/test'
+    require 'sequel'
+    require 'sequel/extensions/migration'
+    include Rack::Test::Methods
+  end
+
+  around do |example|
+    skip 'set MYSQL_DATABASE_URL for MySQL e2e coverage' unless ENV['MYSQL_DATABASE_URL']
+
+    KaryaRodaDummyAppSupport.with_dummy_app do |_app_root, rack_app|
+      self.current_rack_app = rack_app
+      with_mysql_backend(prefix: 'karya_roda_mysql_e2e', namespace: 'roda_mysql_e2e') do |database_url|
+        Dir.mktmpdir('karya-roda-mysql-migrations-') do |migration_dir|
+          described_class.install_mysql_migration(target_dir: migration_dir)
+          db = Sequel.connect(database_url)
+          Sequel::Migrator.run(db, migration_dir)
+          Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace: 'roda_mysql_e2e')
+          example.run
+        ensure
+          db&.disconnect
+        end
+      end
+    end
+  ensure
+    self.current_rack_app = nil
+  end
+
+  def app
+    current_rack_app
+  end
+
+  it 'serves the packaged dashboard document' do
+    get '/karya'
+
+    expect(last_response.status).to eq(200)
+    expect_dashboard_document(last_response.body, mount_path: '/karya', title: 'Karya Dashboard')
+  end
+
+  it 'uses the configured MySQL backend through the Roda host route' do
+    get '/karya/runtime-probe'
+
+    expect(last_response.status).to eq(200)
+    payload = JSON.parse(last_response.body)
+    expect(payload.fetch('backend')).to eq('mysql')
+    expect(payload.fetch('job_id')).to start_with('roda-probe-')
+  end
+end

--- a/gems/karya-roda/spec/karya/roda_mysql_e2e_spec.rb
+++ b/gems/karya-roda/spec/karya/roda_mysql_e2e_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Karya::Roda, :dashboard_manifest_fixture, :integration do
           described_class.install_mysql_migration(target_dir: migration_dir)
           db = Sequel.connect(database_url)
           Sequel::Migrator.run(db, migration_dir)
-          Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace: 'roda_mysql_e2e')
           example.run
         ensure
           db&.disconnect

--- a/gems/karya-roda/spec/karya/roda_postgres_e2e_spec.rb
+++ b/gems/karya-roda/spec/karya/roda_postgres_e2e_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Karya::Roda, :dashboard_manifest_fixture, :integration do
           described_class.install_postgres_migration(target_dir: migration_dir)
           db = Sequel.connect(database_url)
           Sequel::Migrator.run(db, migration_dir)
-          Karya.configure_backend(Karya::Backend::Postgres, url: database_url, namespace: 'roda_e2e')
           example.run
         ensure
           db&.disconnect

--- a/gems/karya-roda/spec/karya/roda_spec.rb
+++ b/gems/karya-roda/spec/karya/roda_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Karya::Roda, :dashboard_manifest_fixture do
     end
   end
 
+  it 'delegates MySQL migration install through the folded Sequel support' do
+    Dir.mktmpdir('karya-roda-mysql-migration-') do |dir|
+      path = described_class.install_mysql_migration(target_dir: dir)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+      expect(File.read(path)).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'renders the dashboard document for the Roda mount path' do
     document = described_class.render_dashboard_page
 

--- a/gems/karya-sinatra/Gemfile
+++ b/gems/karya-sinatra/Gemfile
@@ -12,6 +12,7 @@ gem 'karya-dashboard', path: '../karya-dashboard'
 
 gemspec
 
+gem 'mysql2'
 gem 'pg'
 gem 'rack-test', require: false
 gem 'rake', require: false

--- a/gems/karya-sinatra/Gemfile.lock
+++ b/gems/karya-sinatra/Gemfile.lock
@@ -28,8 +28,8 @@ GEM
     concurrent-ruby (1.3.6)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -62,11 +62,19 @@ GEM
     lint_roller (1.1.0)
     logger (1.7.0)
     mustermann (3.1.1)
-    parallel (1.28.0)
+    mysql2 (0.5.7)
+      bigdecimal
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     prism (1.9.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -147,16 +155,23 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
-  arm64-darwin-24
-  arm64-darwin-25
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   karya!
   karya-dashboard!
   karya-sinatra!
+  mysql2
   pg
   rack-test
   rake

--- a/gems/karya-sinatra/lib/karya/sinatra.rb
+++ b/gems/karya-sinatra/lib/karya/sinatra.rb
@@ -19,6 +19,10 @@ module Karya
       Karya::Sequel.install_postgres_migration(target_dir:, migration_name:)
     end
 
+    def install_mysql_migration(target_dir:, migration_name: 'create_karya_mysql_backend')
+      Karya::Sequel.install_mysql_migration(target_dir:, migration_name:)
+    end
+
     def render_dashboard_page(scope: nil, title: Karya::Dashboard::DEFAULT_TITLE, asset_prefix: nil, name: 'dashboard')
       Karya::Dashboard.render_document(title:, mount_path: mount_path(scope:), asset_prefix:, name:)
     end

--- a/gems/karya-sinatra/sig/karya/sinatra.rbs
+++ b/gems/karya-sinatra/sig/karya/sinatra.rbs
@@ -6,6 +6,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_mysql_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
 
     def self.render_dashboard_page: (
       ?scope: String?,

--- a/gems/karya-sinatra/spec/karya/sinatra_mysql_e2e_spec.rb
+++ b/gems/karya-sinatra/spec/karya/sinatra_mysql_e2e_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Karya::Sinatra, :dashboard_manifest_fixture, :integration do
           described_class.install_mysql_migration(target_dir: migration_dir)
           db = Sequel.connect(database_url)
           Sequel::Migrator.run(db, migration_dir)
-          Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace: 'sinatra_mysql_e2e')
           example.run
         ensure
           db&.disconnect

--- a/gems/karya-sinatra/spec/karya/sinatra_mysql_e2e_spec.rb
+++ b/gems/karya-sinatra/spec/karya/sinatra_mysql_e2e_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Karya::Sinatra, :dashboard_manifest_fixture, :integration do
+  if ENV['E2E'] == '1'
+    require 'rack'
+    require 'rack/test'
+    require 'sequel'
+    require 'sequel/extensions/migration'
+    include Rack::Test::Methods
+  end
+
+  def with_dummy_app(source_dir)
+    Dir.mktmpdir('karya-sinatra-') do |root|
+      app_root = File.join(root, 'app')
+      FileUtils.copy_entry(source_dir, app_root)
+      app, = Rack::Builder.parse_file(File.join(app_root, 'config.ru'))
+      yield app
+    end
+  end
+
+  around do |example|
+    skip 'set MYSQL_DATABASE_URL for MySQL e2e coverage' unless ENV['MYSQL_DATABASE_URL']
+
+    source_dir = File.expand_path('../dummy/modular', __dir__)
+    with_dummy_app(source_dir) do |rack_app|
+      self.current_rack_app = rack_app
+      with_mysql_backend(prefix: 'karya_sinatra_mysql_e2e', namespace: 'sinatra_mysql_e2e') do |database_url|
+        Dir.mktmpdir('karya-sinatra-mysql-migrations-') do |migration_dir|
+          described_class.install_mysql_migration(target_dir: migration_dir)
+          db = Sequel.connect(database_url)
+          Sequel::Migrator.run(db, migration_dir)
+          Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace: 'sinatra_mysql_e2e')
+          example.run
+        ensure
+          db&.disconnect
+        end
+      end
+    end
+  ensure
+    self.current_rack_app = nil
+  end
+
+  def app
+    current_rack_app
+  end
+
+  it 'serves the packaged dashboard document' do
+    get '/karya', {}, { 'HTTP_HOST' => 'localhost' }
+
+    expect(last_response.status).to eq(200)
+    expect_dashboard_document(last_response.body, mount_path: '/karya', title: 'Karya Dashboard')
+  end
+
+  it 'uses the configured MySQL backend through the Sinatra host route' do
+    get '/karya/runtime-probe', {}, { 'HTTP_HOST' => 'localhost' }
+
+    expect(last_response.status).to eq(200)
+    payload = JSON.parse(last_response.body)
+    expect(payload.fetch('backend')).to eq('mysql')
+    expect(payload.fetch('job_id')).to start_with('sinatra-modular-probe-')
+  end
+end

--- a/gems/karya-sinatra/spec/karya/sinatra_postgres_e2e_spec.rb
+++ b/gems/karya-sinatra/spec/karya/sinatra_postgres_e2e_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Karya::Sinatra, :dashboard_manifest_fixture, :integration do
           described_class.install_postgres_migration(target_dir: migration_dir)
           db = Sequel.connect(database_url)
           Sequel::Migrator.run(db, migration_dir)
-          Karya.configure_backend(Karya::Backend::Postgres, url: database_url, namespace: 'sinatra_e2e')
           example.run
         ensure
           db&.disconnect

--- a/gems/karya-sinatra/spec/karya/sinatra_spec.rb
+++ b/gems/karya-sinatra/spec/karya/sinatra_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Karya::Sinatra, :dashboard_manifest_fixture do
     end
   end
 
+  it 'delegates MySQL migration install through the folded Sequel support' do
+    Dir.mktmpdir('karya-sinatra-mysql-migration-') do |dir|
+      path = described_class.install_mysql_migration(target_dir: dir)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+      expect(File.read(path)).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'renders the dashboard document for the Sinatra mount path' do
     document = described_class.render_dashboard_page
 

--- a/spec/support/framework_postgres_backend_support.rb
+++ b/spec/support/framework_postgres_backend_support.rb
@@ -26,6 +26,15 @@ module FrameworkPostgresBackendSupport
     end
   end
 
+  def with_mysql_backend(prefix:, namespace:)
+    preserve_backend_configuration do
+      with_mysql_database(prefix:) do |database_url|
+        yield database_url
+        Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace:)
+      end
+    end
+  end
+
   def restore_backend_ivar(name, value)
     if value.equal?(UNDEFINED)
       Karya.remove_instance_variable(name) if Karya.instance_variable_defined?(name)

--- a/spec/support/framework_postgres_backend_support.rb
+++ b/spec/support/framework_postgres_backend_support.rb
@@ -20,8 +20,8 @@ module FrameworkPostgresBackendSupport
   def with_postgres_backend(prefix:, namespace:)
     preserve_backend_configuration do
       with_postgres_database(prefix:) do |database_url|
-        yield database_url
         Karya.configure_backend(Karya::Backend::Postgres, url: database_url, namespace:)
+        yield database_url
       end
     end
   end
@@ -29,8 +29,8 @@ module FrameworkPostgresBackendSupport
   def with_mysql_backend(prefix:, namespace:)
     preserve_backend_configuration do
       with_mysql_database(prefix:) do |database_url|
-        yield database_url
         Karya.configure_backend(Karya::Backend::MySQL, url: database_url, namespace:)
+        yield database_url
       end
     end
   end

--- a/spec/support/framework_sql_backend_support.rb
+++ b/spec/support/framework_sql_backend_support.rb
@@ -5,7 +5,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-module FrameworkPostgresBackendSupport
+module FrameworkSQLBackendSupport
   UNDEFINED = Object.new.freeze
 
   def preserve_backend_configuration
@@ -46,5 +46,5 @@ module FrameworkPostgresBackendSupport
 end
 
 RSpec.configure do |config|
-  config.include FrameworkPostgresBackendSupport
+  config.include FrameworkSQLBackendSupport
 end

--- a/spec/support/mysql_e2e_support.rb
+++ b/spec/support/mysql_e2e_support.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require 'securerandom'
+require 'uri'
+
+module MySQLE2ESupport
+  module_function
+
+  DEFAULT_ADMIN_DATABASE_URL = 'mysql2://root:rootROOT!1@127.0.0.1:3306/mysql'
+
+  def admin_database_url
+    ENV.fetch('MYSQL_DATABASE_URL', DEFAULT_ADMIN_DATABASE_URL)
+  end
+
+  def with_mysql_database(prefix:)
+    require 'mysql2'
+
+    database_name = "#{prefix.tr('-', '_')}_#{SecureRandom.hex(6)}"
+    admin_url = MySQLE2ESupport.admin_database_url
+    connection = Mysql2::Client.new(**MySQLE2ESupport.admin_connection_params(admin_url))
+    connection.query("CREATE DATABASE #{quote_ident(database_name)} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+    yield MySQLE2ESupport.database_url_for(admin_url, database_name)
+  ensure
+    connection&.query("DROP DATABASE IF EXISTS #{quote_ident(database_name)}")
+    connection&.close
+  end
+
+  def admin_connection_params(database_url)
+    uri = URI.parse(database_url)
+    database_name = uri.path.to_s.delete_prefix('/')
+    {
+      host: uri.host || '127.0.0.1',
+      port: uri.port || 3306,
+      username: uri.user,
+      password: uri.password,
+      database: database_name.empty? ? 'mysql' : database_name,
+      encoding: 'utf8mb4'
+    }.compact
+  end
+
+  def database_url_for(admin_url, database_name)
+    uri = URI.parse(admin_url)
+    uri.path = "/#{database_name}"
+    uri.to_s
+  end
+
+  def quote_ident(value)
+    "`#{value.to_s.gsub('`', '``')}`"
+  end
+end
+
+RSpec.configure do |config|
+  config.include MySQLE2ESupport
+end

--- a/spec/support/postgres_e2e_support.rb
+++ b/spec/support/postgres_e2e_support.rb
@@ -29,10 +29,10 @@ module PostgresE2ESupport
     require 'pg'
 
     database_name = "#{prefix.tr('-', '_')}_#{SecureRandom.hex(6)}"
-    admin_url = admin_database_url
-    connection = PG.connect(admin_connection_params(admin_url))
+    admin_url = PostgresE2ESupport.admin_database_url
+    connection = PG.connect(PostgresE2ESupport.admin_connection_params(admin_url))
     connection.exec("CREATE DATABASE #{PG::Connection.quote_ident(database_name)}")
-    yield database_url_for(admin_url, database_name)
+    yield PostgresE2ESupport.database_url_for(admin_url, database_name)
   ensure
     connection&.exec("DROP DATABASE IF EXISTS #{PG::Connection.quote_ident(database_name)} WITH (FORCE)")
     connection&.close


### PR DESCRIPTION
- Implemented MySQL migration installation for Karya::Hanami, Karya::Rails, Karya::Roda, and Karya::Sinatra.
- Added integration tests for MySQL backend functionality in each framework to ensure proper operation.
- Updated Gemfiles to include the mysql2 gem for MySQL database interactions.
- Enhanced existing support files to handle MySQL database creation and teardown during tests.
- Refactored code to delegate MySQL migration installation through respective framework support modules.

closes: #134