### PR TITLE
feat: add SQLite backend support and migrations

### DIFF
--- a/core/karya/Gemfile
+++ b/core/karya/Gemfile
@@ -24,4 +24,5 @@ gem 'rubocop-rake', require: false
 gem 'rubocop-rspec', require: false
 gem 'sequel', '~> 5.0'
 gem 'simplecov', '~> 0.22', require: false
+gem 'sqlite3', '~> 2.6'
 gem 'thor', '~> 1.3'

--- a/core/karya/Gemfile.lock
+++ b/core/karya/Gemfile.lock
@@ -154,6 +154,14 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    sqlite3 (2.9.4-aarch64-linux-gnu)
+    sqlite3 (2.9.4-aarch64-linux-musl)
+    sqlite3 (2.9.4-arm-linux-gnu)
+    sqlite3 (2.9.4-arm-linux-musl)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
+    sqlite3 (2.9.4-x86_64-linux-musl)
     thor (1.5.0)
     timeout (0.6.1)
     tzinfo (2.0.6)
@@ -191,6 +199,7 @@ DEPENDENCIES
   rubocop-rspec
   sequel (~> 5.0)
   simplecov (~> 0.22)
+  sqlite3 (~> 2.6)
   thor (~> 1.3)
 
 BUNDLED WITH

--- a/core/karya/lib/karya/active_record.rb
+++ b/core/karya/lib/karya/active_record.rb
@@ -9,6 +9,7 @@ require 'fileutils'
 
 require_relative 'internal/mysql_schema_catalog'
 require_relative 'internal/postgres_schema_catalog'
+require_relative 'internal/sqlite_schema_catalog'
 
 module Karya
   # Active Record migration/install support for SQL-backed Karya backends.
@@ -46,6 +47,25 @@ module Karya
       File.write(
         path,
         Karya::Internal::MySQLSchemaCatalog.render_active_record_migration(
+          class_name:,
+          migration_version:
+        )
+      )
+      path
+    end
+
+    def install_sqlite_migration(target_dir:, migration_name: 'Create Karya SQLite Backend')
+      require_activerecord!
+
+      class_name = normalize_migration_name(migration_name, fallback: 'CreateKaryaSqliteBackend')
+      migration_version = "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}"
+      file_name = "#{timestamp}_#{underscore(class_name)}.rb"
+      path = File.expand_path(file_name, target_dir)
+
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(
+        path,
+        Karya::Internal::SQLiteSchemaCatalog.render_active_record_migration(
           class_name:,
           migration_version:
         )

--- a/core/karya/lib/karya/backend.rb
+++ b/core/karya/lib/karya/backend.rb
@@ -16,5 +16,6 @@ module Karya
     autoload :MySQL, 'karya/backend/mysql'
     autoload :Postgres, 'karya/backend/postgres'
     autoload :Redis, 'karya/backend/redis'
+    autoload :SQLite, 'karya/backend/sqlite'
   end
 end

--- a/core/karya/lib/karya/backend/sqlite.rb
+++ b/core/karya/lib/karya/backend/sqlite.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require_relative '../base'
+require_relative '../backend'
+require_relative '../backpressure'
+require_relative '../circuit_breaker'
+require_relative '../fairness'
+require_relative '../queue_store/sqlite'
+
+module Karya
+  module Backend
+    # SQLite-backed backend wrapper for local durable queue-store boot.
+    class SQLite
+      include Base
+
+      def initialize(url:, namespace: QueueStore::SQLite::DEFAULT_NAMESPACE, **queue_store_options)
+        @identifier = 'sqlite'
+        @queue_store_options = {
+          url:,
+          namespace:,
+          **queue_store_options
+        }.freeze
+      end
+
+      attr_reader :identifier
+
+      def build_queue_store
+        QueueStore::SQLite.new(**queue_store_options)
+      rescue ArgumentError, TypeError, InvalidQueueStoreOperationError => e
+        raise InvalidBackendConfigurationError, "#{queue_store_configuration_error_message}: #{e.message}", cause: e
+      end
+
+      private
+
+      attr_reader :queue_store_options
+
+      def queue_store_configuration_error_message
+        invalid_keys = queue_store_options.keys - valid_queue_store_option_keys
+        return "invalid SQLite backend queue-store configuration: unexpected option keys #{invalid_keys.map(&:inspect).join(', ')}" unless invalid_keys.empty?
+
+        'invalid SQLite backend queue-store configuration'
+      end
+
+      def valid_queue_store_option_keys
+        %i[
+          url
+          namespace
+          expired_tombstone_limit
+          completed_batch_retention_limit
+          max_batch_size
+          policy_set
+          circuit_breaker_policy_set
+          fairness_policy
+        ]
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/internal/sqlite_schema_catalog.rb
+++ b/core/karya/lib/karya/internal/sqlite_schema_catalog.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module Internal
+    # Shared SQLite persistence catalog for the durable queue-store snapshot.
+    module SQLiteSchemaCatalog
+      module_function
+
+      TABLE_NAME = 'karya_queue_store_states'
+
+      def create_table_sql
+        <<~SQL
+          CREATE TABLE IF NOT EXISTS #{TABLE_NAME} (
+            namespace text PRIMARY KEY,
+            payload text NOT NULL,
+            updated_at text NOT NULL DEFAULT CURRENT_TIMESTAMP
+          )
+        SQL
+      end
+
+      def drop_table_sql
+        "DROP TABLE IF EXISTS #{TABLE_NAME}"
+      end
+
+      def render_active_record_migration(class_name:, migration_version:)
+        <<~RUBY
+          # frozen_string_literal: true
+
+          class #{class_name} < ActiveRecord::Migration[#{migration_version}]
+            def up
+              execute <<~SQL
+                #{create_table_sql.rstrip}
+              SQL
+            end
+
+            def down
+              execute <<~SQL
+                #{drop_table_sql}
+              SQL
+            end
+          end
+        RUBY
+      end
+
+      def render_sequel_migration
+        <<~RUBY
+          # frozen_string_literal: true
+
+          Sequel.migration do
+            up do
+              run <<~SQL
+                #{create_table_sql.rstrip}
+              SQL
+            end
+
+            down do
+              run <<~SQL
+                #{drop_table_sql}
+              SQL
+            end
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store.rb
+++ b/core/karya/lib/karya/queue_store.rb
@@ -40,5 +40,6 @@ module Karya
     autoload :MySQL, 'karya/queue_store/mysql'
     autoload :Postgres, 'karya/queue_store/postgres'
     autoload :Redis, 'karya/queue_store/redis'
+    autoload :SQLite, 'karya/queue_store/sqlite'
   end
 end

--- a/core/karya/lib/karya/queue_store/sqlite.rb
+++ b/core/karya/lib/karya/queue_store/sqlite.rb
@@ -131,7 +131,7 @@ module Karya
       attr_reader :mutex, :namespace, :persistence_mutex, :reservation_token_sequence, :url
 
       def connection
-        reconnect_if_forked
+        reconnect_if_needed
         @connection
       end
 
@@ -181,9 +181,9 @@ module Karya
         end
       end
 
-      def reconnect_if_forked
+      def reconnect_if_needed
         current_pid = Process.pid
-        return if @connection_pid == current_pid
+        return if @connection_pid == current_pid && @connection
 
         @connection&.close
         @connection = build_connection

--- a/core/karya/lib/karya/queue_store/sqlite.rb
+++ b/core/karya/lib/karya/queue_store/sqlite.rb
@@ -63,7 +63,7 @@ module Karya
           host = normalize_string(uri.host)
           uri_path = uri.path.to_s
           raw_path = if host && host != 'localhost'
-                       File.join(host, uri_path)
+                       File.join(host, uri_path.sub(%r{\A/+}, ''))
                      else
                        uri_path
                      end

