### PR TITLE
chore: update dependency versions and groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,30 +9,209 @@ updates:
     directory: /danger
     schedule:
       interval: daily
+    groups:
+      danger-runtime:
+        patterns:
+          - danger
+          - danger-*
+      http-client:
+        patterns:
+          - faraday*
   - package-ecosystem: bundler
-    directory: /core/karya
+    directory: /gems/karya
     schedule:
       interval: daily
+    groups:
+      code-quality:
+        patterns:
+          - rubocop*
+          - reek
+      test-coverage:
+        patterns:
+          - rspec*
+          - simplecov
+      data-stores:
+        patterns:
+          - activerecord
+          - mysql2
+          - pg
+          - redis
+          - sequel
+          - sqlite3
+      cli-runtime:
+        patterns:
+          - thor
   - package-ecosystem: bundler
     directory: /gems/karya-dashboard
     schedule:
       interval: daily
+    groups:
+      code-quality:
+        patterns:
+          - rubocop*
+          - reek
+      test-coverage:
+        patterns:
+          - rspec*
+          - simplecov
+  - package-ecosystem: bundler
+    directory: /gems/karya-hanami
+    schedule:
+      interval: daily
+    groups:
+      framework-runtime:
+        patterns:
+          - hanami*
+          - kaal-hanami
+      code-quality:
+        patterns:
+          - rubocop*
+          - reek
+      test-coverage:
+        patterns:
+          - rspec*
+          - simplecov
+          - rack-test
+      data-stores:
+        patterns:
+          - mysql2
+          - pg
+          - redis
+          - sequel
+          - sqlite3
   - package-ecosystem: bundler
     directory: /gems/karya-rails
     schedule:
       interval: daily
+    groups:
+      framework-runtime:
+        patterns:
+          - rails*
+          - kaal-rails
+      code-quality:
+        patterns:
+          - rubocop*
+          - reek
+      test-coverage:
+        patterns:
+          - rspec*
+          - simplecov
+          - rack-test
+      data-stores:
+        patterns:
+          - mysql2
+          - pg
+          - redis
+          - sequel
+          - sqlite3
+  - package-ecosystem: bundler
+    directory: /gems/karya-roda
+    schedule:
+      interval: daily
+    groups:
+      framework-runtime:
+        patterns:
+          - roda
+          - kaal-roda
+          - rack
+      code-quality:
+        patterns:
+          - rubocop*
+          - reek
+      test-coverage:
+        patterns:
+          - rspec*
+          - simplecov
+          - rack-test
+      data-stores:
+        patterns:
+          - mysql2
+          - pg
+          - redis
+          - sequel
+          - sqlite3
   - package-ecosystem: bundler
     directory: /gems/karya-sinatra
     schedule:
       interval: daily
+    groups:
+      framework-runtime:
+        patterns:
+          - sinatra
+          - kaal-sinatra
+          - rack
+      code-quality:
+        patterns:
+          - rubocop*
+          - reek
+      test-coverage:
+        patterns:
+          - rspec*
+          - simplecov
+          - rack-test
+      data-stores:
+        patterns:
+          - mysql2
+          - pg
+          - redis
+          - sequel
+          - sqlite3
   - package-ecosystem: npm
     directory: /gems/karya-dashboard
     schedule:
       interval: daily
+    groups:
+      react-runtime:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+      typescript-toolchain:
+        patterns:
+          - typescript
+          - typescript-eslint
+          - "@typescript-eslint/*"
+          - "@types/node"
+      lint-toolchain:
+        patterns:
+          - eslint
+          - "@eslint/*"
+          - eslint-plugin-*
+          - stylelint
+          - stylelint-*
+      build-toolchain:
+        patterns:
+          - vite
+          - "@vitejs/*"
+          - tailwindcss
+          - "@tailwindcss/*"
+          - postcss
+          - autoprefixer
+          - sass
+      browser-tests:
+        patterns:
+          - playwright
+          - "@playwright/*"
   - package-ecosystem: bundler
     directory: /docs
     schedule:
       interval: daily