--- a/core/karya/lib/karya/queue_store/sqlite.rb
+++ b/core/karya/lib/karya/queue_store/sqlite.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require 'securerandom'
+require 'uri'
+
+require_relative 'internal/reference_queue_store'
+require_relative 'sqlite/internal'
+
+module Karya
+  module QueueStore
+    # SQLite-backed local durable queue store that persists canonical queue state in SQLite.
+    class SQLite
+      include Karya::QueueStore::Internal::ReferenceQueueStore
+
+      module Internal
+        StoreState = Karya::QueueStore::Internal::StoreState
+      end
+
+      DEFAULT_NAMESPACE = 'karya'
+      DEFAULT_EXPIRED_TOMBSTONE_LIMIT = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_EXPIRED_TOMBSTONE_LIMIT
+      DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT
+      DEFAULT_MAX_BATCH_SIZE = Karya::QueueStore::Internal::ReferenceQueueStore::DEFAULT_MAX_BATCH_SIZE
+      RESERVE_QUEUES_ERROR_MESSAGE = Karya::QueueStore::Internal::ReferenceQueueStore::RESERVE_QUEUES_ERROR_MESSAGE
+      private_constant :Internal
+
+      # Normalizes required non-empty SQLite string configuration values.
+      class PresentString
+        def initialize(value)
+          @value = value
+        end
+
+        def normalize
+          return unless value.is_a?(String)
+
+          normalized_value = value.strip
+          normalized_value unless normalized_value.empty?
+        end
+
+        private
+
+        attr_reader :value
+      end
+
+      # Parses a SQLite file URL into a local filesystem path.
+      class ConnectionPath
+        def self.build(url:, present_string_class:)
+          new(url:, present_string_class:).build
+        end
+
+        def initialize(url:, present_string_class:)
+          @url = url
+          @present_string_class = present_string_class
+        end
+
+        def build
+          uri = URI.parse(url)
+          validate_scheme(uri)
+          host = normalize_string(uri.host)
+          uri_path = uri.path.to_s
+          raw_path = if host && host != 'localhost'
+                       File.join(host, uri_path)
+                     else
+                       uri_path
+                     end
+          path = URI::DEFAULT_PARSER.unescape(raw_path)
+          raise InvalidQueueStoreOperationError, 'url must include a durable SQLite file path' if ['', '/', ':memory:', '/:memory:'].include?(path)
+
+          path
+        rescue URI::InvalidURIError, ArgumentError => e
+          raise InvalidQueueStoreOperationError, "invalid SQLite url: #{e.message}", cause: e
+        end
+
+        private
+
+        attr_reader :present_string_class, :url
+
+        def normalize_string(value)
+          present_string_class.new(value).normalize
+        end
+
+        def validate_scheme(uri)
+          return if %w[sqlite sqlite3].include?(uri.scheme)
+
+          raise InvalidQueueStoreOperationError, 'url must use sqlite:// or sqlite3://'
+        end
+      end
+
+      # Builds configured SQLite connections for the queue store.
+      class ConnectionBuilder
+        def self.build(path)
+          database = SQLite3::Database.new(path)
+          database.results_as_hash = true
+          begin
+            database.busy_timeout = 5000
+          rescue NoMethodError
+            nil
+          end
+          database
+        end
+      end
+
+      def initialize(url:, namespace: DEFAULT_NAMESPACE, **options)
+        raise InvalidQueueStoreOperationError, 'token_generator is managed internally by Karya::QueueStore::SQLite' if options.key?(:token_generator)
+
+        Internal::DependencyLoader.require_sqlite3!
+        @url = normalize_url(url)
+        @namespace = normalize_namespace(namespace)
+        @connection_path = ConnectionPath.build(url: @url, present_string_class: PresentString)
+        @connection = build_connection
+        @connection_pid = Process.pid
+        configure_reference_queue_store(
+          initializer_options_class: Karya::QueueStore::Internal::InitializerOptions,
+          store_state_class: Internal::StoreState,
+          token_generator: -> { SecureRandom.uuid },
+          **options
+        )
+        @persistence_mutex = Internal::PersistenceMutex.new(connection:, owner: self)
+        @mutex = @persistence_mutex
+        @persistence_mutex.ensure_schema
+        load_persisted_state
+      rescue StandardError
+        @connection&.close
+        raise
+      end
+
+      attr_reader :mutex, :namespace, :persistence_mutex, :reservation_token_sequence, :url
+
+      def connection
+        reconnect_if_forked
+        @connection
+      end
+
+      def load_persisted_state
+        restore_state_snapshot(persistence_mutex.load_state_snapshot)
+      end
+
+      def dump_state_payload
+        Internal::StateCodec.dump(
+          state:,
+          reservation_token_sequence:
+        )
+      end
+
+      def restore_authoritative_state_after_failure
+        load_persisted_state
+        nil
+      rescue StandardError
+        nil
+      end
+
+      private
+
+      attr_reader :connection_path, :state
+
+      def normalize_url(value)
+        normalized = PresentString.new(value).normalize
+        return normalized if normalized
+
+        raise InvalidQueueStoreOperationError, 'url must be a non-empty String'
+      end
+
+      def normalize_namespace(value)
+        normalized = PresentString.new(value).normalize
+        return normalized if normalized
+
+        raise InvalidQueueStoreOperationError, 'namespace must be a non-empty String'
+      end
+
+      def restore_state_snapshot(snapshot)
+        if snapshot
+          @state = snapshot.fetch(:state)
+          @reservation_token_sequence = snapshot.fetch(:reservation_token_sequence)
+        else
+          @state = Internal::StoreState.new(expired_tombstone_limit:)
+          @reservation_token_sequence = 0
+        end
+      end
+
+      def reconnect_if_forked
+        current_pid = Process.pid
+        return if @connection_pid == current_pid
+
+        @connection&.close
+        @connection = build_connection
+        @connection_pid = current_pid
+        nil
+      rescue StandardError
+        @connection = nil
+        raise
+      end
+
+      def build_connection
+        ConnectionBuilder.build(connection_path)
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/sqlite/internal.rb
+++ b/core/karya/lib/karya/queue_store/sqlite/internal.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require_relative 'internal/dependency_loader'
+require_relative 'internal/persistence_mutex'
+require_relative 'internal/state_codec'

--- a/core/karya/lib/karya/queue_store/sqlite/internal/dependency_loader.rb
+++ b/core/karya/lib/karya/queue_store/sqlite/internal/dependency_loader.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class SQLite
+      module Internal
+        # Loads optional runtime dependencies for the SQLite-backed queue store.
+        module DependencyLoader
+          module_function
+
+          def require_sqlite3!
+            require 'sqlite3'
+          rescue LoadError => e
+            raise LoadError,
+                  "#{e.message}. Add `gem 'sqlite3'` to your Gemfile to use Karya::Backend::SQLite and Karya::QueueStore::SQLite.",
+                  cause: e
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/sqlite/internal/persistence_mutex.rb
+++ b/core/karya/lib/karya/queue_store/sqlite/internal/persistence_mutex.rb
@@ -102,7 +102,7 @@ module Karya
 
           def connection
             owner.send(:connection)
-          rescue StandardError
+          rescue NoMethodError
             fallback_connection
           end
         end

--- a/core/karya/lib/karya/queue_store/sqlite/internal/persistence_mutex.rb
+++ b/core/karya/lib/karya/queue_store/sqlite/internal/persistence_mutex.rb
@@ -57,7 +57,7 @@ module Karya
 
           def synchronize_owned_state(read_only: false, persist_if: nil)
             local_mutex.synchronize do
-              with_transaction do
+              with_transaction(read_only:) do
                 owner.send(:restore_state_snapshot, load_state_snapshot)
                 result = yield
                 persist_snapshot_if_needed(result, persist_if) unless read_only
@@ -69,8 +69,8 @@ module Karya
             end
           end
 
-          def with_transaction
-            connection.execute('BEGIN IMMEDIATE TRANSACTION')
+          def with_transaction(read_only: false)
+            connection.execute(read_only ? 'BEGIN TRANSACTION' : 'BEGIN IMMEDIATE TRANSACTION')
             result = yield
             connection.execute('COMMIT')
             result

--- a/core/karya/lib/karya/queue_store/sqlite/internal/persistence_mutex.rb
+++ b/core/karya/lib/karya/queue_store/sqlite/internal/persistence_mutex.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require_relative '../../../internal/sqlite_schema_catalog'
+
+module Karya
+  module QueueStore
+    class SQLite
+      module Internal
+        # SQLite-backed synchronization boundary for shared queue-store state.
+        class PersistenceMutex
+          SELECT_SQL = <<~SQL.freeze
+            SELECT payload
+            FROM #{Karya::Internal::SQLiteSchemaCatalog::TABLE_NAME}
+            WHERE namespace = ?
+          SQL
+          UPSERT_SQL = <<~SQL.freeze
+            INSERT INTO #{Karya::Internal::SQLiteSchemaCatalog::TABLE_NAME} (namespace, payload, updated_at)
+            VALUES (?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(namespace)
+            DO UPDATE SET payload = excluded.payload, updated_at = excluded.updated_at
+          SQL
+
+          def initialize(connection:, owner:)
+            @fallback_connection = connection
+            @owner = owner
+            @local_mutex = Thread::Mutex.new
+          end
+
+          def ensure_schema
+            connection.execute_batch(Karya::Internal::SQLiteSchemaCatalog.create_table_sql)
+            nil
+          end
+
+          def synchronize(persist_if: nil, &)
+            synchronize_owned_state(persist_if:, &)
+          end
+
+          def read_only_synchronize(&)
+            synchronize_owned_state(read_only: true, &)
+          end
+
+          def load_state_snapshot
+            rows = connection.execute(SELECT_SQL, [owner.namespace])
+            return nil if rows.empty?
+
+            StateCodec.load(rows[0].fetch('payload'))
+          end
+
+          private
+
+          attr_reader :fallback_connection, :local_mutex, :owner
+
+          def synchronize_owned_state(read_only: false, persist_if: nil)
+            local_mutex.synchronize do
+              with_transaction do
+                owner.send(:restore_state_snapshot, load_state_snapshot)
+                result = yield
+                persist_snapshot_if_needed(result, persist_if) unless read_only
+                result
+              end
+            rescue StandardError
+              restore_owner_state_after_failure
+              raise
+            end
+          end
+
+          def with_transaction
+            connection.execute('BEGIN IMMEDIATE TRANSACTION')
+            result = yield
+            connection.execute('COMMIT')
+            result
+          rescue StandardError
+            safe_rollback
+            raise
+          end
+
+          def persist_snapshot_if_needed(result, persist_if)
+            return if persist_if && !persist_if.call(result)
+
+            connection.execute(UPSERT_SQL, [owner.namespace, owner.send(:dump_state_payload)])
+            nil
+          end
+
+          def restore_owner_state_after_failure
+            owner.send(:restore_authoritative_state_after_failure)
+            nil
+          rescue StandardError
+            nil
+          end
+
+          def safe_rollback
+            connection.execute('ROLLBACK')
+            nil
+          rescue StandardError
+            nil
+          end
+
+          def connection
+            owner.send(:connection)
+          rescue StandardError
+            fallback_connection
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/queue_store/sqlite/internal/state_codec.rb
+++ b/core/karya/lib/karya/queue_store/sqlite/internal/state_codec.rb
@@ -31,7 +31,7 @@ module Karya
             snapshot = Marshal.load(payload.unpack1('m0'))
             # rubocop:enable Security/MarshalLoad
             validate_snapshot(snapshot)
-          rescue ArgumentError, TypeError => e
+          rescue ArgumentError, EOFError, TypeError => e
             raise InvalidQueueStoreOperationError, "invalid SQLite state snapshot: #{e.class}: #{e.message}", cause: e
           end
 

--- a/core/karya/lib/karya/queue_store/sqlite/internal/state_codec.rb
+++ b/core/karya/lib/karya/queue_store/sqlite/internal/state_codec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Karya
+  module QueueStore
+    class SQLite
+      module Internal
+        # Encodes the durable queue-store state payload stored in SQLite.
+        module StateCodec
+          module_function
+
+          def dump(state:, reservation_token_sequence:)
+            [
+              Marshal.dump(
+                {
+                  state:,
+                  reservation_token_sequence:
+                }
+              )
+            ].pack('m0')
+          end
+
+          def load(payload)
+            # The payload is produced internally by `dump` and never accepted
+            # from user input or external network callers.
+            # rubocop:disable Security/MarshalLoad
+            snapshot = Marshal.load(payload.unpack1('m0'))
+            # rubocop:enable Security/MarshalLoad
+            validate_snapshot(snapshot)
+          rescue ArgumentError, TypeError => e
+            raise InvalidQueueStoreOperationError, "invalid SQLite state snapshot: #{e.class}: #{e.message}", cause: e
+          end
+
+          def validate_snapshot(snapshot)
+            unless snapshot.is_a?(Hash) &&
+                   snapshot.fetch(:state).is_a?(Karya::QueueStore::Internal::StoreState) &&
+                   snapshot.fetch(:reservation_token_sequence).is_a?(Integer)
+              raise InvalidQueueStoreOperationError, 'invalid SQLite state snapshot payload'
+            end
+
+            snapshot
+          rescue KeyError => e
+            raise InvalidQueueStoreOperationError, "invalid SQLite state snapshot: #{e.message}", cause: e
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/karya/lib/karya/sequel.rb
+++ b/core/karya/lib/karya/sequel.rb
@@ -9,6 +9,7 @@ require 'fileutils'
 
 require_relative 'internal/mysql_schema_catalog'
 require_relative 'internal/postgres_schema_catalog'
+require_relative 'internal/sqlite_schema_catalog'
 
 module Karya
   # Sequel migration/install support for SQL-backed Karya backends.
@@ -36,6 +37,18 @@ module Karya
 
       FileUtils.mkdir_p(File.dirname(path))
       File.write(path, Karya::Internal::MySQLSchemaCatalog.render_sequel_migration)
+      path
+    end
+
+    def install_sqlite_migration(target_dir:, migration_name: 'create_karya_sqlite_backend')
+      require_sequel!
+
+      normalized_name = normalize_migration_name(migration_name, fallback: 'create_karya_sqlite_backend')
+      file_name = "#{timestamp}_#{normalized_name}.rb"
+      path = File.expand_path(file_name, target_dir)
+
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, Karya::Internal::SQLiteSchemaCatalog.render_sequel_migration)
       path
     end
 

--- a/core/karya/sig/karya/active_record.rbs
+++ b/core/karya/sig/karya/active_record.rbs
@@ -8,6 +8,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_sqlite_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
     def self.require_activerecord!: () -> void
     def self.normalize_migration_name: (String? name, ?fallback: String) -> String
     def self.underscore: (String value) -> String

--- a/core/karya/sig/karya/backend.rbs
+++ b/core/karya/sig/karya/backend.rbs
@@ -17,6 +17,7 @@ module Karya
       singleton(MySQL) |
       singleton(Postgres) |
       singleton(Redis) |
+      singleton(SQLite) |
       (::Class & _BackendClass)
   end
 end

--- a/core/karya/sig/karya/backend/sqlite.rbs
+++ b/core/karya/sig/karya/backend/sqlite.rbs
@@ -1,0 +1,28 @@
+module Karya
+  module Backend
+    class SQLite
+      include Base
+
+      def initialize: (
+        url: String,
+        ?namespace: String,
+        ?expired_tombstone_limit: Integer,
+        ?completed_batch_retention_limit: Integer,
+        ?max_batch_size: Integer,
+        ?policy_set: Backpressure::PolicySet,
+        ?circuit_breaker_policy_set: CircuitBreaker::PolicySet,
+        ?fairness_policy: Fairness::Policy
+      ) -> void
+
+      attr_reader identifier: "sqlite"
+
+      def build_queue_store: () -> QueueStore::SQLite
+
+      private
+
+      attr_reader queue_store_options: Hash[Symbol, Karya::backend_option_value]
+      def queue_store_configuration_error_message: () -> String
+      def valid_queue_store_option_keys: () -> Array[Symbol]
+    end
+  end
+end

--- a/core/karya/sig/karya/internal/sqlite_schema_catalog.rbs
+++ b/core/karya/sig/karya/internal/sqlite_schema_catalog.rbs
@@ -1,0 +1,15 @@
+module Karya
+  module Internal
+    module SQLiteSchemaCatalog
+      TABLE_NAME: String
+
+      def self.create_table_sql: () -> String
+      def self.drop_table_sql: () -> String
+      def self.render_active_record_migration: (
+        class_name: String,
+        migration_version: String
+      ) -> String
+      def self.render_sequel_migration: () -> String
+    end
+  end
+end

--- a/core/karya/sig/karya/queue_store/sqlite.rbs
+++ b/core/karya/sig/karya/queue_store/sqlite.rbs
@@ -33,6 +33,10 @@ module Karya
         def self.build: (url: String, present_string_class: singleton(PresentString)) -> String
       end
 
+      class ConnectionBuilder
+        def self.build: (String path) -> Internal::_Connection
+      end
+
       module Internal
         interface _Connection
           def results_as_hash: () -> bool

--- a/core/karya/sig/karya/queue_store/sqlite.rbs
+++ b/core/karya/sig/karya/queue_store/sqlite.rbs
@@ -1,0 +1,66 @@
+module Karya
+  module QueueStore
+    class SQLite
+      include Karya::QueueStore::Internal::ReferenceQueueStore
+
+      DEFAULT_NAMESPACE: String
+      DEFAULT_EXPIRED_TOMBSTONE_LIMIT: Integer
+      DEFAULT_COMPLETED_BATCH_RETENTION_LIMIT: Integer
+      DEFAULT_MAX_BATCH_SIZE: Integer
+      RESERVE_QUEUES_ERROR_MESSAGE: String
+
+      def initialize: (
+        url: String,
+        ?namespace: String,
+        ?expired_tombstone_limit: Integer,
+        ?completed_batch_retention_limit: Integer,
+        ?max_batch_size: Integer,
+        ?policy_set: Backpressure::PolicySet,
+        ?circuit_breaker_policy_set: CircuitBreaker::PolicySet,
+        ?fairness_policy: Fairness::Policy
+      ) -> void
+
+      class PresentString
+        def initialize: (String? value) -> void
+        def normalize: () -> String?
+
+        private
+
+        attr_reader value: String?
+      end
+
+      class ConnectionPath
+        def self.build: (url: String, present_string_class: singleton(PresentString)) -> String
+      end
+
+      module Internal
+        interface _Connection
+          def results_as_hash: () -> bool
+          def results_as_hash=: (bool value) -> bool
+          def busy_timeout=: (Integer milliseconds) -> Integer?
+          def execute: (String sql, ?Array[String] bind_vars) -> Array[Hash[String, String]]
+          def execute_batch: (String sql) -> void
+          def close: () -> void
+        end
+      end
+
+      attr_reader connection: Internal::_Connection
+      attr_reader mutex: Internal::PersistenceMutex
+      attr_reader namespace: String
+      attr_reader persistence_mutex: Internal::PersistenceMutex
+      attr_reader reservation_token_sequence: Integer
+      attr_reader url: String
+
+      def load_persisted_state: () -> void
+      def dump_state_payload: () -> String
+      def restore_authoritative_state_after_failure: () -> nil
+
+      private
+
+      attr_reader state: Karya::QueueStore::Internal::StoreState
+      def normalize_url: (String? value) -> String
+      def normalize_namespace: (String? value) -> String
+      def restore_state_snapshot: (Internal::StateCodec::snapshot? snapshot) -> void
+    end
+  end
+end

--- a/core/karya/sig/karya/queue_store/sqlite/internal/dependency_loader.rbs
+++ b/core/karya/sig/karya/queue_store/sqlite/internal/dependency_loader.rbs
@@ -1,0 +1,11 @@
+module Karya
+  module QueueStore
+    class SQLite
+      module Internal
+        module DependencyLoader
+          def self.require_sqlite3!: () -> void
+        end
+      end
+    end
+  end
+end

--- a/core/karya/sig/karya/queue_store/sqlite/internal/persistence_mutex.rbs
+++ b/core/karya/sig/karya/queue_store/sqlite/internal/persistence_mutex.rbs
@@ -1,0 +1,31 @@
+module Karya
+  module QueueStore
+    class SQLite
+      module Internal
+        class PersistenceMutex
+          def initialize: (connection: SQLite::Internal::_Connection, owner: SQLite) -> void
+
+          def ensure_schema: () -> nil
+          def synchronize: [R] (?persist_if: ^(R result) -> bool?) { () -> R } -> R
+          def read_only_synchronize: [R] { () -> R } -> R
+          def load_state_snapshot: () -> StateCodec::snapshot?
+
+          private
+
+          attr_reader connection: SQLite::Internal::_Connection
+          attr_reader local_mutex: Thread::Mutex
+          attr_reader owner: SQLite
+
+          def synchronize_owned_state: [R] (
+            ?read_only: bool,
+            ?persist_if: ^(R result) -> bool?
+          ) { () -> R } -> R
+          def with_transaction: [R] { () -> R } -> R
+          def persist_snapshot_if_needed: [R] (R result, ^(R result) -> bool?) -> nil
+          def restore_owner_state_after_failure: () -> nil
+          def safe_rollback: () -> nil
+        end
+      end
+    end
+  end
+end

--- a/core/karya/sig/karya/queue_store/sqlite/internal/persistence_mutex.rbs
+++ b/core/karya/sig/karya/queue_store/sqlite/internal/persistence_mutex.rbs
@@ -20,7 +20,7 @@ module Karya
             ?read_only: bool,
             ?persist_if: ^(R result) -> bool?
           ) { () -> R } -> R
-          def with_transaction: [R] { () -> R } -> R
+          def with_transaction: [R] (?read_only: bool) { () -> R } -> R
           def persist_snapshot_if_needed: [R] (R result, ^(R result) -> bool?) -> nil
           def restore_owner_state_after_failure: () -> nil
           def safe_rollback: () -> nil

--- a/core/karya/sig/karya/queue_store/sqlite/internal/state_codec.rbs
+++ b/core/karya/sig/karya/queue_store/sqlite/internal/state_codec.rbs
@@ -1,0 +1,21 @@
+module Karya
+  module QueueStore
+    class SQLite
+      module Internal
+        module StateCodec
+          type snapshot = {
+            state: Karya::QueueStore::Internal::StoreState,
+            reservation_token_sequence: Integer
+          }
+
+          def self.dump: (
+            state: Karya::QueueStore::Internal::StoreState,
+            reservation_token_sequence: Integer
+          ) -> String
+          def self.load: (String payload) -> snapshot
+          def self.validate_snapshot: (snapshot snapshot) -> snapshot
+        end
+      end
+    end
+  end
+end

--- a/core/karya/sig/karya/sequel.rbs
+++ b/core/karya/sig/karya/sequel.rbs
@@ -8,6 +8,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_sqlite_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
     def self.require_sequel!: () -> void
     def self.normalize_migration_name: (String? name, ?fallback: String) -> String
     def self.timestamp: () -> String