+    groups:
+      docs-runtime:
+        patterns:
+          - github-pages
+          - just-the-docs
+          - jekyll*
+          - minima
+      markdown-rendering:
+        patterns:
+          - kramdown*
+      platform-support:
+        patterns:
+          - tzinfo*
+          - wdm
+          - http_parser.rb
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/gems/karya-dashboard/package.json
+++ b/gems/karya-dashboard/package.json
@@ -13,8 +13,8 @@
     "firefox:e2e": "yarn prepackage-build && yarn exec -- playwright test --project=firefox"
   },
   "dependencies": {
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "resolutions": {
     "postcss": "^8.5.15"
@@ -24,7 +24,7 @@
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^25.9.2",
-    "@types/react": "^19.2.15",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.5.0",

--- a/gems/karya-dashboard/yarn.lock
+++ b/gems/karya-dashboard/yarn.lock
@@ -907,12 +907,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^19.2.15":
-  version: 19.2.15
-  resolution: "@types/react@npm:19.2.15"
+"@types/react@npm:^19.2.17":
+  version: 19.2.17
+  resolution: "@types/react@npm:19.2.17"
   dependencies:
     csstype: "npm:^3.2.2"
-  checksum: 10c0/b554eab715bb14e581f0ae60e5cefe91e1a5e06c31022b543a9806cf224aa056f21e4fb46208e46eb934d86ca0b247ebc82377192a0dead303cb28b8764c6e67
+  checksum: 10c0/bc2c4af96b3e480604424de70d5ebda90c5f4b485df471858c0bc2d7d70364b606ec3c4d8579f94f01aa0c6c0591f56bcf14cba5689f5eea4b74250ccdc3a232
   languageName: node
   linkType: hard
 
@@ -2129,7 +2129,7 @@ __metadata:
     "@playwright/test": "npm:^1.60.0"
     "@tailwindcss/postcss": "npm:^4.3.0"
     "@types/node": "npm:^25.9.2"
-    "@types/react": "npm:^19.2.15"
+    "@types/react": "npm:^19.2.17"
     "@types/react-dom": "npm:^19.2.3"
     "@vitejs/plugin-react": "npm:^6.0.2"
     autoprefixer: "npm:^10.5.0"
@@ -2137,8 +2137,8 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^13.0.0"
     globals: "npm:^17.6.0"
     postcss: "npm:^8.5.15"
-    react: "npm:^19.2.6"
-    react-dom: "npm:^19.2.6"
+    react: "npm:^19.2.7"
+    react-dom: "npm:^19.2.7"
     sass: "npm:^1.100.0"
     semver: "npm:^7.8.1"
     stylelint: "npm:^17.13.0"
@@ -2804,21 +2804,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^19.2.6":
-  version: 19.2.6
-  resolution: "react-dom@npm:19.2.6"
+"react-dom@npm:^19.2.7":
+  version: 19.2.7
+  resolution: "react-dom@npm:19.2.7"
   dependencies:
     scheduler: "npm:^0.27.0"
   peerDependencies:
-    react: ^19.2.6
-  checksum: 10c0/dbf2aef67857c03a612bc9316a4562e5066f43fa04bf28f7f0734963fc1350da2c9f8eb973930655453281079f30cc8222bab383dbec4b5097084e2c081e3334
+    react: ^19.2.7
+  checksum: 10c0/970ff600f6e80d47d39e2f226f12f226173b3cba3382efc97c5f0cd663de9af38c7a4c11c213fb936094faeac83060d660247accaa96b752180d5b951b9cfecb
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.6":
-  version: 19.2.6
-  resolution: "react@npm:19.2.6"
-  checksum: 10c0/66afde33b9a9ee87b1e1cae39d8e7e040d1262e719524fd70660c4d4ce79929c532ac19fc3df5a911edaf02768fdf2c49de4ede1ba99bc6aad72796e0e26e798
+"react@npm:^19.2.7":
+  version: 19.2.7
+  resolution: "react@npm:19.2.7"
+  checksum: 10c0/0bd0e2f1bbd4ba97561c6597bf8a5fec05e6476fe61e165c1065598d16668efc6715205599c94d3ddd49d36cb0f21cbf1b9bcc18ee840b805ce222c3e8d558ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Updated React and React-DOM versions to ^19.2.7 for improved performance and security.
- Bumped @types/react version to ^19.2.17 for better TypeScript support.
- Added dependency groups in dependabot.yml for better organization and management of updates across various packages.