--- a/core/karya/spec/e2e/karya/cli_worker_sqlite_spec.rb
+++ b/core/karya/spec/e2e/karya/cli_worker_sqlite_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require File.expand_path('../../../../../spec/support/sqlite_e2e_support', __dir__)
+
+RSpec.describe Karya::CLI, :e2e, :integration do
+  def sqlite_boot_file(sqlite_url:, namespace:, marker_file:)
+    <<~RUBY
+      # frozen_string_literal: true
+
+      now = Time.utc(2026, 5, 5, 12, 0, 0)
+      queue_store = Karya::Backend::SQLite.new(
+        url: #{sqlite_url.inspect},
+        namespace: #{namespace.inspect}
+      ).build_queue_store
+      queue_store.enqueue(
+        job: Karya::Job.new(
+          id: 'job-sqlite-1',
+          queue: 'billing',
+          handler: 'billing_sync',
+          arguments: { 'account_id' => 42, 'marker_path' => #{marker_file.inspect} },
+          state: :submission,
+          created_at: now
+        ),
+        now: now
+      )
+      queue_store.connection.close
+      Karya.configure_backend(Karya::Backend::SQLite, url: #{sqlite_url.inspect}, namespace: #{namespace.inspect})
+
+      class CliWorkerSQLiteHandler
+        def self.call(account_id:, marker_path:)
+          File.write(marker_path, JSON.generate('account_id' => account_id, 'pid' => Process.pid))
+        end
+      end
+    RUBY
+  end
+
+  it 'boots a worker through the SQLite backend path with a local durable database file' do
+    with_sqlite_database(prefix: 'karya_cli_sqlite_e2e') do |database_url|
+      Dir.mktmpdir('karya-cli-sqlite-e2e') do |directory|
+        state_file = File.join(directory, 'runtime.json')
+        marker_file = File.join(directory, 'handler.json')
+        namespace = "karya-sqlite-e2e-#{Process.pid}-#{File.basename(directory)}"
+        boot_file = File.join(directory, 'worker_boot.rb')
+
+        File.write(boot_file, sqlite_boot_file(sqlite_url: database_url, namespace:, marker_file:))
+
+        stdout, stderr, status = Open3.capture3(
+          *karya_command(
+            'worker',
+            'billing',
+            '--require',
+            boot_file,
+            '--handler',
+            'billing_sync=CliWorkerSQLiteHandler',
+            '--worker-id',
+            'worker-cli-sqlite-e2e',
+            '--processes',
+            '1',
+            '--threads',
+            '1',
+            '--poll-interval',
+            '0',
+            '--max-iterations',
+            '1',
+            '--state-file',
+            state_file
+          ),
+          chdir: KaryaE2EHelpers::PACKAGE_ROOT
+        )
+
+        expect(status.exitstatus).to eq(0), -> { "stdout:\n#{stdout}\n\nstderr:\n#{stderr}" }
+        expect(JSON.parse(File.read(marker_file))).to include('account_id' => 42)
+        expect(read_runtime_state(state_file).fetch('snapshot').fetch('phase')).to eq('stopped')
+      end
+    end
+  end
+end

--- a/core/karya/spec/karya/active_record_spec.rb
+++ b/core/karya/spec/karya/active_record_spec.rb
@@ -34,11 +34,30 @@ RSpec.describe Karya::ActiveRecord do
     end
   end
 
+  it 'writes an Active Record migration for the SQLite backend' do
+    Dir.mktmpdir('karya-ar-sqlite-migration-') do |dir|
+      path = described_class.install_sqlite_migration(target_dir: dir)
+      contents = File.read(path)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_sqlite_backend\.rb\z/)
+      expect(contents).to include("class CreateKaryaSqliteBackend < ActiveRecord::Migration[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]")
+      expect(contents).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'falls back to the default MySQL migration name when the requested name is blank' do
     Dir.mktmpdir('karya-ar-mysql-migration-default-') do |dir|
       path = described_class.install_mysql_migration(target_dir: dir, migration_name: '')
 
       expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+    end
+  end
+
+  it 'falls back to the default SQLite migration name when the requested name is blank' do
+    Dir.mktmpdir('karya-ar-sqlite-migration-default-') do |dir|
+      path = described_class.install_sqlite_migration(target_dir: dir, migration_name: '')
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_sqlite_backend\.rb\z/)
     end
   end
 

--- a/core/karya/spec/karya/backend/sq_lite_spec.rb
+++ b/core/karya/spec/karya/backend/sq_lite_spec.rb
@@ -6,7 +6,7 @@ require 'tmpdir'
 
 RSpec.describe Karya::Backend::SQLite do
   def sqlite_url_for(directory)
-    "sqlite3://#{File.join(directory, 'karya.sqlite3')}"
+    "sqlite3:///#{File.join(directory, 'karya.sqlite3').sub(%r{\A/+}, '')}"
   end
 
   def standalone_queue_store_script
@@ -15,7 +15,7 @@ RSpec.describe Karya::Backend::SQLite do
       require 'karya/queue_store/sqlite'
 
       Dir.mktmpdir('karya-standalone-sqlite-') do |directory|
-        url = "sqlite3://" + File.join(directory, 'karya.sqlite3')
+        url = "sqlite3:///" + File.join(directory, 'karya.sqlite3').sub(%r{\A/+}, '')
         now = Time.utc(2026, 5, 5, 12, 0, 0)
         store = Karya::QueueStore::SQLite.new(url:, namespace: 'standalone')
         job = Karya::Job.new(id: 'job-1', queue: 'billing', handler: 'billing_sync', state: :submission, created_at: now)

--- a/core/karya/spec/karya/backend/sq_lite_spec.rb
+++ b/core/karya/spec/karya/backend/sq_lite_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'rbconfig'
+require 'tmpdir'
+
+RSpec.describe Karya::Backend::SQLite do
+  def sqlite_url_for(directory)
+    "sqlite3://#{File.join(directory, 'karya.sqlite3')}"
+  end
+
+  def standalone_queue_store_script
+    <<~RUBY
+      require 'tmpdir'
+      require 'karya/queue_store/sqlite'
+
+      Dir.mktmpdir('karya-standalone-sqlite-') do |directory|
+        url = "sqlite3://" + File.join(directory, 'karya.sqlite3')
+        now = Time.utc(2026, 5, 5, 12, 0, 0)
+        store = Karya::QueueStore::SQLite.new(url:, namespace: 'standalone')
+        job = Karya::Job.new(id: 'job-1', queue: 'billing', handler: 'billing_sync', state: :submission, created_at: now)
+        store.enqueue(job:, now: now + 1)
+        reservation = store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 60, now: now + 2)
+        store.start_execution(reservation_token: reservation.token, now: now + 3)
+        failed = store.fail_execution(reservation_token: reservation.token, now: now + 4, failure_classification: :error)
+        puts failed.state
+      end
+    RUBY
+  end
+
+  it 'loads as a standalone backend file' do
+    lib_path = File.expand_path('../../../lib', __dir__)
+    script = <<~RUBY
+      require 'karya/backend/sqlite'
+      puts Karya::Backend::SQLite.new(url: 'sqlite3:///tmp/karya.sqlite3').identifier
+    RUBY
+
+    stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', lib_path, '-e', script)
+
+    expect(status.success?).to be(true), stderr
+    expect(stdout).to eq("sqlite\n")
+  end
+
+  it 'loads SQLite queue-store execution paths as a standalone file' do
+    lib_path = File.expand_path('../../../lib', __dir__)
+    stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', lib_path, '-e', standalone_queue_store_script)
+
+    expect(status.success?).to be(true), stderr
+    expect(stdout).to eq("failed\n")
+  end
+
+  it 'raises an actionable load error when the sqlite3 gem is not available' do
+    lib_path = File.expand_path('../../../lib', __dir__)
+    script = <<~RUBY
+      module Kernel
+        alias_method :__karya_original_require_for_sqlite_spec, :require
+
+        def require(name)
+          raise LoadError, 'cannot load such file -- sqlite3' if name == 'sqlite3'
+
+          __karya_original_require_for_sqlite_spec(name)
+        end
+      end
+
+      begin
+        require 'karya/backend/sqlite'
+        Karya::Backend::SQLite.new(url: 'sqlite3:///tmp/karya.sqlite3').build_queue_store
+      rescue LoadError => e
+        warn e.message
+        exit 0
+      end
+
+      exit 1
+    RUBY
+
+    _stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', lib_path, '-e', script)
+
+    expect(status.success?).to be(true)
+    expect(stderr).to include("Add `gem 'sqlite3'` to your Gemfile to use Karya::Backend::SQLite and Karya::QueueStore::SQLite.")
+  end
+
+  it 'raises an actionable load error from the dependency loader when sqlite3 is unavailable' do
+    dependency_loader = Karya::QueueStore::SQLite.send(:const_get, :Internal).const_get(:DependencyLoader)
+    allow(dependency_loader).to receive(:require).with('sqlite3').and_raise(LoadError, 'cannot load such file -- sqlite3')
+
+    expect do
+      dependency_loader.require_sqlite3!
+    end.to raise_error(
+      LoadError,
+      /Add `gem 'sqlite3'` to your Gemfile to use Karya::Backend::SQLite and Karya::QueueStore::SQLite\./
+    )
+  end
+
+  it 'exposes the backend identifier' do
+    backend = described_class.new(url: 'sqlite3:///tmp/karya.sqlite3')
+
+    expect(backend.identifier).to eq('sqlite')
+  end
+
+  it 'builds the SQLite queue store owned by the backend definition' do
+    Dir.mktmpdir('karya-sqlite-backend-build-') do |directory|
+      queue_store = described_class.new(url: sqlite_url_for(directory)).build_queue_store
+
+      expect(queue_store).to be_a(Karya::QueueStore::SQLite)
+    end
+  end
+
+  it 'forwards namespace and queue-store options to the queue store' do
+    Dir.mktmpdir('karya-sqlite-backend-options-') do |directory|
+      queue_store = described_class.new(
+        url: sqlite_url_for(directory),
+        namespace: 'payments',
+        max_batch_size: 50
+      ).build_queue_store
+
+      expect(queue_store.send(:namespace)).to eq('payments')
+      expect(queue_store.send(:max_batch_size)).to eq(50)
+    end
+  end
+
+  it 'normalizes invalid queue-store keyword errors into backend configuration errors' do
+    Dir.mktmpdir('karya-sqlite-backend-invalid-keywords-') do |directory|
+      invalid_backend = described_class.new(
+        url: sqlite_url_for(directory),
+        namespace: 'payments',
+        unsupported_option: true
+      )
+
+      expect do
+        invalid_backend.build_queue_store
+      end.to raise_error(
+        Karya::InvalidBackendConfigurationError,
+        /invalid SQLite backend queue-store configuration: unexpected option keys :unsupported_option: unknown keywords: unsupported_option/
+      ) { |error| expect(error.cause).to be_a(ArgumentError) }
+    end
+  end
+
+  it 'normalizes queue-store validation failures into backend configuration errors' do
+    invalid_backend = described_class.new(url: ' ', namespace: 'payments')
+
+    expect do
+      invalid_backend.build_queue_store
+    end.to raise_error(
+      Karya::InvalidBackendConfigurationError,
+      /invalid SQLite backend queue-store configuration: url must be a non-empty String/
+    ) { |error| expect(error.cause).to be_a(Karya::InvalidQueueStoreOperationError) }
+  end
+end

--- a/core/karya/spec/karya/queue_store/sq_lite_spec.rb
+++ b/core/karya/spec/karya/queue_store/sq_lite_spec.rb
@@ -195,7 +195,9 @@ RSpec.describe Karya::QueueStore::SQLite do
         raise 'rollback failed'
       end
     end.new
-    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: failing_connection, owner: store)
+    owner = instance_double(described_class)
+    allow(owner).to receive(:connection).and_raise(NoMethodError, 'fallback connection only')
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: failing_connection, owner:)
 
     expect(mutex.send(:safe_rollback)).to be_nil
   end

--- a/core/karya/spec/karya/queue_store/sq_lite_spec.rb
+++ b/core/karya/spec/karya/queue_store/sq_lite_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Karya::QueueStore::SQLite do
+  subject(:store) { described_class.new(url: database_url, namespace:) }
+
+  let(:created_at) { Time.utc(2026, 5, 5, 12, 0, 0) }
+  let(:internal_namespace) { described_class.send(:const_get, :Internal) }
+  let(:namespace) { 'sqlite-unit' }
+  let(:database_directory) { Dir.mktmpdir('karya-sqlite-unit-') }
+  let(:database_url) { "sqlite3://#{File.join(database_directory, 'karya.sqlite3')}" }
+
+  after do
+    FileUtils.rm_rf(database_directory)
+  end
+
+  def submission_job(
+    id:,
+    queue: 'billing',
+    handler: 'billing_sync',
+    retry_policy: nil,
+    uniqueness_key: nil,
+    uniqueness_scope: nil
+  )
+    Karya::Job.new(
+      id:,
+      queue:,
+      handler:,
+      state: :submission,
+      created_at:,
+      retry_policy:,
+      uniqueness_key:,
+      uniqueness_scope:
+    )
+  end
+
+  def workflow_job(step_id, handler: step_id)
+    Karya::Job.new(
+      id: "job-#{step_id}",
+      queue: :billing,
+      handler:,
+      state: :submission,
+      created_at:
+    )
+  end
+
+  it 'validates constructor inputs' do
+    expect do
+      described_class.new(url: '', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must be a non-empty String')
+
+    expect do
+      described_class.new(url: Object.new, namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must be a non-empty String')
+
+    expect do
+      described_class.new(url: 'postgres://example.test/karya', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must use sqlite:// or sqlite3://')
+
+    expect do
+      described_class.new(url: 'sqlite3:///:memory:', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must include a durable SQLite file path')
+
+    expect do
+      described_class.new(url: 'sqlite3://', namespace:)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'url must include a durable SQLite file path')
+
+    expect do
+      described_class.new(url: database_url, namespace: ' ')
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'namespace must be a non-empty String')
+
+    expect do
+      described_class.new(url: database_url, max_batch_size: 0)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /max_batch_size must be a positive Integer/)
+
+    expect do
+      described_class.new(url: database_url, token_generator: -> { 'manual-token' })
+    end.to raise_error(
+      Karya::InvalidQueueStoreOperationError,
+      'token_generator is managed internally by Karya::QueueStore::SQLite'
+    )
+  end
+
+  it 'builds a connection path from a non-localhost SQLite host component' do
+    path = described_class::ConnectionPath.build(
+      url: 'sqlite3://shared-volume/tmp/karya.sqlite3',
+      present_string_class: described_class::PresentString
+    )
+
+    expect(path).to eq('shared-volume/tmp/karya.sqlite3')
+  end
+
+  it 'normalizes URI parsing failures into SQLite url validation errors' do
+    allow(URI).to receive(:parse).and_raise(URI::InvalidURIError.new('bad sqlite uri'))
+
+    expect do
+      described_class::ConnectionPath.build(url: 'sqlite3:///tmp/karya.sqlite3', present_string_class: described_class::PresentString)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, 'invalid SQLite url: bad sqlite uri')
+  end
+
+  it 'does not inherit from the in-memory concrete store' do
+    expect(described_class.superclass).not_to eq(Karya::QueueStore::InMemory)
+  end
+
+  it 'persists queued, reserved, and succeeded job state across instances' do
+    store.enqueue(
+      job: submission_job(
+        id: 'job-1',
+        uniqueness_key: 'account-1',
+        uniqueness_scope: :queued
+      ),
+      now: created_at + 1
+    )
+
+    second_store = described_class.new(url: database_url, namespace:)
+    uniqueness_decision = second_store.uniqueness_decision(
+      job: submission_job(
+        id: 'job-2',
+        uniqueness_key: 'account-1',
+        uniqueness_scope: :queued
+      ),
+      now: created_at + 2
+    )
+    reservation = second_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 60, now: created_at + 3)
+
+    third_store = described_class.new(url: database_url, namespace:)
+    running = third_store.start_execution(reservation_token: reservation.token, now: created_at + 4)
+    succeeded = third_store.complete_execution(reservation_token: reservation.token, now: created_at + 5)
+
+    expect(uniqueness_decision.fetch(:action)).to eq(:reject)
+    expect(running.state).to eq(:running)
+    expect(succeeded.state).to eq(:succeeded)
+  end
+
+  it 'persists workflow control state across instances' do
+    definition = Karya::Workflow.define(:approval_flow) do
+      step :review, handler: :review, wait_for_approval: :manager_approved
+    end
+
+    store.enqueue_workflow(
+      definition:,
+      jobs_by_step_id: { review: workflow_job(:review, handler: :review) },
+      batch_id: :approval_batch,
+      now: created_at + 1
+    )
+
+    second_store = described_class.new(url: database_url, namespace:)
+    pause_report = second_store.pause_workflow(batch_id: :approval_batch, now: created_at + 2)
+    resume_report = second_store.resume_workflow(batch_id: :approval_batch, now: created_at + 3)
+    approval_report = second_store.approve_workflow_checkpoints(batch_id: :approval_batch, step_ids: [:review], now: created_at + 4)
+
+    snapshot = described_class.new(url: database_url, namespace:).workflow_snapshot(batch_id: :approval_batch, now: created_at + 5)
+    history = described_class.new(url: database_url, namespace:).workflow_history(batch_id: :approval_batch, now: created_at + 5)
+
+    expect(pause_report.action).to eq(:pause_workflow)
+    expect(resume_report.action).to eq(:resume_workflow)
+    expect(approval_report.action).to eq(:approve_workflow_checkpoints)
+    expect(snapshot.step_states).to eq('review' => :queued)
+    expect(history.entries.map(&:action)).to include('pause_requested', 'resumed', 'approval_approved')
+  end
+
+  it 'restores persisted state after a failed mutation transaction' do
+    store.enqueue(job: submission_job(id: 'job-1'), now: created_at + 1)
+    allow(store.connection).to receive(:execute).and_wrap_original do |original, sql, *bind_vars|
+      raise 'forced sqlite write failure' if sql.include?('INSERT INTO karya_queue_store_states')
+
+      original.call(sql, *bind_vars)
+    end
+
+    expect do
+      store.enqueue(job: submission_job(id: 'job-2'), now: created_at + 2)
+    end.to raise_error(StandardError, /forced sqlite write failure/)
+
+    recovered_store = described_class.new(url: database_url, namespace:)
+    first = recovered_store.reserve(queue: 'billing', worker_id: 'worker-1', lease_duration: 60, now: created_at + 3)
+    expect(first.job_id).to eq('job-1')
+    expect(
+      recovered_store.reserve(queue: 'billing', worker_id: 'worker-2', lease_duration: 60, now: created_at + 4)
+    ).to be_nil
+  end
+
+  it 'returns nil when restoring authoritative state also fails' do
+    failing_store = described_class.allocate
+    allow(failing_store).to receive(:load_persisted_state).and_raise(StandardError, 'reload failed')
+
+    expect(failing_store.restore_authoritative_state_after_failure).to be_nil
+  end
+
+  it 'returns nil when persistence mutex rollback also fails' do
+    failing_connection = Class.new do
+      def execute(_sql, _bind_vars = nil)
+        raise 'rollback failed'
+      end
+    end.new
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: failing_connection, owner: store)
+
+    expect(mutex.send(:safe_rollback)).to be_nil
+  end
+
+  it 'returns nil when owner state restoration fails inside the persistence mutex' do
+    owner = instance_double(described_class)
+    allow(owner).to receive(:restore_authoritative_state_after_failure).and_raise(StandardError, 'restore failed')
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: store.connection, owner:)
+
+    expect(mutex.send(:restore_owner_state_after_failure)).to be_nil
+  end
+
+  it 'falls back to the bootstrap connection when the owner cannot provide one' do
+    fallback_connection = instance_double(SQLite3::Database)
+    owner = instance_double(described_class)
+    allow(owner).to receive(:connection).and_raise(StandardError, 'owner unavailable')
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: fallback_connection, owner:)
+
+    expect(mutex.send(:connection)).to be(fallback_connection)
+  end
+
+  it 'returns a configured SQLite connection even when busy_timeout is unavailable' do
+    fake_connection = Object.new
+    fake_connection.define_singleton_method(:results_as_hash=) { |_value| true }
+    allow(SQLite3::Database).to receive(:new).and_return(fake_connection)
+
+    connection = described_class::ConnectionBuilder.build('/tmp/karya.sqlite3')
+
+    expect(connection).to be(fake_connection)
+  end
+
+  it 'closes the SQLite connection when initialization fails after the connection opens' do
+    fake_connection = instance_double(SQLite3::Database, close: nil)
+    fake_mutex = instance_double(internal_namespace.const_get(:PersistenceMutex))
+    allow(described_class::ConnectionBuilder).to receive(:build).and_return(fake_connection)
+    allow(internal_namespace.const_get(:PersistenceMutex)).to receive(:new).and_return(fake_mutex)
+    allow(fake_mutex).to receive(:ensure_schema).and_raise(StandardError, 'schema failed')
+
+    expect do
+      described_class.new(url: database_url, namespace:)
+    end.to raise_error(StandardError, 'schema failed')
+
+    expect(fake_connection).to have_received(:close)
+  end
+
+  it 'reopens the SQLite connection after a fork before using the store again' do
+    original_connection = instance_double(SQLite3::Database, close: nil)
+    replacement_connection = instance_double(SQLite3::Database)
+    allow(replacement_connection).to receive(:results_as_hash=)
+    allow(replacement_connection).to receive(:busy_timeout=)
+    store.instance_variable_set(:@connection, original_connection)
+    store.instance_variable_set(:@connection_pid, Process.pid - 1)
+    allow(described_class::ConnectionBuilder).to receive(:build).with(store.send(:connection_path)).and_return(replacement_connection)
+
+    expect(store.connection).to be(replacement_connection)
+    expect(original_connection).to have_received(:close)
+  end
+
+  it 'clears the inherited connection if reopening after fork fails' do
+    original_connection = instance_double(SQLite3::Database, close: nil)
+    store.instance_variable_set(:@connection, original_connection)
+    store.instance_variable_set(:@connection_pid, Process.pid - 1)
+    allow(described_class::ConnectionBuilder).to receive(:build).with(store.send(:connection_path)).and_raise(StandardError, 'reconnect failed')
+
+    expect do
+      store.connection
+    end.to raise_error(StandardError, 'reconnect failed')
+
+    expect(store.instance_variable_get(:@connection)).to be_nil
+    expect(original_connection).to have_received(:close)
+  end
+
+  it 'reopens a forked SQLite store even when no inherited connection is present' do
+    replacement_connection = instance_double(SQLite3::Database)
+    allow(replacement_connection).to receive(:results_as_hash=)
+    allow(replacement_connection).to receive(:busy_timeout=)
+    store.instance_variable_set(:@connection, nil)
+    store.instance_variable_set(:@connection_pid, Process.pid - 1)
+    allow(described_class::ConnectionBuilder).to receive(:build).with(store.send(:connection_path)).and_return(replacement_connection)
+
+    expect(store.connection).to be(replacement_connection)
+  end
+
+  it 'rejects malformed SQLite state payloads' do
+    expect do
+      internal_namespace.const_get(:StateCodec).load('not-base64')
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid SQLite state snapshot/)
+  end
+
+  it 'rejects invalid decoded SQLite state payloads' do
+    payload = [Marshal.dump({ state: Object.new, reservation_token_sequence: 1 })].pack('m0')
+
+    expect do
+      internal_namespace.const_get(:StateCodec).load(payload)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid SQLite state snapshot/)
+  end
+
+  it 'rejects decoded SQLite state payloads with missing keys' do
+    payload = [Marshal.dump({ reservation_token_sequence: 1 })].pack('m0')
+
+    expect do
+      internal_namespace.const_get(:StateCodec).load(payload)
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid SQLite state snapshot/)
+  end
+end

--- a/core/karya/spec/karya/queue_store/sq_lite_spec.rb
+++ b/core/karya/spec/karya/queue_store/sq_lite_spec.rb
@@ -200,6 +200,28 @@ RSpec.describe Karya::QueueStore::SQLite do
     expect(mutex.send(:safe_rollback)).to be_nil
   end
 
+  it 'uses a deferred transaction for read-only synchronization' do
+    observed_sql = []
+    connection = Class.new do
+      def initialize(observed_sql)
+        @observed_sql = observed_sql
+      end
+
+      def execute(sql, _bind_vars = nil)
+        @observed_sql << sql
+        []
+      end
+    end.new(observed_sql)
+    owner = instance_double(described_class, namespace: namespace)
+    allow(owner).to receive(:connection).and_return(connection)
+    allow(owner).to receive(:restore_state_snapshot)
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection:, owner:)
+
+    mutex.read_only_synchronize { :ok }
+
+    expect(observed_sql.first).to eq('BEGIN TRANSACTION')
+  end
+
   it 'returns nil when owner state restoration fails inside the persistence mutex' do
     owner = instance_double(described_class)
     allow(owner).to receive(:restore_authoritative_state_after_failure).and_raise(StandardError, 'restore failed')
@@ -293,6 +315,14 @@ RSpec.describe Karya::QueueStore::SQLite do
   it 'rejects malformed SQLite state payloads' do
     expect do
       internal_namespace.const_get(:StateCodec).load('not-base64')
+    end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid SQLite state snapshot/)
+  end
+
+  it 'rejects truncated SQLite state payloads' do
+    truncated_payload = [Marshal.dump({ state: store.send(:state), reservation_token_sequence: 1 })[0...2]].pack('m0')
+
+    expect do
+      internal_namespace.const_get(:StateCodec).load(truncated_payload)
     end.to raise_error(Karya::InvalidQueueStoreOperationError, /invalid SQLite state snapshot/)
   end
 

--- a/core/karya/spec/karya/queue_store/sq_lite_spec.rb
+++ b/core/karya/spec/karya/queue_store/sq_lite_spec.rb
@@ -252,6 +252,16 @@ RSpec.describe Karya::QueueStore::SQLite do
     end.to raise_error(StandardError, 'owner unavailable')
   end
 
+  it 'retries connection rebuild when a same-process reconnect previously failed' do
+    store.instance_variable_set(:@connection, nil)
+    store.instance_variable_set(:@connection_pid, Process.pid)
+
+    recovered_connection = instance_double(SQLite3::Database)
+    allow(described_class::ConnectionBuilder).to receive(:build).with(store.send(:connection_path)).and_return(recovered_connection)
+
+    expect(store.connection).to be(recovered_connection)
+  end
+
   it 'returns a configured SQLite connection even when busy_timeout is unavailable' do
     fake_connection = Object.new
     fake_connection.define_singleton_method(:results_as_hash=) { |_value| true }

--- a/core/karya/spec/karya/queue_store/sq_lite_spec.rb
+++ b/core/karya/spec/karya/queue_store/sq_lite_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Karya::QueueStore::SQLite do
   let(:internal_namespace) { described_class.send(:const_get, :Internal) }
   let(:namespace) { 'sqlite-unit' }
   let(:database_directory) { Dir.mktmpdir('karya-sqlite-unit-') }
-  let(:database_url) { "sqlite3://#{File.join(database_directory, 'karya.sqlite3')}" }
+  let(:database_url) { "sqlite3:///#{File.join(database_directory, 'karya.sqlite3').sub(%r{\A/+}, '')}" }
 
   after do
     FileUtils.rm_rf(database_directory)
@@ -211,10 +211,21 @@ RSpec.describe Karya::QueueStore::SQLite do
   it 'falls back to the bootstrap connection when the owner cannot provide one' do
     fallback_connection = instance_double(SQLite3::Database)
     owner = instance_double(described_class)
-    allow(owner).to receive(:connection).and_raise(StandardError, 'owner unavailable')
+    allow(owner).to receive(:connection).and_raise(NoMethodError, 'owner unavailable')
     mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: fallback_connection, owner:)
 
     expect(mutex.send(:connection)).to be(fallback_connection)
+  end
+
+  it 're-raises connection failures instead of falling back to the bootstrap connection' do
+    fallback_connection = instance_double(SQLite3::Database)
+    owner = instance_double(described_class)
+    allow(owner).to receive(:connection).and_raise(StandardError, 'owner unavailable')
+    mutex = internal_namespace.const_get(:PersistenceMutex).new(connection: fallback_connection, owner:)
+
+    expect do
+      mutex.send(:connection)
+    end.to raise_error(StandardError, 'owner unavailable')
   end
 
   it 'returns a configured SQLite connection even when busy_timeout is unavailable' do

--- a/core/karya/spec/karya/queue_store/sq_lite_spec.rb
+++ b/core/karya/spec/karya/queue_store/sq_lite_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'sqlite3'
 require 'tmpdir'
 
 RSpec.describe Karya::QueueStore::SQLite do

--- a/core/karya/spec/karya/sequel_spec.rb
+++ b/core/karya/spec/karya/sequel_spec.rb
@@ -40,11 +40,33 @@ RSpec.describe Karya::Sequel do
     end
   end
 
+  it 'writes a Sequel migration for the SQLite backend' do
+    allow(Kernel).to receive(:require).and_call_original
+    allow(Kernel).to receive(:require).with('sequel').and_return(true)
+
+    Dir.mktmpdir('karya-sequel-sqlite-migration-') do |dir|
+      path = described_class.install_sqlite_migration(target_dir: dir)
+      contents = File.read(path)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_sqlite_backend\.rb\z/)
+      expect(contents).to include('Sequel.migration do')
+      expect(contents).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'falls back to the default MySQL migration name when the requested name is blank' do
     Dir.mktmpdir('karya-sequel-default-mysql-migration-') do |dir|
       path = described_class.install_mysql_migration(target_dir: dir, migration_name: '')
 
       expect(File.basename(path)).to match(/\A\d{14}_create_karya_mysql_backend\.rb\z/)
+    end
+  end
+
+  it 'falls back to the default SQLite migration name when the requested name is blank' do
+    Dir.mktmpdir('karya-sequel-default-sqlite-migration-') do |dir|
+      path = described_class.install_sqlite_migration(target_dir: dir, migration_name: '')
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_sqlite_backend\.rb\z/)
     end
   end
 

--- a/docs/pages/backends.md
+++ b/docs/pages/backends.md
@@ -50,6 +50,21 @@ Choose SQLite when:
   backend
 - the deployment is intentionally local or single-node
 
+Add the SQLite client gem before configuring the backend:
+
+```ruby
+# Gemfile
+gem 'sqlite3', '~> 2.6'
+```
+
+```ruby
+Karya.configure_backend(
+  Karya::Backend::SQLite,
+  url: 'sqlite3:///tmp/karya.sqlite3',
+  namespace: 'karya'
+)
+```
+
 Choose Redis when:
 
 - worker processes must share queue and workflow state through Redis

--- a/gems/karya-hanami/Gemfile
+++ b/gems/karya-hanami/Gemfile
@@ -24,3 +24,4 @@ gem 'rubocop-rake', require: false
 gem 'rubocop-rspec', require: false
 gem 'sequel'
 gem 'simplecov', '~> 0.22', require: false
+gem 'sqlite3', '~> 2.6'

--- a/gems/karya-hanami/Gemfile.lock
+++ b/gems/karya-hanami/Gemfile.lock
@@ -179,6 +179,14 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    sqlite3 (2.9.4-aarch64-linux-gnu)
+    sqlite3 (2.9.4-aarch64-linux-musl)
+    sqlite3 (2.9.4-arm-linux-gnu)
+    sqlite3 (2.9.4-arm-linux-musl)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
+    sqlite3 (2.9.4-x86_64-linux-musl)
     thor (1.5.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
@@ -211,6 +219,7 @@ DEPENDENCIES
   rubocop-rspec
   sequel
   simplecov (~> 0.22)
+  sqlite3 (~> 2.6)
 
 BUNDLED WITH
    2.7.2

--- a/gems/karya-hanami/lib/karya/hanami.rb
+++ b/gems/karya-hanami/lib/karya/hanami.rb
@@ -24,6 +24,10 @@ module Karya
       Karya::Sequel.install_mysql_migration(target_dir:, migration_name:)
     end
 
+    def install_sqlite_migration(target_dir:, migration_name: 'create_karya_sqlite_backend')
+      Karya::Sequel.install_sqlite_migration(target_dir:, migration_name:)
+    end
+
     def mount_path(prefix: nil)
       Karya::Internal::MountPath.build(DEFAULT_MOUNT_PATH, scope: prefix)
     end

--- a/gems/karya-hanami/sig/karya/hanami.rbs
+++ b/gems/karya-hanami/sig/karya/hanami.rbs
@@ -10,6 +10,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_sqlite_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
 
     def self.mount_path: (?prefix: String?) -> String
 

--- a/gems/karya-hanami/spec/karya/hanami_integration_spec.rb
+++ b/gems/karya-hanami/spec/karya/hanami_integration_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe Karya::Hanami, :dashboard_manifest_fixture do
     end
   end
 
+  it 'delegates SQLite migration install through the folded Sequel support' do
+    Dir.mktmpdir('karya-hanami-sqlite-migration-') do |dir|
+      path = described_class.install_sqlite_migration(target_dir: dir)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_sqlite_backend\.rb\z/)
+      expect(File.read(path)).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'renders the dashboard document for the Hanami mount path' do
     document = described_class.render_dashboard_page
 

--- a/gems/karya-hanami/spec/karya/hanami_sqlite_e2e_spec.rb
+++ b/gems/karya-hanami/spec/karya/hanami_sqlite_e2e_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'tmpdir'
+
+RSpec.describe Karya::Hanami, :dashboard_manifest_fixture, :integration do
+  if ENV['E2E'] == '1'
+    require 'rack/test'
+    require 'sequel'
+    require 'sequel/extensions/migration'
+    include Rack::Test::Methods
+  end
+
+  around do |example|
+    KaryaHanamiDummyAppSupport.with_dummy_app do |_app_root, rack_app|
+      self.current_rack_app = rack_app
+      with_sqlite_backend(prefix: 'karya_hanami_sqlite_e2e', namespace: 'hanami_sqlite_e2e') do |database_url|
+        Dir.mktmpdir('karya-hanami-sqlite-migrations-') do |migration_dir|
+          described_class.install_sqlite_migration(target_dir: migration_dir)
+          db = Sequel.connect(sequel_database_url_for(database_url))
+          Sequel::Migrator.run(db, migration_dir)
+          example.run
+        ensure
+          db&.disconnect
+        end
+      end
+    end
+  ensure
+    self.current_rack_app = nil
+  end
+
+  def app
+    current_rack_app
+  end
+
+  it 'serves the packaged dashboard document' do
+    get '/karya'
+
+    expect(last_response.status).to eq(200)
+    expect_dashboard_document(last_response.body, mount_path: '/karya', title: 'Karya Dashboard')
+  end
+
+  it 'uses the configured SQLite backend through the Hanami host route' do
+    get '/karya/runtime-probe'
+
+    expect(last_response.status).to eq(200)
+    payload = JSON.parse(last_response.body)
+    expect(payload.fetch('backend')).to eq('sqlite')
+    expect(payload.fetch('job_id')).to start_with('hanami-probe-')
+  end
+end

--- a/gems/karya-hanami/spec/karya/hanami_sqlite_e2e_spec.rb
+++ b/gems/karya-hanami/spec/karya/hanami_sqlite_e2e_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Karya::Hanami, :dashboard_manifest_fixture, :integration do
   end
 
   around do |example|
+    skip 'set E2E=1 for SQLite e2e coverage' unless ENV['E2E'] == '1'
+
     KaryaHanamiDummyAppSupport.with_dummy_app do |_app_root, rack_app|
       self.current_rack_app = rack_app
       with_sqlite_backend(prefix: 'karya_hanami_sqlite_e2e', namespace: 'hanami_sqlite_e2e') do |database_url|

--- a/gems/karya-rails/lib/karya/rails.rb
+++ b/gems/karya-rails/lib/karya/rails.rb
@@ -27,6 +27,10 @@ module Karya
       Karya::ActiveRecord.install_mysql_migration(target_dir:, migration_name:)
     end
 
+    def install_sqlite_migration(target_dir:, migration_name: 'Create Karya SQLite Backend')
+      Karya::ActiveRecord.install_sqlite_migration(target_dir:, migration_name:)
+    end
+
     def render_dashboard_page(
       scope: nil,
       mount_path: DEFAULT_MOUNT_PATH,

--- a/gems/karya-rails/sig/karya/rails.rbs
+++ b/gems/karya-rails/sig/karya/rails.rbs
@@ -10,6 +10,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_sqlite_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
 
     def self.render_dashboard_page: (
       ?scope: String?,

--- a/gems/karya-rails/spec/karya/rails_spec.rb
+++ b/gems/karya-rails/spec/karya/rails_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe Karya::Rails, :dashboard_manifest_fixture do
     end
   end
 
+  it 'delegates SQLite migration install through the folded Active Record support' do
+    Dir.mktmpdir('karya-rails-sqlite-migration-') do |dir|
+      path = described_class.install_sqlite_migration(target_dir: dir)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_sqlite_backend\.rb\z/)
+      expect(File.read(path)).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'renders the dashboard document for the mounted Rails path' do
     document = described_class.render_dashboard_page
 

--- a/gems/karya-rails/spec/karya/rails_sqlite_e2e_spec.rb
+++ b/gems/karya-rails/spec/karya/rails_sqlite_e2e_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Karya::Rails, :dashboard_manifest_fixture, :integration do
   end
 
   around do |example|
+    skip 'set E2E=1 for SQLite e2e coverage' unless ENV['E2E'] == '1'
+
     with_sqlite_backend(prefix: 'karya_rails_sqlite_e2e', namespace: 'rails_sqlite_e2e') do |database_url|
       Dir.mktmpdir('karya-rails-sqlite-migrations-') do |migration_dir|
         migration_name = "Create Karya SQLite Backend #{SecureRandom.hex(4)}"

--- a/gems/karya-rails/spec/karya/rails_sqlite_e2e_spec.rb
+++ b/gems/karya-rails/spec/karya/rails_sqlite_e2e_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'securerandom'
+require 'tmpdir'
+
+RSpec.describe Karya::Rails, :dashboard_manifest_fixture, :integration do
+  if ENV['E2E'] == '1'
+    require 'rails_helper'
+    require 'rack/test'
+    include Rack::Test::Methods
+  end
+
+  around do |example|
+    with_sqlite_backend(prefix: 'karya_rails_sqlite_e2e', namespace: 'rails_sqlite_e2e') do |database_url|
+      Dir.mktmpdir('karya-rails-sqlite-migrations-') do |migration_dir|
+        migration_name = "Create Karya SQLite Backend #{SecureRandom.hex(4)}"
+        migration_path = described_class.install_sqlite_migration(target_dir: migration_dir, migration_name:)
+        migration_class_name = Karya::ActiveRecord.normalize_migration_name(migration_name)
+        ActiveRecord::Base.establish_connection(database_url)
+        ActiveRecord::Migration.verbose = false
+        load migration_path
+        Object.const_get(migration_class_name).migrate(:up)
+        example.run
+      ensure
+        ActiveRecord::Base.connection_pool.disconnect!
+      end
+    end
+  end
+
+  it 'mounts the dashboard engine and serves the packaged document' do
+    get '/karya'
+
+    expect(last_response).to have_http_status(:ok)
+    expect_dashboard_document(last_response.body, mount_path: '/karya', title: 'Karya Dashboard')
+  end
+
+  it 'uses the configured SQLite backend through the mounted engine' do
+    get '/karya/runtime-probe'
+
+    expect(last_response).to have_http_status(:ok)
+    payload = JSON.parse(last_response.body)
+    expect(payload.fetch('backend')).to eq('sqlite')
+    expect(payload.fetch('job_id')).to start_with('rails-probe-')
+    expect(payload.fetch('mount_path')).to eq('/karya')
+  end
+
+  def app
+    Rails.application
+  end
+end

--- a/gems/karya-roda/Gemfile
+++ b/gems/karya-roda/Gemfile
@@ -24,3 +24,4 @@ gem 'rubocop-rake', require: false
 gem 'rubocop-rspec', require: false
 gem 'sequel'
 gem 'simplecov', '~> 0.22', require: false
+gem 'sqlite3', '~> 2.6'

--- a/gems/karya-roda/Gemfile.lock
+++ b/gems/karya-roda/Gemfile.lock
@@ -136,6 +136,14 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    sqlite3 (2.9.4-aarch64-linux-gnu)
+    sqlite3 (2.9.4-aarch64-linux-musl)
+    sqlite3 (2.9.4-arm-linux-gnu)
+    sqlite3 (2.9.4-arm-linux-musl)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
+    sqlite3 (2.9.4-x86_64-linux-musl)
     thor (1.5.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
@@ -168,6 +176,7 @@ DEPENDENCIES
   rubocop-rspec
   sequel
   simplecov (~> 0.22)
+  sqlite3 (~> 2.6)
 
 BUNDLED WITH
    2.7.2

--- a/gems/karya-roda/lib/karya/roda.rb
+++ b/gems/karya-roda/lib/karya/roda.rb
@@ -23,6 +23,10 @@ module Karya
       Karya::Sequel.install_mysql_migration(target_dir:, migration_name:)
     end
 
+    def install_sqlite_migration(target_dir:, migration_name: 'create_karya_sqlite_backend')
+      Karya::Sequel.install_sqlite_migration(target_dir:, migration_name:)
+    end
+
     def render_dashboard_page(scope: nil, title: Karya::Dashboard::DEFAULT_TITLE, asset_prefix: nil, name: 'dashboard')
       Karya::Dashboard.render_document(title:, mount_path: mount_path(scope:), asset_prefix:, name:)
     end

--- a/gems/karya-roda/sig/karya/roda.rbs
+++ b/gems/karya-roda/sig/karya/roda.rbs
@@ -10,6 +10,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_sqlite_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
 
     def self.render_dashboard_page: (
       ?scope: String?,

--- a/gems/karya-roda/spec/karya/roda_spec.rb
+++ b/gems/karya-roda/spec/karya/roda_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe Karya::Roda, :dashboard_manifest_fixture do
     end
   end
 
+  it 'delegates SQLite migration install through the folded Sequel support' do
+    Dir.mktmpdir('karya-roda-sqlite-migration-') do |dir|
+      path = described_class.install_sqlite_migration(target_dir: dir)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_sqlite_backend\.rb\z/)
+      expect(File.read(path)).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'renders the dashboard document for the Roda mount path' do
     document = described_class.render_dashboard_page
 

--- a/gems/karya-roda/spec/karya/roda_sqlite_e2e_spec.rb
+++ b/gems/karya-roda/spec/karya/roda_sqlite_e2e_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'tmpdir'
+
+RSpec.describe Karya::Roda, :dashboard_manifest_fixture, :integration do
+  if ENV['E2E'] == '1'
+    require 'rack/test'
+    require 'sequel'
+    require 'sequel/extensions/migration'
+    include Rack::Test::Methods
+  end
+
+  around do |example|
+    KaryaRodaDummyAppSupport.with_dummy_app do |_app_root, rack_app|
+      self.current_rack_app = rack_app
+      with_sqlite_backend(prefix: 'karya_roda_sqlite_e2e', namespace: 'roda_sqlite_e2e') do |database_url|
+        Dir.mktmpdir('karya-roda-sqlite-migrations-') do |migration_dir|
+          described_class.install_sqlite_migration(target_dir: migration_dir)
+          db = Sequel.connect(sequel_database_url_for(database_url))
+          Sequel::Migrator.run(db, migration_dir)
+          example.run
+        ensure
+          db&.disconnect
+        end
+      end
+    end
+  ensure
+    self.current_rack_app = nil
+  end
+
+  def app
+    current_rack_app
+  end
+
+  it 'serves the packaged dashboard document' do
+    get '/karya'
+
+    expect(last_response.status).to eq(200)
+    expect_dashboard_document(last_response.body, mount_path: '/karya', title: 'Karya Dashboard')
+  end
+
+  it 'uses the configured SQLite backend through the Roda host route' do
+    get '/karya/runtime-probe'
+
+    expect(last_response.status).to eq(200)
+    payload = JSON.parse(last_response.body)
+    expect(payload.fetch('backend')).to eq('sqlite')
+    expect(payload.fetch('job_id')).to start_with('roda-probe-')
+  end
+end

--- a/gems/karya-roda/spec/karya/roda_sqlite_e2e_spec.rb
+++ b/gems/karya-roda/spec/karya/roda_sqlite_e2e_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Karya::Roda, :dashboard_manifest_fixture, :integration do
   end
 
   around do |example|
+    skip 'set E2E=1 for SQLite e2e coverage' unless ENV['E2E'] == '1'
+
     KaryaRodaDummyAppSupport.with_dummy_app do |_app_root, rack_app|
       self.current_rack_app = rack_app
       with_sqlite_backend(prefix: 'karya_roda_sqlite_e2e', namespace: 'roda_sqlite_e2e') do |database_url|

--- a/gems/karya-sinatra/Gemfile
+++ b/gems/karya-sinatra/Gemfile
@@ -24,3 +24,4 @@ gem 'rubocop-rake', require: false
 gem 'rubocop-rspec', require: false
 gem 'sequel'
 gem 'simplecov', '~> 0.22', require: false
+gem 'sqlite3', '~> 2.6'

--- a/gems/karya-sinatra/Gemfile.lock
+++ b/gems/karya-sinatra/Gemfile.lock
@@ -150,6 +150,14 @@ GEM
       rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
+    sqlite3 (2.9.4-aarch64-linux-gnu)
+    sqlite3 (2.9.4-aarch64-linux-musl)
+    sqlite3 (2.9.4-arm-linux-gnu)
+    sqlite3 (2.9.4-arm-linux-musl)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
+    sqlite3 (2.9.4-x86_64-linux-musl)
     thor (1.5.0)
     tilt (2.7.0)
     unicode-display_width (3.2.0)
@@ -183,6 +191,7 @@ DEPENDENCIES
   rubocop-rspec
   sequel
   simplecov (~> 0.22)
+  sqlite3 (~> 2.6)
 
 BUNDLED WITH
    2.7.2

--- a/gems/karya-sinatra/lib/karya/sinatra.rb
+++ b/gems/karya-sinatra/lib/karya/sinatra.rb
@@ -23,6 +23,10 @@ module Karya
       Karya::Sequel.install_mysql_migration(target_dir:, migration_name:)
     end
 
+    def install_sqlite_migration(target_dir:, migration_name: 'create_karya_sqlite_backend')
+      Karya::Sequel.install_sqlite_migration(target_dir:, migration_name:)
+    end
+
     def render_dashboard_page(scope: nil, title: Karya::Dashboard::DEFAULT_TITLE, asset_prefix: nil, name: 'dashboard')
       Karya::Dashboard.render_document(title:, mount_path: mount_path(scope:), asset_prefix:, name:)
     end

--- a/gems/karya-sinatra/sig/karya/sinatra.rbs
+++ b/gems/karya-sinatra/sig/karya/sinatra.rbs
@@ -10,6 +10,10 @@ module Karya
       target_dir: String,
       ?migration_name: String
     ) -> String
+    def self.install_sqlite_migration: (
+      target_dir: String,
+      ?migration_name: String
+    ) -> String
 
     def self.render_dashboard_page: (
       ?scope: String?,

--- a/gems/karya-sinatra/spec/karya/sinatra_spec.rb
+++ b/gems/karya-sinatra/spec/karya/sinatra_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe Karya::Sinatra, :dashboard_manifest_fixture do
     end
   end
 
+  it 'delegates SQLite migration install through the folded Sequel support' do
+    Dir.mktmpdir('karya-sinatra-sqlite-migration-') do |dir|
+      path = described_class.install_sqlite_migration(target_dir: dir)
+
+      expect(File.basename(path)).to match(/\A\d{14}_create_karya_sqlite_backend\.rb\z/)
+      expect(File.read(path)).to include('CREATE TABLE IF NOT EXISTS karya_queue_store_states')
+    end
+  end
+
   it 'renders the dashboard document for the Sinatra mount path' do
     document = described_class.render_dashboard_page
 

--- a/gems/karya-sinatra/spec/karya/sinatra_sqlite_e2e_spec.rb
+++ b/gems/karya-sinatra/spec/karya/sinatra_sqlite_e2e_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Karya::Sinatra, :dashboard_manifest_fixture, :integration do
+  if ENV['E2E'] == '1'
+    require 'rack'
+    require 'rack/test'
+    require 'sequel'
+    require 'sequel/extensions/migration'
+    include Rack::Test::Methods
+  end
+
+  def with_dummy_app(source_dir)
+    Dir.mktmpdir('karya-sinatra-') do |root|
+      app_root = File.join(root, 'app')
+      FileUtils.copy_entry(source_dir, app_root)
+      app, = Rack::Builder.parse_file(File.join(app_root, 'config.ru'))
+      yield app
+    end
+  end
+
+  around do |example|
+    source_dir = File.expand_path('../dummy/modular', __dir__)
+    with_dummy_app(source_dir) do |rack_app|
+      self.current_rack_app = rack_app
+      with_sqlite_backend(prefix: 'karya_sinatra_sqlite_e2e', namespace: 'sinatra_sqlite_e2e') do |database_url|
+        Dir.mktmpdir('karya-sinatra-sqlite-migrations-') do |migration_dir|
+          described_class.install_sqlite_migration(target_dir: migration_dir)
+          db = Sequel.connect(sequel_database_url_for(database_url))
+          Sequel::Migrator.run(db, migration_dir)
+          example.run
+        ensure
+          db&.disconnect
+        end
+      end
+    end
+  ensure
+    self.current_rack_app = nil
+  end
+
+  def app
+    current_rack_app
+  end
+
+  it 'serves the packaged dashboard document' do
+    get '/karya', {}, { 'HTTP_HOST' => 'localhost' }
+
+    expect(last_response.status).to eq(200)
+    expect_dashboard_document(last_response.body, mount_path: '/karya', title: 'Karya Dashboard')
+  end
+
+  it 'uses the configured SQLite backend through the Sinatra host route' do
+    get '/karya/runtime-probe', {}, { 'HTTP_HOST' => 'localhost' }
+
+    expect(last_response.status).to eq(200)
+    payload = JSON.parse(last_response.body)
+    expect(payload.fetch('backend')).to eq('sqlite')
+    expect(payload.fetch('job_id')).to start_with('sinatra-modular-probe-')
+  end
+end

--- a/gems/karya-sinatra/spec/karya/sinatra_sqlite_e2e_spec.rb
+++ b/gems/karya-sinatra/spec/karya/sinatra_sqlite_e2e_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Karya::Sinatra, :dashboard_manifest_fixture, :integration do
   end
 
   around do |example|
+    skip 'set E2E=1 for SQLite e2e coverage' unless ENV['E2E'] == '1'
+
     source_dir = File.expand_path('../dummy/modular', __dir__)
     with_dummy_app(source_dir) do |rack_app|
       self.current_rack_app = rack_app

--- a/spec/support/framework_sql_backend_support.rb
+++ b/spec/support/framework_sql_backend_support.rb
@@ -35,6 +35,15 @@ module FrameworkSQLBackendSupport
     end
   end
 
+  def with_sqlite_backend(prefix:, namespace:)
+    preserve_backend_configuration do
+      with_sqlite_database(prefix:) do |database_url|
+        Karya.configure_backend(Karya::Backend::SQLite, url: database_url, namespace:)
+        yield database_url
+      end
+    end
+  end
+
   def restore_backend_ivar(name, value)
     if value.equal?(UNDEFINED)
       Karya.remove_instance_variable(name) if Karya.instance_variable_defined?(name)

--- a/spec/support/sqlite_e2e_support.rb
+++ b/spec/support/sqlite_e2e_support.rb
@@ -17,7 +17,7 @@ module SQLiteE2ESupport
   end
 
   def database_url_for(path)
-    "sqlite3://#{File.expand_path(path)}"
+    "sqlite3:///#{File.expand_path(path).sub(%r{\A/+}, '')}"
   end
 
   def sequel_database_url_for(database_url)

--- a/spec/support/sqlite_e2e_support.rb
+++ b/spec/support/sqlite_e2e_support.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require 'tmpdir'
+
+module SQLiteE2ESupport
+  module_function
+
+  def with_sqlite_database(prefix:)
+    Dir.mktmpdir("#{prefix.tr('_', '-')}-") do |directory|
+      yield database_url_for(File.join(directory, 'karya.sqlite3'))
+    end
+  end
+
+  def database_url_for(path)
+    "sqlite3://#{File.expand_path(path)}"
+  end
+
+  def sequel_database_url_for(database_url)
+    database_url.sub(/\Asqlite3:\/\//, 'sqlite://')
+  end
+end
+
+RSpec.configure do |config|
+  config.include SQLiteE2ESupport
+end


### PR DESCRIPTION
- Introduced a new SQLite backend for Karya, allowing users to configure and use SQLite as a job queue store.
- Added tests for the SQLite backend to ensure functionality and persistence of job states across instances.
- Implemented migration generation for SQLite, enabling users to create necessary database tables easily.
- Updated documentation to include instructions for setting up the SQLite backend.
- Enhanced existing test frameworks to support SQLite integration testing.

closes: #126
closes: #398

